### PR TITLE
Add LatencyThresholdMs to C# quickstart interim response config

### DIFF
--- a/csharp/voice-live-quickstarts/AgentsNewQuickstart/VoiceLiveWithAgentV2.cs
+++ b/csharp/voice-live-quickstarts/AgentsNewQuickstart/VoiceLiveWithAgentV2.cs
@@ -272,6 +272,7 @@ class BasicVoiceAssistant : IDisposable
         };
         interimConfig.Triggers.Add(InterimResponseTrigger.Tool);
         interimConfig.Triggers.Add(InterimResponseTrigger.Latency);
+        interimConfig.LatencyThresholdMs = 100;
 
         var options = new VoiceLiveSessionOptions
         {


### PR DESCRIPTION
## Summary

Adds missing \LatencyThresholdMs = 100\ to the C# quickstart \LlmInterimResponseConfig\, aligning it with Python, Java, and JavaScript quickstarts which all set this value.

## Changes

- **VoiceLiveWithAgentV2.cs**: Added \interimConfig.LatencyThresholdMs = 100;\ after the trigger configuration

## Cross-language alignment verification

| Language | Triggers | LatencyThresholdMs | Instructions |
|----------|----------|-------------------|-------------|
| Python | ✅ TOOL, LATENCY | ✅ 100 | ✅ Same |
| Java | ✅ TOOL, LATENCY | ✅ 100 | ✅ Same |
| JavaScript | ✅ tool, latency | ✅ 100 | ✅ Same |
| C# (this PR) | ✅ Tool, Latency | ✅ **100 (added)** | ✅ Same |

## Related doc updates
Companion doc changes for \zure-ai-docs-pr\ will update C# snippet ranges (+1 line shift) and fix Java doc highlight positions.