### PR TITLE
Switch CodeQL to advanced setup with autobuild for C#

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "30 5 * * 1" # Weekly Monday 5:30 UTC
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ matrix.language == 'csharp' && 'ubuntu-latest' || 'ubuntu-latest' }}
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: csharp
+            build-mode: autobuild
+          - language: java-kotlin
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Problem

CodeQL default setup used \uild-mode: none\ for C# which resulted in low analysis quality:

> Percentage of calls with call target: **83%** (threshold **85%**)

This is because \
one\ mode can't fully resolve NuGet dependencies.

## Fix

Switch from default setup to advanced setup (workflow YAML) with:
- **C#**: \uild-mode: autobuild\ — runs \dotnet build\ to resolve dependencies
- **JS/TS, Python, Java**: \uild-mode: none\ — unchanged, works well without build
- Upgraded to \security-extended\ query suite for broader coverage
- Weekly schedule + push/PR triggers on main