### PR TITLE
Add Dependabot config for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,262 @@
+version: 2
+updates:
+  # === Python ===
+
+  - package-ecosystem: "pip"
+    directory: "/python/voice-live-avatar"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "pip"
+    directory: "/python/voice-live-quickstarts"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "pip"
+    directory: "/python/voice-live-quickstarts/AgentsNewQuickstart"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "pip"
+    directory: "/python/voice-live-voicerag-assistant/app/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "pip"
+    directory: "/voice-live-universal-assistant/python"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "python"
+
+  # === JavaScript / npm ===
+
+  - package-ecosystem: "npm"
+    directory: "/javascript/basic-web-voice-assistant"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "npm"
+    directory: "/javascript/voice-live-car-demo"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "npm"
+    directory: "/javascript/voice-live-interpreter-demo"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "npm"
+    directory: "/javascript/voice-live-trader-demo"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "npm"
+    directory: "/javascript/voice-live-avatar"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "npm"
+    directory: "/javascript/voice-live-quickstarts/ModelQuickstart"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "npm"
+    directory: "/javascript/voice-live-quickstarts/AgentsNewQuickstart"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "npm"
+    directory: "/voice-live-universal-assistant/javascript"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "npm"
+    directory: "/voice-live-universal-assistant/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "npm"
+    directory: "/python/voice-live-voicerag-assistant/app/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  # === C# / NuGet ===
+
+  - package-ecosystem: "nuget"
+    directory: "/csharp/voice-live-quickstarts/ModelQuickstart"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "csharp"
+
+  - package-ecosystem: "nuget"
+    directory: "/csharp/voice-live-quickstarts/AgentQuickstart"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "csharp"
+
+  - package-ecosystem: "nuget"
+    directory: "/csharp/voice-live-quickstarts/BringYourOwnModelQuickstart"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "csharp"
+
+  - package-ecosystem: "nuget"
+    directory: "/csharp/voice-live-quickstarts/AgentsNewQuickstart"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "csharp"
+
+  - package-ecosystem: "nuget"
+    directory: "/csharp/CustomerServiceBot"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "csharp"
+
+  - package-ecosystem: "nuget"
+    directory: "/voice-live-universal-assistant/csharp"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "csharp"
+
+  # === Java / Maven ===
+
+  - package-ecosystem: "maven"
+    directory: "/java/voice-live-quickstarts/ModelQuickstart"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "java"
+
+  - package-ecosystem: "maven"
+    directory: "/voice-live-universal-assistant/java"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "microsoft-foundry/voicelive-repo-maintainers"
+    labels:
+      - "dependencies"
+      - "java"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "30 5 * * 1" # Weekly Monday 5:30 UTC
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ matrix.language == 'csharp' && 'ubuntu-latest' || 'ubuntu-latest' }}
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: csharp
+            build-mode: autobuild
+          - language: java-kotlin
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds \dependabot.yml\ covering **28 directories** across 4 ecosystems:

| Ecosystem | Directories | Key packages |
|---|---|---|
| **pip** | 5 | Python samples + voicerag backend |
| **npm** | 10 | \@azure/ai-voicelive\, Next.js, frontends |
| **nuget** | 6 | C# quickstarts + CustomerServiceBot |
| **maven** | 2 | Java quickstarts |

**Config:** Weekly schedule, \oicelive-repo-maintainers\ as reviewers, per-language labels for filtering.