### PR TITLE
Add MCP quickstart samples for all languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -301,6 +301,9 @@ FakesAssemblies/
 .ntvs_analysis.dat
 node_modules/
 
+# Conversation logs from voice-live quickstarts
+logs/
+
 # Visual Studio 6 build log
 *.plg
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This repository contains samples in multiple programming languages. Choose your 
 Complete C# samples demonstrating:
 - **Agent Quickstart**: Connect to Azure AI Foundry agents with proactive greetings
 - **Agents New Quickstart**: Create and run Voice Live-enabled Foundry Agents (new SDK patterns)
+- **MCP Quickstart**: MCP server integration with remote tool calling and approval flow
 - **Model Quickstart**: Direct VoiceLive model integration
 - **Bring-Your-Own-Model (BYOM) Quickstart**: Use your own models hosted in Foundry with proactive greetings
 - **Customer Service Bot**: Advanced function calling for customer service scenarios and proactive greetings
@@ -57,6 +58,7 @@ Complete C# samples demonstrating:
 Python samples showcasing:
 - **Agent Quickstart**: Azure AI Foundry agent integration with proactive greetings
 - **Agents New Quickstart**: Voice Live + Foundry Agent v2 samples and agent-creation utility
+- **MCP Quickstart**: MCP server integration with remote tool calling and approval flow
 - **Model Quickstart**: Direct model access with flexible authentication
 - **Bring-Your-Own-Model (BYOM) Quickstart**: Use your own models hosted in Foundry with proactive greetings
 - **Function Calling**: Advanced tool integration with custom functions and proactive greetings
@@ -67,6 +69,7 @@ Python samples showcasing:
 ### [JavaScript Samples](./javascript/)
 JavaScript/TypeScript samples showcasing:
 - **Agents New Quickstart**: Node.js Voice Live + Foundry Agent v2 sample and agent-creation utility
+- **MCP Quickstart**: MCP server integration with remote tool calling and approval flow
 - **Model Quickstart**: Direct Voice Live model integration with proactive greetings
 - **Basic Web Voice Assistant**: Browser-based voice assistant with real-time streaming and barge-in support
 - **Voice Live Avatar**: Avatar-enabled voice conversations with Docker deployment
@@ -78,6 +81,7 @@ JavaScript/TypeScript samples showcasing:
 ### [Java Samples](./java/)
 Java samples  showcasing:
 - **Agents New Quickstart**: Voice Live + Foundry Agent v2 sample and agent-creation utility
+- **MCP Quickstart**: MCP server integration with remote tool calling and approval flow
 - **Model Quickstart**: Direct model access with flexible authentication
 - Built with Java 11+ and Maven
 

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -33,6 +33,15 @@ Demonstrates direct integration with VoiceLive using bring-your-own-models from 
 - Custom Instructions: Define your own system instructions for the AI
 - Flexible Authentication: Supports both API key and Azure credential authentication
 
+### [MCP Quickstart](./voice-live-quickstarts/MCPQuickstart/)
+Demonstrates MCP (Model Context Protocol) server integration with VoiceLive, enabling the assistant to use remote tools (DeepWiki, Azure Docs) during voice conversations.
+
+**Key Features:**
+- MCP server definitions using `VoiceLiveMcpServerDefinition`
+- MCP tool discovery, execution, and failure event handling
+- Interactive console-based approval flow for sensitive tools
+- Flexible authentication (API key or Azure credentials)
+
 ### [Agents New Quickstart](./voice-live-quickstarts/AgentsNewQuickstart/)
 Demonstrates the new Voice Live + Foundry Agent workflow, including creating an agent with Voice Live metadata and running a v2 voice assistant sample.
 

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -546,6 +546,32 @@ namespace Azure.AI.VoiceLive.Samples
                 return;
             }
 
+            const int MaxApprovalCallsPerTask = 3;
+            _approvalCallCount.TryGetValue(serverLabel, out var currentCount);
+            if (currentCount >= MaxApprovalCallsPerTask)
+            {
+                _logger.LogInformation("Auto-denying {Tool} — reached {Count} calls this task", toolName, currentCount);
+                Console.WriteLine($"   Auto-denied: {serverLabel}/{toolName} (max {MaxApprovalCallsPerTask} calls reached)");
+                try
+                {
+                    await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new
+                    {
+                        type = "conversation.item.create",
+                        item = new
+                        {
+                            type = "mcp_approval_response",
+                            approval_request_id = approvalId,
+                            approve = false
+                        }
+                    }), cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning("Failed to send auto-deny: {Error}", ex.Message);
+                }
+                return;
+            }
+
             _logger.LogInformation("MCP approval request: server={Server} tool={Tool}", serverLabel, toolName);
             Console.WriteLine();
             Console.WriteLine($"🔐 MCP Approval Request (voice-based):");
@@ -712,7 +738,11 @@ namespace Azure.AI.VoiceLive.Samples
                         }), token).ConfigureAwait(false);
                         await _session.SendCommandAsync(BinaryData.FromObjectAsJson(new { type = "response.create" }), token).ConfigureAwait(false);
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        if (ex.Message.Contains("active response", StringComparison.OrdinalIgnoreCase))
+                            _needsResponseCreate = true;
+                    }
                 }
             }, token);
         }

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -335,7 +335,7 @@ namespace Azure.AI.VoiceLive.Samples
                                 {
                                     type = "message",
                                     role = "system",
-                                    content = new[] { new { type = "input_text", text = "A tool call is still running. The user just interrupted. Briefly ask them: do you want to keep waiting for the result, or skip it and move on? Keep it short." } }
+                                    content = new[] { new { type = "input_text", text = "A tool call is still running. The user just spoke. Briefly acknowledge them and let them know you're still waiting for results. One short sentence." } }
                                 }
                             }), cancellationToken).ConfigureAwait(false);
                         }
@@ -726,15 +726,14 @@ namespace Azure.AI.VoiceLive.Samples
             _ = Task.Run(async () =>
             {
                 int stallCount = 0;
-                while (_mcpCallInProgress > 0)
+                while (_mcpCallInProgress > 0 && stallCount < 3)
                 {
                     await Task.Delay(15000, token).ConfigureAwait(false);
                     if (_mcpCallInProgress <= 0 || _session == null)
                         break;
                     stallCount++;
-                    string msg = stallCount == 1
-                        ? "The tool call is taking longer than expected. Briefly let the user know you're still waiting for results."
-                        : "The tool call is taking very long. Ask the user: would you like to keep waiting, or should I move on and answer with what I know? Keep it short.";
+                    // MCP calls cannot be cancelled — only honest status updates are possible.
+                    string msg = "The tool call is still running. Briefly reassure the user that you're still waiting for results. One short sentence only.";
                     try
                     {
                         await _session.SendCommandAsync(BinaryData.FromObjectAsJson(new

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -306,9 +306,9 @@ namespace Azure.AI.VoiceLive.Samples
         {
             switch (serverEvent)
             {
-                case SessionUpdateSessionUpdated:
+                case SessionUpdateSessionUpdated sessionUpdated:
                     _logger.LogInformation("Session updated");
-                    WriteLog($"SessionID: {_session?.SessionId}");
+                    WriteLog($"SessionID: {sessionUpdated.Session?.Id}");
                     WriteLog($"Model: {_model}");
                     WriteLog($"Voice: {_voice}");
                     WriteLog("");
@@ -428,7 +428,7 @@ namespace Azure.AI.VoiceLive.Samples
                         else
                         {
                             Console.WriteLine($"❌ Error: {msg}");
-                        WriteLog($"ERROR: {msg}");
+                            WriteLog($"ERROR: {msg}");
                         }
                     }
                     _responseActive = false;
@@ -483,7 +483,7 @@ namespace Azure.AI.VoiceLive.Samples
                         bool isStale = _staleMcpItems.Remove(itemId);
                         _logger.LogInformation("MCP call completed for {ItemId} (stale={IsStale})", itemId, isStale);
                         Console.WriteLine("✅ MCP tool call completed successfully");
-                        WriteLog($"MCP call completed: {itemId} (stale={isStale});");
+                        WriteLog($"MCP call completed: {itemId} (stale={isStale})");
 
                         // Clean up item mapping
                         _mcpItemToServer.Remove(itemId);

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -33,7 +35,7 @@ namespace Azure.AI.VoiceLive.Samples
             var endpoint = configuration["VoiceLive:Endpoint"] ?? Environment.GetEnvironmentVariable("AZURE_VOICELIVE_ENDPOINT") ?? "https://your-resource-name.services.ai.azure.com/";
             var model = configuration["VoiceLive:Model"] ?? Environment.GetEnvironmentVariable("AZURE_VOICELIVE_MODEL") ?? "gpt-realtime";
             var voice = configuration["VoiceLive:Voice"] ?? Environment.GetEnvironmentVariable("AZURE_VOICELIVE_VOICE") ?? "en-US-Ava:DragonHDLatestNeural";
-            var instructions = configuration["VoiceLive:Instructions"] ?? "You are a helpful AI assistant with access to MCP tools. Use the tools to help answer user questions. Respond naturally and conversationally.";
+            var instructions = configuration["VoiceLive:Instructions"] ?? "You are a helpful AI assistant with access to MCP tools. Use the tools to help answer user questions. Respond naturally and conversationally. Some tools require user approval before they can be used. When you receive a system message asking you to request permission, you MUST clearly ask the user for their explicit approval before proceeding. Always wait for the user to say yes or no. Never skip the approval question or assume permission is granted.";
             var useTokenCredential = args.Length > 0 && args[0] == "--use-token-credential";
 
             // Setup logging
@@ -139,6 +141,19 @@ namespace Azure.AI.VoiceLive.Samples
         private bool _disposed;
         private bool _responseActive;
         private bool _canCancelResponse;
+
+        // Voice-based MCP approval state
+        private record ApprovalInfo(string ApprovalId, string ServerLabel, string FunctionName);
+        private ApprovalInfo? _pendingApproval;
+        private readonly Queue<ApprovalInfo> _approvalQueue = new();
+        private bool _approvalPromptNeeded;
+        private int _mcpCallInProgress;
+        private readonly HashSet<string> _handledMcpCompletions = new();
+        private bool _needsResponseCreate;
+        private readonly Dictionary<string, int> _approvalCallCount = new();
+        private readonly Dictionary<string, string> _mcpItemToServer = new();
+        private HashSet<string> _approvalServers = new();
+        private CancellationTokenSource? _mcpStallCts;
 
         public MCPVoiceAssistant(
             VoiceLiveClient client,
@@ -254,6 +269,13 @@ namespace Azure.AI.VoiceLive.Samples
                 sessionOptions.Tools.Add(tool);
             }
 
+            // Track which servers require approval for per-turn loop prevention
+            _approvalServers = new HashSet<string>(
+                mcpServers.OfType<VoiceLiveMcpServerDefinition>()
+                    .Where(s => s.RequireApproval?.ToString()?.Contains("always", StringComparison.OrdinalIgnoreCase) == true)
+                    .Select(s => s.ServerLabel ?? "")
+            );
+
             await _session!.ConfigureSessionAsync(sessionOptions, cancellationToken).ConfigureAwait(false);
             _logger.LogInformation("Session with MCP tools configured");
         }
@@ -293,6 +315,28 @@ namespace Azure.AI.VoiceLive.Samples
                         try { await _session!.ClearStreamingAudioAsync(cancellationToken).ConfigureAwait(false); }
                         catch { }
                     }
+                    // Reset approval call counter only when no approval is pending
+                    if (_pendingApproval == null)
+                        _approvalCallCount.Clear();
+                    // If an MCP call is running, ask the user if they want to wait or skip
+                    if (_mcpCallInProgress > 0 && _pendingApproval == null)
+                    {
+                        _logger.LogInformation("User spoke during MCP call — will ask if they want to skip");
+                        try
+                        {
+                            await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new
+                            {
+                                type = "conversation.item.create",
+                                item = new
+                                {
+                                    type = "message",
+                                    role = "system",
+                                    content = new[] { new { type = "input_text", text = "A tool call is still running. The user just interrupted. Briefly ask them: do you want to keep waiting for the result, or skip it and move on? Keep it short." } }
+                                }
+                            }), cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (Exception ex) { _logger.LogWarning("Failed to inject MCP skip inquiry: {Error}", ex.Message); }
+                    }
                     break;
 
                 case SessionUpdateInputAudioBufferSpeechStopped:
@@ -318,16 +362,51 @@ namespace Azure.AI.VoiceLive.Samples
                 case SessionUpdateResponseDone:
                     _responseActive = false;
                     _canCancelResponse = false;
+                    // If an approval prompt needs to be injected, do it now
+                    if (_approvalPromptNeeded && _pendingApproval != null)
+                    {
+                        _approvalPromptNeeded = false;
+                        await SendApprovalVoicePromptAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                    else if (_needsResponseCreate)
+                    {
+                        _needsResponseCreate = false;
+                        try { await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new { type = "response.create" }), cancellationToken).ConfigureAwait(false); }
+                        catch { }
+                    }
                     break;
 
                 case SessionUpdateError errorEvent:
                     var msg = errorEvent.Error?.Message ?? "";
                     if (!msg.Contains("no active response", StringComparison.OrdinalIgnoreCase))
                     {
-                        Console.WriteLine($"❌ Error: {msg}");
+                        // Suppress non-fatal interim/collision errors
+                        if (msg.Contains("interim response", StringComparison.OrdinalIgnoreCase))
+                        {
+                            _logger.LogWarning("Interim response not supported with this model pipeline (non-fatal)");
+                        }
+                        else if (msg.Contains("active response in progress", StringComparison.OrdinalIgnoreCase))
+                        {
+                            _logger.LogDebug("Response collision (expected during MCP flow): {Message}", msg);
+                        }
+                        else
+                        {
+                            Console.WriteLine($"❌ Error: {msg}");
+                        }
                     }
                     _responseActive = false;
                     _canCancelResponse = false;
+                    break;
+
+                // Transcription event — used for voice-based approval resolution
+                case SessionUpdateConversationItemInputAudioTranscriptionCompleted transcription:
+                    var transcript = transcription.Transcript ?? "";
+                    _logger.LogInformation("User said: {Transcript}", transcript);
+                    Console.WriteLine($"👤 You said:\t{transcript}");
+                    if (_pendingApproval != null)
+                    {
+                        await ResolveVoiceApprovalAsync(transcript, cancellationToken).ConfigureAwait(false);
+                    }
                     break;
 
                 // MCP-specific events
@@ -342,20 +421,98 @@ namespace Azure.AI.VoiceLive.Samples
 
                 case SessionUpdateResponseMcpCallInProgress mcpInProgress:
                     Console.WriteLine("⏳ MCP tool call in progress...");
+                    _mcpCallInProgress++;
+                    StartMcpStallTimer(cancellationToken);
                     break;
 
                 case SessionUpdateResponseMcpCallCompleted mcpCompleted:
-                    Console.WriteLine("✅ MCP tool call completed");
-                    _logger.LogInformation("MCP call completed");
+                {
+                    var itemId = mcpCompleted.ItemId ?? "";
+                    _mcpCallInProgress = Math.Max(0, _mcpCallInProgress - 1);
+                    CancelMcpStallTimer();
+                    if (_handledMcpCompletions.Contains(itemId))
+                    {
+                        _logger.LogDebug("Ignoring duplicate MCP completion for {ItemId}", itemId);
+                    }
+                    else
+                    {
+                        _handledMcpCompletions.Add(itemId);
+                        _logger.LogInformation("MCP call completed for {ItemId}", itemId);
+                        Console.WriteLine("✅ MCP tool call completed successfully");
+
+                        // Clean up item mapping
+                        _mcpItemToServer.Remove(itemId);
+
+                        // Reset approval counter if no more approvals are pending
+                        if (_pendingApproval == null && _approvalQueue.Count == 0)
+                            _approvalCallCount.Clear();
+
+                        // Kick the model to incorporate and speak the MCP output
+                        try
+                        {
+                            await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new { type = "response.create" }), cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            if (ex.Message.Contains("active response", StringComparison.OrdinalIgnoreCase))
+                                _needsResponseCreate = true;
+                            else
+                                _logger.LogWarning("Failed to create response after MCP call: {Error}", ex.Message);
+                        }
+                    }
                     break;
+                }
 
                 case SessionUpdateResponseMcpCallFailed mcpFailed:
                     Console.WriteLine("❌ MCP tool call failed");
+                    _mcpCallInProgress = Math.Max(0, _mcpCallInProgress - 1);
+                    CancelMcpStallTimer();
+                    try { await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new { type = "response.create" }), cancellationToken).ConfigureAwait(false); }
+                    catch { }
                     break;
 
                 case SessionUpdateConversationItemCreated itemCreated
                     when itemCreated.Item is SessionResponseMcpApprovalRequestItem mcpApproval:
                     await HandleMCPApprovalAsync(mcpApproval, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case SessionUpdateConversationItemCreated itemCreated:
+                    _logger.LogDebug("Conversation item created: {ItemType}", itemCreated.Item?.GetType().Name);
+                    // Track mcp_call items for server mapping and announce non-approval tool calls
+                    if (itemCreated.Item is SessionResponseMcpCallItem mcpCallItem)
+                    {
+                        var serverLabel = mcpCallItem.ServerLabel ?? "";
+                        var functionName = mcpCallItem.Name ?? "";
+                        var mcpItemId = mcpCallItem.Id ?? "";
+                        _logger.LogInformation("MCP Call triggered: server_label={Server}, function_name={Function}", serverLabel, functionName);
+                        Console.WriteLine($"🔧 MCP tool call: {serverLabel}/{functionName}");
+                        if (!string.IsNullOrEmpty(mcpItemId))
+                            _mcpItemToServer[mcpItemId] = $"{serverLabel}/{functionName}";
+
+                        // Announce the tool call so the user knows something is happening
+                        if (_pendingApproval == null && !_approvalServers.Contains(serverLabel))
+                        {
+                            try
+                            {
+                                await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new
+                                {
+                                    type = "conversation.item.create",
+                                    item = new
+                                    {
+                                        type = "message",
+                                        role = "system",
+                                        content = new[] { new { type = "input_text", text = "Briefly tell the user you're looking something up. One short sentence only." } }
+                                    }
+                                }), cancellationToken).ConfigureAwait(false);
+                                await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new { type = "response.create" }), cancellationToken).ConfigureAwait(false);
+                            }
+                            catch (Exception ex)
+                            {
+                                if (!ex.Message.Contains("active response", StringComparison.OrdinalIgnoreCase))
+                                    _logger.LogWarning("Failed to create tool announcement: {Error}", ex.Message);
+                            }
+                        }
+                    }
                     break;
 
                 default:
@@ -367,50 +524,214 @@ namespace Azure.AI.VoiceLive.Samples
 
         // <handle_approval>
         /// <summary>
-        /// Handle MCP approval request by prompting the user in the console.
+        /// Handle MCP approval request by asking the user via voice.
         /// </summary>
         private async Task HandleMCPApprovalAsync(SessionResponseMcpApprovalRequestItem approvalItem, CancellationToken cancellationToken)
         {
             var approvalId = approvalItem.Id;
-            var serverLabel = approvalItem.ServerLabel;
-            var toolName = approvalItem.Name;
-            var arguments = approvalItem.Arguments;
+            var serverLabel = approvalItem.ServerLabel ?? "";
+            var toolName = approvalItem.Name ?? "";
 
-            Console.WriteLine();
-            Console.WriteLine("🔐 MCP Approval Request:");
-            Console.WriteLine($"   Server:    {serverLabel}");
-            Console.WriteLine($"   Tool:      {toolName}");
-            Console.WriteLine($"   Arguments: {arguments}");
-
-            // Prompt the user for approval
-            bool approved = false;
-            while (true)
+            if (string.IsNullOrEmpty(approvalId))
             {
-                Console.Write("   Approve? (y/n): ");
-                var input = Console.ReadLine()?.Trim().ToLowerInvariant();
-                if (input == "y") { approved = true; break; }
-                if (input == "n") { approved = false; break; }
-                Console.WriteLine("   Invalid input. Please type 'y' or 'n'.");
+                _logger.LogError("MCP approval item missing ID");
+                return;
             }
 
-            // Send the approval or denial response via SendCommandAsync with raw JSON
-            await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new
+            // If another approval is already pending, queue this one
+            if (_pendingApproval != null)
             {
-                type = "conversation.item.create",
-                item = new
+                _logger.LogInformation("Queuing approval for {Tool} — another is already pending", toolName);
+                _approvalQueue.Enqueue(new ApprovalInfo(approvalId, serverLabel, toolName));
+                return;
+            }
+
+            _logger.LogInformation("MCP approval request: server={Server} tool={Tool}", serverLabel, toolName);
+            Console.WriteLine();
+            Console.WriteLine($"🔐 MCP Approval Request (voice-based):");
+            Console.WriteLine($"   Server: {serverLabel}  Tool: {toolName}");
+
+            _pendingApproval = new ApprovalInfo(approvalId, serverLabel, toolName);
+
+            if (!_responseActive)
+            {
+                await SendApprovalVoicePromptAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                _approvalPromptNeeded = true;
+            }
+        }
+
+        /// <summary>
+        /// Inject a system message asking the model to verbally request permission.
+        /// </summary>
+        private async Task SendApprovalVoicePromptAsync(CancellationToken cancellationToken)
+        {
+            var pending = _pendingApproval;
+            if (pending == null) return;
+
+            var server = pending.ServerLabel;
+            _approvalCallCount.TryGetValue(server, out var callCount);
+            _approvalCallCount[server] = callCount + 1;
+
+            string prompt;
+            if (callCount == 0)
+            {
+                prompt = "You MUST ask the user for explicit permission before proceeding. "
+                       + $"Say exactly: \"I'd like to search the {server} service for information. "
+                       + "Do you approve? Please say yes or no.\"";
+            }
+            else
+            {
+                prompt = "You MUST ask the user for permission again. "
+                       + "Say exactly: \"I need to do one more search to get complete information. "
+                       + "Should I continue? Please say yes or no.\"";
+            }
+
+            try
+            {
+                await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new
                 {
-                    type = "mcp_approval_response",
-                    approval_request_id = approvalId,
-                    approve = approved,
-                }
-            }), cancellationToken).ConfigureAwait(false);
-            _logger.LogInformation("Sent MCP approval response: {Approved} for {Tool}", approved, toolName);
+                    type = "conversation.item.create",
+                    item = new
+                    {
+                        type = "message",
+                        role = "system",
+                        content = new[] { new { type = "input_text", text = prompt } }
+                    }
+                }), cancellationToken).ConfigureAwait(false);
+                await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new { type = "response.create" }), cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Failed to send approval voice prompt: {Error}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Interpret the user's spoken response as approval or denial.
+        /// </summary>
+        private async Task ResolveVoiceApprovalAsync(string transcript, CancellationToken cancellationToken)
+        {
+            var pending = _pendingApproval;
+            if (pending == null) return;
+
+            var text = transcript.Trim().ToLowerInvariant();
+
+            bool approved = Regex.IsMatch(text, @"\byes\b");
+            bool denied = Regex.IsMatch(text, @"\b(no|stop|cancel)\b");
+
+            if (!approved && !denied)
+            {
+                // Ambiguous — ask again via the deferred prompt mechanism
+                _logger.LogInformation("Ambiguous approval response: {Transcript}", transcript);
+                _approvalPromptNeeded = true;
+                return;
+            }
+
+            if (approved && denied)
+            {
+                // Conflicting signals — treat as denial for safety
+                approved = false;
+            }
+
+            // Clear the pending state before sending the response
+            _pendingApproval = null;
+            if (!approved)
+                _approvalCallCount.Clear();
+
+            try
+            {
+                await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new
+                {
+                    type = "conversation.item.create",
+                    item = new
+                    {
+                        type = "mcp_approval_response",
+                        approval_request_id = pending.ApprovalId,
+                        approve = approved,
+                    }
+                }), cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("Failed to send approval response: {Error}", ex.Message);
+                return;
+            }
+            _logger.LogInformation("Voice approval resolved: {Approved} for {Tool}", approved, pending.FunctionName);
+            Console.WriteLine($"   Voice approval: {(approved ? "Approved ✅" : "Denied ❌")}");
+
+            // Process next queued approval, if any
+            await ProcessNextApprovalAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Pop the next queued approval and ask via voice.
+        /// </summary>
+        private async Task ProcessNextApprovalAsync(CancellationToken cancellationToken)
+        {
+            if (_approvalQueue.Count == 0) return;
+
+            var next = _approvalQueue.Dequeue();
+            _pendingApproval = next;
+
+            if (!_responseActive)
+            {
+                await SendApprovalVoicePromptAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                _approvalPromptNeeded = true;
+            }
         }
         // </handle_approval>
+
+        // <mcp_stall_detection>
+        private void StartMcpStallTimer(CancellationToken ct)
+        {
+            CancelMcpStallTimer();
+            _mcpStallCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            var token = _mcpStallCts.Token;
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(15000, token).ConfigureAwait(false);
+                if (_mcpCallInProgress > 0 && _session != null)
+                {
+                    try
+                    {
+                        await _session.SendCommandAsync(BinaryData.FromObjectAsJson(new
+                        {
+                            type = "conversation.item.create",
+                            item = new
+                            {
+                                type = "message",
+                                role = "system",
+                                content = new[] { new { type = "input_text", text = "The tool call is taking longer than expected. Briefly let the user know you're still waiting for results." } }
+                            }
+                        }), token).ConfigureAwait(false);
+                        await _session.SendCommandAsync(BinaryData.FromObjectAsJson(new { type = "response.create" }), token).ConfigureAwait(false);
+                    }
+                    catch { }
+                }
+            }, token);
+        }
+
+        private void CancelMcpStallTimer()
+        {
+            if (_mcpStallCts != null)
+            {
+                _mcpStallCts.Cancel();
+                _mcpStallCts.Dispose();
+                _mcpStallCts = null;
+            }
+        }
+        // </mcp_stall_detection>
 
         public void Dispose()
         {
             if (_disposed) return;
+            CancelMcpStallTimer();
             _audioProcessor?.Dispose();
             _session?.Dispose();
             _disposed = true;

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -225,11 +225,11 @@ namespace Azure.AI.VoiceLive.Samples
                 new VoiceLiveMcpServerDefinition("deepwiki", "https://mcp.deepwiki.com/mcp")
                 {
                     AllowedTools = { "read_wiki_structure", "ask_question" },
-                    RequireApproval = BinaryData.FromObjectAsJson(MCPApprovalType.Never),
+                    RequireApproval = BinaryData.FromString("\"never\""),
                 },
                 new VoiceLiveMcpServerDefinition("azure_doc", "https://learn.microsoft.com/api/mcp")
                 {
-                    RequireApproval = BinaryData.FromObjectAsJson(MCPApprovalType.Always),
+                    RequireApproval = BinaryData.FromString("\"always\""),
                 },
             };
 

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -721,9 +721,16 @@ namespace Azure.AI.VoiceLive.Samples
             var token = _mcpStallCts.Token;
             _ = Task.Run(async () =>
             {
-                await Task.Delay(15000, token).ConfigureAwait(false);
-                if (_mcpCallInProgress > 0 && _session != null)
+                int stallCount = 0;
+                while (_mcpCallInProgress > 0)
                 {
+                    await Task.Delay(15000, token).ConfigureAwait(false);
+                    if (_mcpCallInProgress <= 0 || _session == null)
+                        break;
+                    stallCount++;
+                    string msg = stallCount == 1
+                        ? "The tool call is taking longer than expected. Briefly let the user know you're still waiting for results."
+                        : "The tool call is taking very long. Ask the user: would you like to keep waiting, or should I move on and answer with what I know? Keep it short.";
                     try
                     {
                         await _session.SendCommandAsync(BinaryData.FromObjectAsJson(new
@@ -733,7 +740,7 @@ namespace Azure.AI.VoiceLive.Samples
                             {
                                 type = "message",
                                 role = "system",
-                                content = new[] { new { type = "input_text", text = "The tool call is taking longer than expected. Briefly let the user know you're still waiting for results." } }
+                                content = new[] { new { type = "input_text", text = msg } }
                             }
                         }), token).ConfigureAwait(false);
                         await _session.SendCommandAsync(BinaryData.FromObjectAsJson(new { type = "response.create" }), token).ConfigureAwait(false);

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -261,7 +261,8 @@ namespace Azure.AI.VoiceLive.Samples
             // Enable input audio transcription so we receive
             // SessionUpdateConversationItemInputAudioTranscriptionCompleted events
             // (required for the voice-based approval flow).
-            sessionOptions.InputAudioTranscription = new AudioInputTranscriptionOptions("azure-speech");
+            sessionOptions.InputAudioTranscription = new AudioInputTranscriptionOptions(
+                _model.Contains("realtime", StringComparison.OrdinalIgnoreCase) ? "whisper-1" : "azure-speech");
 
             sessionOptions.Modalities.Clear();
             sessionOptions.Modalities.Add(InteractionModality.Text);

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -258,6 +258,11 @@ namespace Azure.AI.VoiceLive.Samples
                 TurnDetection = turnDetection
             };
 
+            // Enable input audio transcription so we receive
+            // SessionUpdateConversationItemInputAudioTranscriptionCompleted events
+            // (required for the voice-based approval flow).
+            sessionOptions.InputAudioTranscription = new AudioInputTranscriptionOptions("azure-speech");
+
             sessionOptions.Modalities.Clear();
             sessionOptions.Modalities.Add(InteractionModality.Text);
             sessionOptions.Modalities.Add(InteractionModality.Audio);
@@ -315,9 +320,11 @@ namespace Azure.AI.VoiceLive.Samples
                         try { await _session!.ClearStreamingAudioAsync(cancellationToken).ConfigureAwait(false); }
                         catch { }
                     }
-                    // Reset approval call counter only when no approval is pending
-                    if (_pendingApproval == null)
-                        _approvalCallCount.Clear();
+                    // Do NOT reset _approvalCallCount here — the counter should only
+                    // reset on task completion (in MCP-call-completed when no pending/queued
+                    // approvals remain) or on explicit denial (in ResolveVoiceApprovalAsync).
+                    // Resetting on every speech-start would let the model retry denied calls.
+
                     // If an MCP call is running, ask the user if they want to wait or skip
                     if (_mcpCallInProgress > 0 && _pendingApproval == null)
                     {

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -189,7 +189,7 @@ namespace Azure.AI.VoiceLive.Samples
                 Console.WriteLine(new string('=', 70));
                 Console.WriteLine("🎤 VOICE ASSISTANT WITH MCP READY");
                 Console.WriteLine("Try saying:");
-                Console.WriteLine("  • 'Can you summarize the GitHub repo azure-sdk-for-net?'");
+                Console.WriteLine("  • 'What is the GitHub repo fastapi about?'");
                 Console.WriteLine("  • 'Search the Azure documentation for Voice Live API.'");
                 Console.WriteLine("You may need to approve some MCP tool calls in the console.");
                 Console.WriteLine("Press Ctrl+C to exit");

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -35,7 +35,7 @@ namespace Azure.AI.VoiceLive.Samples
             var endpoint = configuration["VoiceLive:Endpoint"] ?? Environment.GetEnvironmentVariable("AZURE_VOICELIVE_ENDPOINT") ?? "https://your-resource-name.services.ai.azure.com/";
             var model = configuration["VoiceLive:Model"] ?? Environment.GetEnvironmentVariable("AZURE_VOICELIVE_MODEL") ?? "gpt-realtime";
             var voice = configuration["VoiceLive:Voice"] ?? Environment.GetEnvironmentVariable("AZURE_VOICELIVE_VOICE") ?? "en-US-Ava:DragonHDLatestNeural";
-            var instructions = configuration["VoiceLive:Instructions"] ?? "You are a helpful AI assistant with access to MCP tools. Use the tools to help answer user questions. Respond naturally and conversationally. Some tools require user approval before they can be used. When you receive a system message asking you to request permission, you MUST clearly ask the user for their explicit approval before proceeding. Always wait for the user to say yes or no. Never skip the approval question or assume permission is granted.";
+            var instructions = configuration["VoiceLive:Instructions"] ?? "You are a helpful AI assistant with access to MCP tools. Use the tools to help answer user questions. Respond naturally and conversationally. Some tools require user approval before they can be used. When you receive a system message asking you to request permission, you MUST clearly ask the user for their explicit approval before proceeding. Always wait for the user to say yes or no. Never skip the approval question or assume permission is granted. If a tool result arrives after the conversation has moved to a different topic, briefly introduce it as a late result before sharing the findings.";
             var useTokenCredential = args.Length > 0 && args[0] == "--use-token-credential";
 
             // Setup logging
@@ -154,6 +154,8 @@ namespace Azure.AI.VoiceLive.Samples
         private readonly Dictionary<string, string> _mcpItemToServer = new();
         private HashSet<string> _approvalServers = new();
         private CancellationTokenSource? _mcpStallCts;
+        private readonly HashSet<string> _activeMcpItems = new();
+        private readonly HashSet<string> _staleMcpItems = new();
 
         public MCPVoiceAssistant(
             VoiceLiveClient client,
@@ -325,7 +327,8 @@ namespace Azure.AI.VoiceLive.Samples
                     // If an MCP call is running, ask the user if they want to wait or skip
                     if (_mcpCallInProgress > 0 && _pendingApproval == null)
                     {
-                        _logger.LogInformation("User spoke during MCP call — will ask if they want to skip");
+                        foreach (var id in _activeMcpItems) _staleMcpItems.Add(id);
+                        _logger.LogInformation("User spoke during MCP call — marking {Count} calls as stale", _activeMcpItems.Count);
                         try
                         {
                             await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new
@@ -335,11 +338,11 @@ namespace Azure.AI.VoiceLive.Samples
                                 {
                                     type = "message",
                                     role = "system",
-                                    content = new[] { new { type = "input_text", text = "A tool call is still running. The user just spoke. Briefly acknowledge them and let them know you're still waiting for results. One short sentence." } }
+                                    content = new[] { new { type = "input_text", text = "A tool call is still running in the background. The user just spoke. Respond to what the user said. If a tool result arrives later, briefly introduce it as a late result from an earlier request." } }
                                 }
                             }), cancellationToken).ConfigureAwait(false);
                         }
-                        catch (Exception ex) { _logger.LogWarning("Failed to inject MCP skip inquiry: {Error}", ex.Message); }
+                        catch (Exception ex) { _logger.LogWarning("Failed to inject MCP status update: {Error}", ex.Message); }
                     }
                     break;
 
@@ -426,6 +429,7 @@ namespace Azure.AI.VoiceLive.Samples
                 case SessionUpdateResponseMcpCallInProgress mcpInProgress:
                     Console.WriteLine("⏳ MCP tool call in progress...");
                     _mcpCallInProgress++;
+                    _activeMcpItems.Add(mcpInProgress.ItemId ?? "");
                     StartMcpStallTimer(cancellationToken);
                     break;
 
@@ -433,6 +437,7 @@ namespace Azure.AI.VoiceLive.Samples
                 {
                     var itemId = mcpCompleted.ItemId ?? "";
                     _mcpCallInProgress = Math.Max(0, _mcpCallInProgress - 1);
+                    _activeMcpItems.Remove(itemId);
                     CancelMcpStallTimer();
                     if (_handledMcpCompletions.Contains(itemId))
                     {
@@ -441,7 +446,8 @@ namespace Azure.AI.VoiceLive.Samples
                     else
                     {
                         _handledMcpCompletions.Add(itemId);
-                        _logger.LogInformation("MCP call completed for {ItemId}", itemId);
+                        bool isStale = _staleMcpItems.Remove(itemId);
+                        _logger.LogInformation("MCP call completed for {ItemId} (stale={IsStale})", itemId, isStale);
                         Console.WriteLine("✅ MCP tool call completed successfully");
 
                         // Clean up item mapping
@@ -450,6 +456,25 @@ namespace Azure.AI.VoiceLive.Samples
                         // Reset approval counter if no more approvals are pending
                         if (_pendingApproval == null && _approvalQueue.Count == 0)
                             _approvalCallCount.Clear();
+
+                        // If the user moved on during this call, tell the model it's a late result
+                        if (isStale)
+                        {
+                            try
+                            {
+                                await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new
+                                {
+                                    type = "conversation.item.create",
+                                    item = new
+                                    {
+                                        type = "message",
+                                        role = "system",
+                                        content = new[] { new { type = "input_text", text = "This tool result is from an earlier request. The user has since moved on. Briefly introduce it as a late result, e.g. 'By the way, those results from earlier just came in...' then share the key findings concisely." } }
+                                    }
+                                }), cancellationToken).ConfigureAwait(false);
+                            }
+                            catch (Exception ex) { _logger.LogWarning("Failed to inject late-result context: {Error}", ex.Message); }
+                        }
 
                         // Kick the model to incorporate and speak the MCP output
                         try
@@ -468,12 +493,17 @@ namespace Azure.AI.VoiceLive.Samples
                 }
 
                 case SessionUpdateResponseMcpCallFailed mcpFailed:
+                {
+                    var failedItemId = mcpFailed.ItemId ?? "";
                     Console.WriteLine("❌ MCP tool call failed");
                     _mcpCallInProgress = Math.Max(0, _mcpCallInProgress - 1);
+                    _activeMcpItems.Remove(failedItemId);
+                    _staleMcpItems.Remove(failedItemId);
                     CancelMcpStallTimer();
                     try { await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new { type = "response.create" }), cancellationToken).ConfigureAwait(false); }
                     catch { }
                     break;
+                }
 
                 case SessionUpdateConversationItemCreated itemCreated
                     when itemCreated.Item is SessionResponseMcpApprovalRequestItem mcpApproval:
@@ -728,7 +758,7 @@ namespace Azure.AI.VoiceLive.Samples
                 int stallCount = 0;
                 while (_mcpCallInProgress > 0 && stallCount < 3)
                 {
-                    await Task.Delay(15000, token).ConfigureAwait(false);
+                    await Task.Delay(10000, token).ConfigureAwait(false);
                     if (_mcpCallInProgress <= 0 || _session == null)
                         break;
                     stallCount++;

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -156,6 +156,8 @@ namespace Azure.AI.VoiceLive.Samples
         private CancellationTokenSource? _mcpStallCts;
         private readonly HashSet<string> _activeMcpItems = new();
         private readonly HashSet<string> _staleMcpItems = new();
+        private bool _mcpResultsPending;
+        private readonly HashSet<string> _approvedServersThisTurn = new();
 
         public MCPVoiceAssistant(
             VoiceLiveClient client,
@@ -324,6 +326,10 @@ namespace Azure.AI.VoiceLive.Samples
                     // approvals remain) or on explicit denial (in ResolveVoiceApprovalAsync).
                     // Resetting on every speech-start would let the model retry denied calls.
 
+                    // Reset approved-servers-this-turn when user starts a new topic
+                    if (_pendingApproval == null && _mcpCallInProgress <= 0)
+                        _approvedServersThisTurn.Clear();
+
                     // If an MCP call is running, ask the user if they want to wait or skip
                     if (_mcpCallInProgress > 0 && _pendingApproval == null)
                     {
@@ -374,6 +380,13 @@ namespace Azure.AI.VoiceLive.Samples
                     {
                         _approvalPromptNeeded = false;
                         await SendApprovalVoicePromptAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                    // If MCP results are pending and all calls are now done, create response
+                    else if (_mcpResultsPending && _mcpCallInProgress <= 0 && _pendingApproval == null)
+                    {
+                        _mcpResultsPending = false;
+                        try { await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new { type = "response.create" }), cancellationToken).ConfigureAwait(false); }
+                        catch { }
                     }
                     else if (_needsResponseCreate)
                     {
@@ -476,17 +489,26 @@ namespace Azure.AI.VoiceLive.Samples
                             catch (Exception ex) { _logger.LogWarning("Failed to inject late-result context: {Error}", ex.Message); }
                         }
 
-                        // Kick the model to incorporate and speak the MCP output
-                        try
+                        // Batch response: only call response.create when ALL MCP calls for this
+                        // turn have completed. This prevents partial results and repeated tool calls.
+                        if (_pendingApproval == null && _approvalQueue.Count == 0 && _mcpCallInProgress <= 0)
                         {
-                            await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new { type = "response.create" }), cancellationToken).ConfigureAwait(false);
+                            try
+                            {
+                                await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new { type = "response.create" }), cancellationToken).ConfigureAwait(false);
+                            }
+                            catch (Exception ex)
+                            {
+                                if (ex.Message.Contains("active response", StringComparison.OrdinalIgnoreCase))
+                                    _needsResponseCreate = true;
+                                else
+                                    _logger.LogWarning("Failed to create response after MCP call: {Error}", ex.Message);
+                            }
                         }
-                        catch (Exception ex)
+                        else
                         {
-                            if (ex.Message.Contains("active response", StringComparison.OrdinalIgnoreCase))
-                                _needsResponseCreate = true;
-                            else
-                                _logger.LogWarning("Failed to create response after MCP call: {Error}", ex.Message);
+                            _mcpResultsPending = true;
+                            _logger.LogInformation("MCP calls still in progress ({Count}) — deferring response", _mcpCallInProgress);
                         }
                     }
                     break;
@@ -606,6 +628,31 @@ namespace Azure.AI.VoiceLive.Samples
                 return;
             }
 
+            // Auto-approve if user already approved this server earlier in the same turn
+            if (_approvedServersThisTurn.Contains(serverLabel))
+            {
+                _logger.LogInformation("Auto-approving {Tool} — server already approved this turn", toolName);
+                Console.WriteLine($"   Auto-approved: {serverLabel}/{toolName} (already approved this turn)");
+                try
+                {
+                    await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new
+                    {
+                        type = "conversation.item.create",
+                        item = new
+                        {
+                            type = "mcp_approval_response",
+                            approval_request_id = approvalId,
+                            approve = true
+                        }
+                    }), cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning("Failed to send auto-approve: {Error}", ex.Message);
+                }
+                return;
+            }
+
             _logger.LogInformation("MCP approval request: server={Server} tool={Tool}", serverLabel, toolName);
             Console.WriteLine();
             Console.WriteLine($"🔐 MCP Approval Request (voice-based):");
@@ -698,8 +745,13 @@ namespace Azure.AI.VoiceLive.Samples
 
             // Clear the pending state before sending the response
             _pendingApproval = null;
-            if (!approved)
+            if (approved)
+                _approvedServersThisTurn.Add(pending.ServerLabel);
+            else
+            {
                 _approvalCallCount.Clear();
+                _approvedServersThisTurn.Remove(pending.ServerLabel);
+            }
 
             try
             {

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -275,11 +275,7 @@ namespace Azure.AI.VoiceLive.Samples
             }
 
             // Track which servers require approval for per-turn loop prevention
-            _approvalServers = new HashSet<string>(
-                mcpServers.OfType<VoiceLiveMcpServerDefinition>()
-                    .Where(s => s.RequireApproval?.ToString()?.Contains("always", StringComparison.OrdinalIgnoreCase) == true)
-                    .Select(s => s.ServerLabel ?? "")
-            );
+            _approvalServers = new HashSet<string> { "azure_doc" };
 
             await _session!.ConfigureSessionAsync(sessionOptions, cancellationToken).ConfigureAwait(false);
             _logger.LogInformation("Session with MCP tools configured");
@@ -392,7 +388,7 @@ namespace Azure.AI.VoiceLive.Samples
                         {
                             _logger.LogWarning("Interim response not supported with this model pipeline (non-fatal)");
                         }
-                        else if (msg.Contains("active response in progress", StringComparison.OrdinalIgnoreCase))
+                        else if (msg.Contains("active response", StringComparison.OrdinalIgnoreCase))
                         {
                             _logger.LogDebug("Response collision (expected during MCP flow): {Message}", msg);
                         }

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -158,6 +159,7 @@ namespace Azure.AI.VoiceLive.Samples
         private readonly HashSet<string> _staleMcpItems = new();
         private bool _mcpResultsPending;
         private readonly HashSet<string> _approvedServersThisTurn = new();
+        private static readonly string LogFilename = $"conversation_{DateTime.Now:yyyyMMdd_HHmmss}.log";
 
         public MCPVoiceAssistant(
             VoiceLiveClient client,
@@ -306,6 +308,10 @@ namespace Azure.AI.VoiceLive.Samples
             {
                 case SessionUpdateSessionUpdated:
                     _logger.LogInformation("Session updated");
+                    WriteLog($"SessionID: {_session?.SessionId}");
+                    WriteLog($"Model: {_model}");
+                    WriteLog($"Voice: {_voice}");
+                    WriteLog("");
                     if (_audioProcessor != null)
                         await _audioProcessor.StartCaptureAsync().ConfigureAwait(false);
                     break;
@@ -325,6 +331,15 @@ namespace Azure.AI.VoiceLive.Samples
                     // reset on task completion (in MCP-call-completed when no pending/queued
                     // approvals remain) or on explicit denial (in ResolveVoiceApprovalAsync).
                     // Resetting on every speech-start would let the model retry denied calls.
+
+                    // Clear deferred response flags if no MCP calls are in progress.
+                    // Prevents stale needsResponseCreate from re-triggering result playback
+                    // after the user interrupts.
+                    if (_mcpCallInProgress <= 0)
+                    {
+                        _needsResponseCreate = false;
+                        _mcpResultsPending = false;
+                    }
 
                     // Reset approved-servers-this-turn when user starts a new topic
                     if (_pendingApproval == null && _mcpCallInProgress <= 0)
@@ -375,6 +390,7 @@ namespace Azure.AI.VoiceLive.Samples
                 case SessionUpdateResponseDone:
                     _responseActive = false;
                     _canCancelResponse = false;
+                    WriteLog("--- Response complete ---");
                     // If an approval prompt needs to be injected, do it now
                     if (_approvalPromptNeeded && _pendingApproval != null)
                     {
@@ -412,6 +428,7 @@ namespace Azure.AI.VoiceLive.Samples
                         else
                         {
                             Console.WriteLine($"❌ Error: {msg}");
+                        WriteLog($"ERROR: {msg}");
                         }
                     }
                     _responseActive = false;
@@ -423,6 +440,7 @@ namespace Azure.AI.VoiceLive.Samples
                     var transcript = transcription.Transcript ?? "";
                     _logger.LogInformation("User said: {Transcript}", transcript);
                     Console.WriteLine($"👤 You said:\t{transcript}");
+                    WriteLog($"User Input:\t{transcript}");
                     if (_pendingApproval != null)
                     {
                         await ResolveVoiceApprovalAsync(transcript, cancellationToken).ConfigureAwait(false);
@@ -432,15 +450,18 @@ namespace Azure.AI.VoiceLive.Samples
                 // MCP-specific events
                 case SessionUpdateMcpListToolsCompleted mcpListDone:
                     Console.WriteLine("🔧 MCP tools discovered successfully");
+                    WriteLog("MCP tools discovered successfully");
                     _logger.LogInformation("MCP tools discovered for server");
                     break;
 
                 case SessionUpdateMcpListToolsFailed:
                     Console.WriteLine("❌ MCP tool discovery failed");
+                    WriteLog("ERROR: MCP tool discovery failed");
                     break;
 
                 case SessionUpdateResponseMcpCallInProgress mcpInProgress:
                     Console.WriteLine("⏳ MCP tool call in progress...");
+                    WriteLog($"MCP call in progress: {mcpInProgress.ItemId}");
                     _mcpCallInProgress++;
                     _activeMcpItems.Add(mcpInProgress.ItemId ?? "");
                     StartMcpStallTimer(cancellationToken);
@@ -462,6 +483,7 @@ namespace Azure.AI.VoiceLive.Samples
                         bool isStale = _staleMcpItems.Remove(itemId);
                         _logger.LogInformation("MCP call completed for {ItemId} (stale={IsStale})", itemId, isStale);
                         Console.WriteLine("✅ MCP tool call completed successfully");
+                        WriteLog($"MCP call completed: {itemId} (stale={isStale});");
 
                         // Clean up item mapping
                         _mcpItemToServer.Remove(itemId);
@@ -518,6 +540,7 @@ namespace Azure.AI.VoiceLive.Samples
                 {
                     var failedItemId = mcpFailed.ItemId ?? "";
                     Console.WriteLine("❌ MCP tool call failed");
+                    WriteLog($"ERROR: MCP call failed: {failedItemId}");
                     _mcpCallInProgress = Math.Max(0, _mcpCallInProgress - 1);
                     _activeMcpItems.Remove(failedItemId);
                     _staleMcpItems.Remove(failedItemId);
@@ -657,6 +680,7 @@ namespace Azure.AI.VoiceLive.Samples
             Console.WriteLine();
             Console.WriteLine($"🔐 MCP Approval Request (voice-based):");
             Console.WriteLine($"   Server: {serverLabel}  Tool: {toolName}");
+            WriteLog($"Approval request: server={serverLabel} tool={toolName}");
 
             _pendingApproval = new ApprovalInfo(approvalId, serverLabel, toolName);
 
@@ -773,6 +797,7 @@ namespace Azure.AI.VoiceLive.Samples
             }
             _logger.LogInformation("Voice approval resolved: {Approved} for {Tool}", approved, pending.FunctionName);
             Console.WriteLine($"   Voice approval: {(approved ? "Approved ✅" : "Denied ❌")}");
+            WriteLog($"Approval resolved: {(approved ? "APPROVED" : "DENIED")} for {pending.ServerLabel}/{pending.FunctionName}");
 
             // Process next queued approval, if any
             await ProcessNextApprovalAsync(cancellationToken).ConfigureAwait(false);
@@ -849,6 +874,18 @@ namespace Azure.AI.VoiceLive.Samples
             }
         }
         // </mcp_stall_detection>
+
+        private static void WriteLog(string message)
+        {
+            try
+            {
+                var logDir = Path.Combine(Directory.GetCurrentDirectory(), "logs");
+                Directory.CreateDirectory(logDir);
+                var logPath = Path.Combine(logDir, LogFilename);
+                File.AppendAllText(logPath, $"[{DateTime.Now:HH:mm:ss}] {message}{Environment.NewLine}");
+            }
+            catch (IOException) { }
+        }
 
         public void Dispose()
         {

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -1,0 +1,589 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Azure.AI.VoiceLive;
+using Azure.Identity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NAudio.Wave;
+
+namespace Azure.AI.VoiceLive.Samples
+{
+    /// <summary>
+    /// MCP Quickstart - demonstrates MCP server integration with VoiceLive SDK.
+    /// Shows how to define MCP servers, handle MCP tool calls, and implement
+    /// an approval flow for tool calls that require user consent.
+    /// </summary>
+    public class Program
+    {
+        public static async Task<int> Main(string[] args)
+        {
+            // Setup configuration
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            var apiKey = configuration["VoiceLive:ApiKey"] ?? Environment.GetEnvironmentVariable("AZURE_VOICELIVE_API_KEY");
+            var endpoint = configuration["VoiceLive:Endpoint"] ?? Environment.GetEnvironmentVariable("AZURE_VOICELIVE_ENDPOINT") ?? "https://your-resource-name.services.ai.azure.com/";
+            var model = configuration["VoiceLive:Model"] ?? Environment.GetEnvironmentVariable("AZURE_VOICELIVE_MODEL") ?? "gpt-realtime";
+            var voice = configuration["VoiceLive:Voice"] ?? Environment.GetEnvironmentVariable("AZURE_VOICELIVE_VOICE") ?? "en-US-Ava:DragonHDLatestNeural";
+            var instructions = configuration["VoiceLive:Instructions"] ?? "You are a helpful AI assistant with access to MCP tools. Use the tools to help answer user questions. Respond naturally and conversationally.";
+            var useTokenCredential = args.Length > 0 && args[0] == "--use-token-credential";
+
+            // Setup logging
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+                builder.SetMinimumLevel(LogLevel.Information);
+            });
+
+            var logger = loggerFactory.CreateLogger<Program>();
+
+            // Validate credentials
+            if (string.IsNullOrEmpty(apiKey) && !useTokenCredential)
+            {
+                Console.WriteLine("❌ Error: No authentication provided");
+                Console.WriteLine("Set AZURE_VOICELIVE_API_KEY or use --use-token-credential.");
+                return 1;
+            }
+
+            // Check audio system
+            if (!CheckAudioSystem(logger))
+                return 1;
+
+            try
+            {
+                VoiceLiveClient client;
+                if (useTokenCredential)
+                {
+                    client = new VoiceLiveClient(new Uri(endpoint), new DefaultAzureCredential(), new VoiceLiveClientOptions());
+                    logger.LogInformation("Using Azure token credential");
+                }
+                else
+                {
+                    client = new VoiceLiveClient(new Uri(endpoint), new AzureKeyCredential(apiKey!), new VoiceLiveClientOptions());
+                    logger.LogInformation("Using API key credential");
+                }
+
+                using var assistant = new MCPVoiceAssistant(client, model, voice, instructions, loggerFactory);
+                using var cts = new CancellationTokenSource();
+
+                Console.CancelKeyPress += (sender, e) =>
+                {
+                    e.Cancel = true;
+                    cts.Cancel();
+                };
+
+                await assistant.StartAsync(cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                Console.WriteLine("\n👋 Voice assistant with MCP shut down. Goodbye!");
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Fatal error");
+                Console.WriteLine($"❌ Error: {ex.Message}");
+                return 1;
+            }
+
+            return 0;
+        }
+
+        private static bool CheckAudioSystem(ILogger logger)
+        {
+            try
+            {
+                using var waveIn = new WaveInEvent { WaveFormat = new WaveFormat(24000, 16, 1), BufferMilliseconds = 50 };
+                waveIn.DataAvailable += (_, __) => { };
+                waveIn.StartRecording();
+                waveIn.StopRecording();
+
+                var buffer = new BufferedWaveProvider(new WaveFormat(24000, 16, 1)) { BufferDuration = TimeSpan.FromMilliseconds(200) };
+                using var waveOut = new WaveOutEvent { DesiredLatency = 100 };
+                waveOut.Init(buffer);
+                waveOut.Play();
+                waveOut.Stop();
+
+                logger.LogInformation("Audio system check passed");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"❌ Audio system check failed: {ex.Message}");
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Voice assistant with MCP server integration.
+    /// </summary>
+    public class MCPVoiceAssistant : IDisposable
+    {
+        private readonly VoiceLiveClient _client;
+        private readonly string _model;
+        private readonly string _voice;
+        private readonly string _instructions;
+        private readonly ILogger<MCPVoiceAssistant> _logger;
+        private readonly ILoggerFactory _loggerFactory;
+
+        private VoiceLiveSession? _session;
+        private AudioProcessor? _audioProcessor;
+        private bool _disposed;
+        private bool _responseActive;
+        private bool _canCancelResponse;
+
+        public MCPVoiceAssistant(
+            VoiceLiveClient client,
+            string model,
+            string voice,
+            string instructions,
+            ILoggerFactory loggerFactory)
+        {
+            _client = client;
+            _model = model;
+            _voice = voice;
+            _instructions = instructions;
+            _loggerFactory = loggerFactory;
+            _logger = loggerFactory.CreateLogger<MCPVoiceAssistant>();
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                _logger.LogInformation("Connecting to VoiceLive API with model {Model}", _model);
+
+                _session = await _client.StartSessionAsync(_model, cancellationToken).ConfigureAwait(false);
+                _audioProcessor = new AudioProcessor(_session, _loggerFactory.CreateLogger<AudioProcessor>());
+
+                await SetupSessionAsync(cancellationToken).ConfigureAwait(false);
+
+                await _audioProcessor.StartPlaybackAsync().ConfigureAwait(false);
+                await _audioProcessor.StartCaptureAsync().ConfigureAwait(false);
+
+                _logger.LogInformation("Voice assistant with MCP ready!");
+                Console.WriteLine();
+                Console.WriteLine(new string('=', 70));
+                Console.WriteLine("🎤 VOICE ASSISTANT WITH MCP READY");
+                Console.WriteLine("Try saying:");
+                Console.WriteLine("  • 'Can you summarize the GitHub repo azure-sdk-for-net?'");
+                Console.WriteLine("  • 'Search the Azure documentation for Voice Live API.'");
+                Console.WriteLine("You may need to approve some MCP tool calls in the console.");
+                Console.WriteLine("Press Ctrl+C to exit");
+                Console.WriteLine(new string('=', 70));
+                Console.WriteLine();
+
+                await ProcessEventsAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogInformation("Shutting down...");
+            }
+            finally
+            {
+                if (_audioProcessor != null)
+                    await _audioProcessor.CleanupAsync().ConfigureAwait(false);
+            }
+        }
+
+        // <define_mcp_servers>
+        /// <summary>
+        /// Define MCP servers that Voice Live can use during the session.
+        /// Each server is a VoiceLiveMcpServerDefinition instance added to the session options tools list.
+        /// </summary>
+        private List<VoiceLiveToolDefinition> DefineMCPServers()
+        {
+            var mcpTools = new List<VoiceLiveToolDefinition>
+            {
+                new VoiceLiveMcpServerDefinition("deepwiki", "https://mcp.deepwiki.com/mcp")
+                {
+                    AllowedTools = { "read_wiki_structure", "ask_question" },
+                    RequireApproval = BinaryData.FromObjectAsJson(MCPApprovalType.Never),
+                },
+                new VoiceLiveMcpServerDefinition("azure_doc", "https://learn.microsoft.com/api/mcp")
+                {
+                    RequireApproval = BinaryData.FromObjectAsJson(MCPApprovalType.Always),
+                },
+            };
+
+            return mcpTools;
+        }
+        // </define_mcp_servers>
+
+        // <configure_session>
+        private async Task SetupSessionAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Setting up session with MCP tools...");
+
+            var azureVoice = new AzureStandardVoice(_voice);
+            var turnDetection = new ServerVadTurnDetection
+            {
+                Threshold = 0.5f,
+                PrefixPadding = TimeSpan.FromMilliseconds(300),
+                SilenceDuration = TimeSpan.FromMilliseconds(500)
+            };
+
+            // Create session options and add MCP servers to the tools list
+            var sessionOptions = new VoiceLiveSessionOptions
+            {
+                InputAudioEchoCancellation = new AudioEchoCancellation(),
+                Model = _model,
+                Instructions = _instructions,
+                Voice = azureVoice,
+                InputAudioFormat = InputAudioFormat.Pcm16,
+                OutputAudioFormat = OutputAudioFormat.Pcm16,
+                TurnDetection = turnDetection
+            };
+
+            sessionOptions.Modalities.Clear();
+            sessionOptions.Modalities.Add(InteractionModality.Text);
+            sessionOptions.Modalities.Add(InteractionModality.Audio);
+
+            // Add MCP servers to the tools list
+            var mcpServers = DefineMCPServers();
+            foreach (var tool in mcpServers)
+            {
+                sessionOptions.Tools.Add(tool);
+            }
+
+            await _session!.ConfigureSessionAsync(sessionOptions, cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation("Session with MCP tools configured");
+        }
+        // </configure_session>
+
+        private async Task ProcessEventsAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await foreach (SessionUpdate serverEvent in _session!.GetUpdatesAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    await HandleSessionUpdateAsync(serverEvent, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException) { }
+        }
+
+        // <handle_mcp_events>
+        private async Task HandleSessionUpdateAsync(SessionUpdate serverEvent, CancellationToken cancellationToken)
+        {
+            switch (serverEvent)
+            {
+                case SessionUpdateSessionUpdated:
+                    _logger.LogInformation("Session updated");
+                    if (_audioProcessor != null)
+                        await _audioProcessor.StartCaptureAsync().ConfigureAwait(false);
+                    break;
+
+                case SessionUpdateInputAudioBufferSpeechStarted:
+                    Console.WriteLine("🎤 Listening...");
+                    if (_audioProcessor != null)
+                        await _audioProcessor.StopPlaybackAsync().ConfigureAwait(false);
+                    if (_responseActive && _canCancelResponse)
+                    {
+                        try { await _session!.CancelResponseAsync(cancellationToken).ConfigureAwait(false); }
+                        catch { }
+                        try { await _session!.ClearStreamingAudioAsync(cancellationToken).ConfigureAwait(false); }
+                        catch { }
+                    }
+                    break;
+
+                case SessionUpdateInputAudioBufferSpeechStopped:
+                    Console.WriteLine("🤔 Processing...");
+                    if (_audioProcessor != null)
+                        await _audioProcessor.StartPlaybackAsync().ConfigureAwait(false);
+                    break;
+
+                case SessionUpdateResponseCreated:
+                    _responseActive = true;
+                    _canCancelResponse = true;
+                    break;
+
+                case SessionUpdateResponseAudioDelta audioDelta:
+                    if (audioDelta.Delta != null && _audioProcessor != null)
+                        await _audioProcessor.QueueAudioAsync(audioDelta.Delta.ToArray()).ConfigureAwait(false);
+                    break;
+
+                case SessionUpdateResponseAudioDone:
+                    Console.WriteLine("🎤 Ready for next input...");
+                    break;
+
+                case SessionUpdateResponseDone:
+                    _responseActive = false;
+                    _canCancelResponse = false;
+                    break;
+
+                case SessionUpdateError errorEvent:
+                    var msg = errorEvent.Error?.Message ?? "";
+                    if (!msg.Contains("no active response", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Console.WriteLine($"❌ Error: {msg}");
+                    }
+                    _responseActive = false;
+                    _canCancelResponse = false;
+                    break;
+
+                // MCP-specific events
+                case SessionUpdateMcpListToolsCompleted mcpListDone:
+                    Console.WriteLine("🔧 MCP tools discovered successfully");
+                    _logger.LogInformation("MCP tools discovered for server");
+                    break;
+
+                case SessionUpdateMcpListToolsFailed:
+                    Console.WriteLine("❌ MCP tool discovery failed");
+                    break;
+
+                case SessionUpdateResponseMcpCallInProgress mcpInProgress:
+                    Console.WriteLine("⏳ MCP tool call in progress...");
+                    break;
+
+                case SessionUpdateResponseMcpCallCompleted mcpCompleted:
+                    Console.WriteLine("✅ MCP tool call completed");
+                    _logger.LogInformation("MCP call completed");
+                    break;
+
+                case SessionUpdateResponseMcpCallFailed mcpFailed:
+                    Console.WriteLine("❌ MCP tool call failed");
+                    break;
+
+                case SessionUpdateConversationItemCreated itemCreated
+                    when itemCreated.Item is SessionResponseMcpApprovalRequestItem mcpApproval:
+                    await HandleMCPApprovalAsync(mcpApproval, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                default:
+                    _logger.LogDebug("Unhandled event: {EventType}", serverEvent.GetType().Name);
+                    break;
+            }
+        }
+        // </handle_mcp_events>
+
+        // <handle_approval>
+        /// <summary>
+        /// Handle MCP approval request by prompting the user in the console.
+        /// </summary>
+        private async Task HandleMCPApprovalAsync(SessionResponseMcpApprovalRequestItem approvalItem, CancellationToken cancellationToken)
+        {
+            var approvalId = approvalItem.Id;
+            var serverLabel = approvalItem.ServerLabel;
+            var toolName = approvalItem.Name;
+            var arguments = approvalItem.Arguments;
+
+            Console.WriteLine();
+            Console.WriteLine("🔐 MCP Approval Request:");
+            Console.WriteLine($"   Server:    {serverLabel}");
+            Console.WriteLine($"   Tool:      {toolName}");
+            Console.WriteLine($"   Arguments: {arguments}");
+
+            // Prompt the user for approval
+            bool approved = false;
+            while (true)
+            {
+                Console.Write("   Approve? (y/n): ");
+                var input = Console.ReadLine()?.Trim().ToLowerInvariant();
+                if (input == "y") { approved = true; break; }
+                if (input == "n") { approved = false; break; }
+                Console.WriteLine("   Invalid input. Please type 'y' or 'n'.");
+            }
+
+            // Send the approval or denial response via SendCommandAsync with raw JSON
+            await _session!.SendCommandAsync(BinaryData.FromObjectAsJson(new
+            {
+                type = "conversation.item.create",
+                item = new
+                {
+                    type = "mcp_approval_response",
+                    approval_request_id = approvalId,
+                    approve = approved,
+                }
+            }), cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation("Sent MCP approval response: {Approved} for {Tool}", approved, toolName);
+        }
+        // </handle_approval>
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _audioProcessor?.Dispose();
+            _session?.Dispose();
+            _disposed = true;
+        }
+    }
+
+    /// <summary>
+    /// Audio processor for real-time capture and playback.
+    /// Same pattern as ModelQuickstart - handles PCM16 24kHz mono audio.
+    /// </summary>
+    public class AudioProcessor : IDisposable
+    {
+        private readonly VoiceLiveSession _session;
+        private readonly ILogger<AudioProcessor> _logger;
+
+        private const int SampleRate = 24000;
+        private const int Channels = 1;
+        private const int BitsPerSample = 16;
+
+        private WaveInEvent? _waveIn;
+        private WaveOutEvent? _waveOut;
+        private BufferedWaveProvider? _playbackBuffer;
+
+        private bool _isCapturing;
+        private bool _isPlaying;
+
+        private readonly Channel<byte[]> _audioSendChannel;
+        private readonly ChannelWriter<byte[]> _audioSendWriter;
+        private readonly ChannelReader<byte[]> _audioSendReader;
+        private readonly Channel<byte[]> _audioPlaybackChannel;
+        private readonly ChannelWriter<byte[]> _audioPlaybackWriter;
+        private readonly ChannelReader<byte[]> _audioPlaybackReader;
+
+        private Task? _audioSendTask;
+        private Task? _audioPlaybackTask;
+        private readonly CancellationTokenSource _cancellationTokenSource;
+        private CancellationTokenSource _playbackCancellationTokenSource;
+
+        public AudioProcessor(VoiceLiveSession session, ILogger<AudioProcessor> logger)
+        {
+            _session = session;
+            _logger = logger;
+
+            _audioSendChannel = Channel.CreateUnbounded<byte[]>();
+            _audioSendWriter = _audioSendChannel.Writer;
+            _audioSendReader = _audioSendChannel.Reader;
+
+            _audioPlaybackChannel = Channel.CreateUnbounded<byte[]>();
+            _audioPlaybackWriter = _audioPlaybackChannel.Writer;
+            _audioPlaybackReader = _audioPlaybackChannel.Reader;
+
+            _cancellationTokenSource = new CancellationTokenSource();
+            _playbackCancellationTokenSource = new CancellationTokenSource();
+        }
+
+        public Task StartCaptureAsync()
+        {
+            if (_isCapturing) return Task.CompletedTask;
+            _isCapturing = true;
+
+            _waveIn = new WaveInEvent
+            {
+                WaveFormat = new WaveFormat(SampleRate, BitsPerSample, Channels),
+                BufferMilliseconds = 50
+            };
+
+            _waveIn.DataAvailable += (sender, e) =>
+            {
+                if (_isCapturing && e.BytesRecorded > 0)
+                {
+                    var audioData = new byte[e.BytesRecorded];
+                    Array.Copy(e.Buffer, 0, audioData, 0, e.BytesRecorded);
+                    _audioSendWriter.TryWrite(audioData);
+                }
+            };
+
+            _waveIn.StartRecording();
+            _audioSendTask = ProcessAudioSendAsync(_cancellationTokenSource.Token);
+            _logger.LogInformation("Started audio capture");
+            return Task.CompletedTask;
+        }
+
+        public Task StartPlaybackAsync()
+        {
+            if (_isPlaying) return Task.CompletedTask;
+            _isPlaying = true;
+
+            _waveOut = new WaveOutEvent { DesiredLatency = 100 };
+            _playbackBuffer = new BufferedWaveProvider(new WaveFormat(SampleRate, BitsPerSample, Channels))
+            {
+                BufferDuration = TimeSpan.FromSeconds(10),
+                DiscardOnBufferOverflow = true
+            };
+
+            _waveOut.Init(_playbackBuffer);
+            _waveOut.Play();
+
+            _playbackCancellationTokenSource = new CancellationTokenSource();
+            _audioPlaybackTask = ProcessAudioPlaybackAsync();
+            _logger.LogInformation("Audio playback ready");
+            return Task.CompletedTask;
+        }
+
+        public async Task StopPlaybackAsync()
+        {
+            if (!_isPlaying) return;
+            _isPlaying = false;
+
+            while (_audioPlaybackReader.TryRead(out _)) { }
+            _playbackBuffer?.ClearBuffer();
+
+            if (_waveOut != null) { _waveOut.Stop(); _waveOut.Dispose(); _waveOut = null; }
+            _playbackBuffer = null;
+            _playbackCancellationTokenSource.Cancel();
+
+            if (_audioPlaybackTask != null)
+            {
+                await _audioPlaybackTask.ConfigureAwait(false);
+                _audioPlaybackTask = null;
+            }
+        }
+
+        public async Task QueueAudioAsync(byte[] audioData)
+        {
+            if (_isPlaying && audioData.Length > 0)
+                await _audioPlaybackWriter.WriteAsync(audioData).ConfigureAwait(false);
+        }
+
+        public async Task CleanupAsync()
+        {
+            _isCapturing = false;
+            if (_waveIn != null) { _waveIn.StopRecording(); _waveIn.Dispose(); _waveIn = null; }
+            _audioSendWriter.TryComplete();
+            if (_audioSendTask != null) await _audioSendTask.ConfigureAwait(false);
+
+            await StopPlaybackAsync().ConfigureAwait(false);
+            _cancellationTokenSource.Cancel();
+            _logger.LogInformation("Audio processor cleaned up");
+        }
+
+        private async Task ProcessAudioSendAsync(CancellationToken ct)
+        {
+            try
+            {
+                await foreach (var audioData in _audioSendReader.ReadAllAsync(ct).ConfigureAwait(false))
+                {
+                    try { await _session.SendInputAudioAsync(audioData, ct).ConfigureAwait(false); }
+                    catch { }
+                }
+            }
+            catch (OperationCanceledException) { }
+        }
+
+        private async Task ProcessAudioPlaybackAsync()
+        {
+            try
+            {
+                var ct = CancellationTokenSource.CreateLinkedTokenSource(
+                    _playbackCancellationTokenSource.Token, _cancellationTokenSource.Token).Token;
+
+                await foreach (var audioData in _audioPlaybackReader.ReadAllAsync(ct).ConfigureAwait(false))
+                {
+                    if (_playbackBuffer != null && _isPlaying)
+                        _playbackBuffer.AddSamples(audioData, 0, audioData.Length);
+                }
+            }
+            catch (OperationCanceledException) { }
+        }
+
+        public void Dispose()
+        {
+            CleanupAsync().Wait();
+            _cancellationTokenSource.Dispose();
+        }
+    }
+}

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.csproj
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.AI.VoiceLive" Version="1.1.0-beta.3" />
+    <PackageReference Include="Azure.Identity" Version="1.17.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.10" />
+    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/csharp/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/README.md
@@ -55,15 +55,26 @@ The counter resets when results are fully delivered or the user denies a request
 
 ### Silence During Tool Calls Must Be Filled
 
-MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses three layers:
+MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses two complementary layers to keep the user informed throughout:
 
-1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
-2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers generates natural filler. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline). The transcription model is also selected per pipeline: `azure-speech` for non-realtime, `whisper-1` for realtime.
-3. **Stall detection** (client-side, repeating 15s timer): Notifies the user up to 3 times that results are still pending. Note: MCP calls **cannot be cancelled** via the API — the call runs until the MCP server responds or the server-side timeout fires.
+1. **Tool announcements** (immediate, client-side): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates. This covers the first few seconds.
+
+2. **Stall detection** (client-side, repeating timer): If a tool call runs longer than expected, the assistant proactively tells the user it's still waiting. This quickstart uses a **10-second interval with a maximum of 3 notifications** — tune these values based on your expected MCP server latency:
+   - **Fast servers (< 5s)**: Stall timer rarely fires. Consider increasing the interval or reducing max notifications.
+   - **Medium servers (5–15s)**: The default 10s/3-max works well. The first notification arrives before most users lose patience.
+   - **Slow servers (15–60s+)**: Consider shorter intervals (e.g. 8s) or more notifications (e.g. 5) to keep the user engaged. However, note that MCP calls **cannot be cancelled** — the notifications are status updates, not actionable options.
+
+Together, these two layers ensure continuous feedback: the announcement handles seconds 0–5, and the stall timer covers 10s+ with periodic reassurance.
+
+### Batched Response After Tool Completion
+
+When the model makes multiple MCP calls in a single turn (common with search-heavy servers), this quickstart waits for **all calls to complete** before generating a response. This prevents partial results from being spoken prematurely and avoids the model making additional tool calls based on incomplete data.
+
+For approval-required servers, once the user approves the first call, subsequent calls to the **same server within the same turn are auto-approved** — avoiding repeated voice prompts for what is logically a single task.
 
 ### Barge-In During MCP Calls
 
-Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message so the model can acknowledge the user and reassure them that results are on the way. Note: since MCP calls cannot be cancelled, the assistant cannot actually skip or abort a running tool call.
+Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message so the model can acknowledge the user and respond to what they said. If the original MCP call completes later, its result is introduced as a **late result** (e.g. *"By the way, those results from earlier just came in..."*). Note: since MCP calls cannot be cancelled, the call continues running in the background regardless of what the user says.
 
 ### Response Collision Handling
 

--- a/csharp/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/README.md
@@ -69,6 +69,16 @@ Users will naturally try to interrupt or ask *"Are you still there?"* during lon
 
 MCP flows generate rapid event sequences where `response.create` calls can collide with active responses. This quickstart defers collisions to the next `ResponseDone` event via a flag, ensuring tool results and approval prompts are never silently dropped.
 
+### MCP Server Selection: Latency Matters
+
+Not all MCP servers are well-suited for voice UX. Servers that respond quickly (< 5 seconds) provide a seamless experience, while slow servers (10–60+ seconds) create awkward silence even with stall notifications. When choosing MCP servers for a voice assistant:
+
+- **Prefer low-latency servers** — search APIs, simple lookups, and cached data sources work best
+- **Avoid servers that perform heavy computation** — large repo analysis, complex document retrieval, or multi-step workflows can take 30–60+ seconds, degrading the voice experience
+- **MCP calls cannot be cancelled** — once a call starts, it runs until the server responds or times out. There is no client-side or API-level cancellation mechanism
+- **Late results arrive out of context** — if the user moves on during a slow MCP call, the result arrives asynchronously and must be introduced as a late result, which can feel disjointed
+- **Consider whether async results are acceptable** for your use case. If users expect real-time answers, long-running MCP servers will frustrate them. If they expect a research-assistant style interaction where results trickle in, it may be acceptable
+
 ## Prerequisites
 
 - [AI Foundry resource](https://learn.microsoft.com/en-us/azure/ai-services/multi-service-resource)

--- a/csharp/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/README.md
@@ -109,7 +109,7 @@ dotnet run -- --use-token-credential
 
 | Say this | MCP Server | Approval | What happens |
 |---|---|---|---|
-| *"Can you summarize the GitHub repo azure-sdk-for-python?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
+| *"What is the GitHub repo fastapi about?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
 | *"Search the Azure documentation for Voice Live API"* | Azure Docs | Voice prompt (`always`) | Assistant asks *"Do you approve?"*, waits for your *yes* or *no* |
 
 ## Troubleshooting

--- a/csharp/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/README.md
@@ -12,7 +12,7 @@ Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-r
 - **Voice-Based Approval**: Instead of blocking on `Console.ReadLine()`, the assistant verbally asks *"Do you approve?"* and interprets the user's spoken *yes* or *no*
 - **Context-Aware Repeat Approvals**: When the model needs additional searches, the prompt changes to *"I need one more search. Should I continue?"*
 - **MCP Tool Announcements**: For auto-approved tools, the assistant says a brief acknowledgement while the call runs
-- **Barge-In Handling**: Interrupting during an MCP call triggers a *"Do you want to keep waiting or skip?"* inquiry
+- **Barge-In Handling**: Interrupting during an MCP call prompts the assistant to acknowledge and reassure the user
 - **MCP Stall Detection**: If a tool call takes >15 seconds, the assistant proactively tells the user it's still waiting
 
 ## Voice UX Considerations for MCP Integration
@@ -59,11 +59,11 @@ MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the a
 
 1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
 2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers generates natural filler. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline). The transcription model is also selected per pipeline: `azure-speech` for non-realtime, `whisper-1` for realtime.
-3. **Stall detection** (client-side, repeating 15s timer): Notifies the user every 15 seconds while an MCP call is running. After 30 seconds, offers the user a choice to keep waiting or move on.
+3. **Stall detection** (client-side, repeating 15s timer): Notifies the user up to 3 times that results are still pending. Note: MCP calls **cannot be cancelled** via the API — the call runs until the MCP server responds or the server-side timeout fires.
 
 ### Barge-In During MCP Calls
 
-Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message asking the model to check: *"Do you want to keep waiting or skip?"* The model handles the conversation naturally from there.
+Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message so the model can acknowledge the user and reassure them that results are on the way. Note: since MCP calls cannot be cancelled, the assistant cannot actually skip or abort a running tool call.
 
 ### Response Collision Handling
 

--- a/csharp/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/README.md
@@ -17,7 +17,13 @@ Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-r
 
 ## Voice UX Considerations for MCP Integration
 
-Integrating MCP servers into a voice assistant introduces unique UX challenges that don't exist in text-based or console-based MCP clients. This quickstart demonstrates patterns to address them. When building your own voice-enabled MCP application, consider the following:
+Integrating MCP servers into a voice assistant introduces unique UX challenges that don't exist in text-based or console-based MCP clients.
+
+MCP servers can be configured with different approval policies:
+- **`require_approval: "never"`** — tool calls proceed automatically (e.g., DeepWiki in this sample)
+- **`require_approval: "always"`** — every tool call requires explicit user consent before execution (e.g., Azure Docs in this sample)
+
+In a text-based client, approval is typically a simple `y/n` console prompt. In a voice UX, this needs to be handled conversationally — and several additional challenges arise around latency, silence, and repeated calls. This quickstart demonstrates patterns to address them:
 
 ### Tool Approval Must Be Voice-Native
 
@@ -39,19 +45,21 @@ The per-request system messages use `"Say exactly:"` phrasing to prevent the mod
 
 ### Repeated Tool Calls Need Contextual Messaging
 
-MCP servers like Azure Docs may require multiple searches to gather complete information. Each search triggers a separate approval if `RequireApproval = "always"`. Rather than asking the identical question each time, this quickstart tracks the call count per server:
+MCP servers may require multiple searches to gather complete information. Each search triggers a separate approval if `require_approval="always"`. Rather than asking the identical question each time, this quickstart tracks the call count per server:
 
 - **First call**: *"I'd like to search the azure_doc service. Do you approve?"*
 - **Subsequent calls**: *"I need one more search for complete information. Should I continue?"*
+- **After 3 approved calls**: Auto-denied to prevent infinite loops — the model responds with what it has
 
 The counter resets when results are fully delivered or the user denies a request.
 
 ### Silence During Tool Calls Must Be Filled
 
-MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses two layers:
+MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses three layers:
 
 1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
-2. **Stall detection** (client-side, 15s timer): If the MCP call takes >15 seconds, the assistant proactively says *"Still waiting for results..."*.
+2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers generates natural filler. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline). The transcription model is also selected per pipeline: `azure-speech` for non-realtime, `whisper-1` for realtime.
+3. **Stall detection** (client-side, repeating 15s timer): Notifies the user every 15 seconds while an MCP call is running. After 30 seconds, offers the user a choice to keep waiting or move on.
 
 ### Barge-In During MCP Calls
 

--- a/csharp/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/README.md
@@ -1,4 +1,4 @@
-# MCP Quickstart
+# C# – MCP Quickstart
 
 > **For common setup instructions, troubleshooting, and detailed information, see the [C# Samples README](../../README.md)**
 
@@ -118,13 +118,11 @@ Not all MCP servers are well-suited for voice UX. Servers that respond quickly (
 
 ## Command Line Options
 
-```powershell
-# Run with API key (from appsettings.json)
-dotnet run
+| Flag | Description |
+|---|---|
+| `--use-token-credential` | Use `DefaultAzureCredential` instead of API key |
 
-# Run with Azure authentication
-dotnet run -- --use-token-credential
-```
+All other settings are configured via `appsettings.json`.
 
 ## Sample Trigger Phrases
 
@@ -132,6 +130,15 @@ dotnet run -- --use-token-credential
 |---|---|---|---|
 | *"What is the GitHub repo fastapi about?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
 | *"Search the Azure documentation for Voice Live API"* | Azure Docs | Voice prompt (`always`) | Assistant asks *"Do you approve?"*, waits for your *yes* or *no* |
+
+## How It Works
+
+1. **MCP Server Definitions**: `VoiceLiveMcpServerDefinition` instances added to the session tools list
+2. **Session Configuration**: `Session.Update` with model, voice, VAD, and MCP tools
+3. **Tool Discovery**: Voice Live connects to each MCP server and discovers available tools
+4. **Tool Announcements**: Auto-approved tool calls trigger a brief spoken acknowledgement
+5. **Voice Approval**: For `require_approval="always"` servers, a system message is injected prompting the model to ask verbally. The user's spoken response is parsed for *yes*/*no* using word-boundary regex
+6. **Result Delivery**: After MCP call completion, `response.create` kicks the model to speak the results
 
 ## Troubleshooting
 

--- a/csharp/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/README.md
@@ -1,0 +1,83 @@
+# MCP Quickstart
+
+> **For common setup instructions, troubleshooting, and detailed information, see the [C# Samples README](../../README.md)**
+
+This sample demonstrates **MCP (Model Context Protocol) server integration** with Voice Live using the Azure AI Voice Live SDK for C#.
+
+Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-realtime`) — but additionally configures remote MCP servers as tools, enabling the assistant to call external services (DeepWiki, Azure Docs) during the conversation and prompting the user for approval when required.
+
+## What Makes This Sample Unique
+
+This sample showcases:
+
+- **MCP Server Integration**: Configure remote MCP servers using `VoiceLiveMcpServerDefinition` in the session tools list
+- **Approval Flow**: Interactive console-based approval for `RequireApproval = "always"` MCP tools
+- **MCP Event Handling**: Process MCP tool discovery, execution, and result events via `SessionUpdate` pattern matching
+- **Flexible Authentication**: Supports both API key and Azure credential authentication
+
+## Prerequisites
+
+- [AI Foundry resource](https://learn.microsoft.com/en-us/azure/ai-services/multi-service-resource)
+- API key or [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) for authentication
+- See [C# Samples README](../../README.md) for common prerequisites
+
+## Quick Start
+
+1. **Update `appsettings.json`**:
+   ```json
+   {
+     "VoiceLive": {
+       "ApiKey": "your-voicelive-api-key",
+       "Endpoint": "https://your-endpoint.services.ai.azure.com/",
+       "Model": "gpt-realtime",
+       "Voice": "en-US-Ava:DragonHDLatestNeural"
+     }
+   }
+   ```
+
+2. **Run the sample**:
+   ```powershell
+   dotnet build
+   dotnet run
+   ```
+
+## Command Line Options
+
+```powershell
+# Run with API key (from appsettings.json)
+dotnet run
+
+# Run with Azure authentication
+dotnet run -- --use-token-credential
+```
+
+### Available Options
+
+- `--use-token-credential`: Use Azure authentication instead of API key
+
+Configuration is managed via `appsettings.json` or environment variables (`AZURE_VOICELIVE_API_KEY`, `AZURE_VOICELIVE_ENDPOINT`, `AZURE_VOICELIVE_MODEL`, `AZURE_VOICELIVE_VOICE`).
+
+### Available Models
+
+- `gpt-realtime` - Latest GPT-realtime model (recommended)
+- See documentation for all available models
+
+## How It Works
+
+The sample extends the Model Quickstart pattern with MCP:
+
+1. **MCP Server Definitions**: Adds `VoiceLiveMcpServerDefinition` instances to `VoiceLiveSessionOptions.Tools`
+2. **Session Configuration**: Sends session config with model, voice, VAD, and MCP tools via `ConfigureSessionAsync`
+3. **Tool Discovery**: Voice Live connects to each MCP server and discovers available tools (`SessionUpdateMcpListToolsCompleted`)
+4. **Tool Execution**: When the model decides to call an MCP tool, the service executes the call (`SessionUpdateResponseMcpCallInProgress` / `SessionUpdateResponseMcpCallCompleted`)
+5. **Approval Flow**: For servers with `RequireApproval = "always"`, a `SessionResponseMcpApprovalRequestItem` is received and the user is prompted in the console
+6. **Approval Response**: The approval/denial is sent back via `SendCommandAsync` with raw JSON
+
+See [C# Samples README](../../README.md) for available voices, troubleshooting, and additional resources.
+
+## Additional Resources
+
+- [Voice Live Documentation](https://learn.microsoft.com/azure/ai-services/speech-service/voice-live)
+- [.NET SDK Documentation](https://learn.microsoft.com/dotnet/api/overview/azure/ai.voicelive-readme)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [Support Guide](../../../SUPPORT.md)

--- a/csharp/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/README.md
@@ -4,16 +4,62 @@
 
 This sample demonstrates **MCP (Model Context Protocol) server integration** with Voice Live using the Azure AI Voice Live SDK for C#.
 
-Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-realtime`) — but additionally configures remote MCP servers as tools, enabling the assistant to call external services (DeepWiki, Azure Docs) during the conversation and prompting the user for approval when required.
+Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-realtime`) — but additionally configures remote MCP servers as tools, enabling the assistant to call external services (DeepWiki, Azure Docs) during the conversation. It implements a **voice-based approval flow** where the assistant verbally asks the user for permission before using tools that require consent.
 
 ## What Makes This Sample Unique
 
-This sample showcases:
-
 - **MCP Server Integration**: Configure remote MCP servers using `VoiceLiveMcpServerDefinition` in the session tools list
-- **Approval Flow**: Interactive console-based approval for `RequireApproval = "always"` MCP tools
-- **MCP Event Handling**: Process MCP tool discovery, execution, and result events via `SessionUpdate` pattern matching
-- **Flexible Authentication**: Supports both API key and Azure credential authentication
+- **Voice-Based Approval**: Instead of blocking on `Console.ReadLine()`, the assistant verbally asks *"Do you approve?"* and interprets the user's spoken *yes* or *no*
+- **Context-Aware Repeat Approvals**: When the model needs additional searches, the prompt changes to *"I need one more search. Should I continue?"*
+- **MCP Tool Announcements**: For auto-approved tools, the assistant says a brief acknowledgement while the call runs
+- **Barge-In Handling**: Interrupting during an MCP call triggers a *"Do you want to keep waiting or skip?"* inquiry
+- **MCP Stall Detection**: If a tool call takes >15 seconds, the assistant proactively tells the user it's still waiting
+
+## Voice UX Considerations for MCP Integration
+
+Integrating MCP servers into a voice assistant introduces unique UX challenges that don't exist in text-based or console-based MCP clients. This quickstart demonstrates patterns to address them. When building your own voice-enabled MCP application, consider the following:
+
+### Tool Approval Must Be Voice-Native
+
+Console-based MCP samples typically use blocking `Console.ReadLine()` for approval — fine for a terminal demo, but it freezes the audio pipeline and breaks the voice experience. In a voice UX, approvals should be handled conversationally:
+
+- Inject a system message instructing the model to **verbally ask for permission**
+- Parse the user's spoken response for clear intent (`yes`, `no`, `stop`, `cancel`)
+- Allow **barge-in** — the user should be able to say "yes" without waiting for the full approval prompt to finish
+
+This quickstart uses word-boundary regex (`\byes\b`, `\b(no|stop|cancel)\b`) to avoid false positives from words like "yesterday" or "nobody".
+
+### System Instructions Must Teach the Model About Approval
+
+The model needs explicit instructions about the approval flow. Without them, it may paraphrase the permission request into a generic *"Let me look that up"* — skipping the actual question. This quickstart includes in the system prompt:
+
+> *"Some tools require user approval. When you receive a system message asking you to request permission, you MUST clearly ask the user for their explicit approval. Never skip the approval question or assume permission is granted."*
+
+The per-request system messages use `"Say exactly:"` phrasing to prevent the model from rewording the question.
+
+### Repeated Tool Calls Need Contextual Messaging
+
+MCP servers like Azure Docs may require multiple searches to gather complete information. Each search triggers a separate approval if `RequireApproval = "always"`. Rather than asking the identical question each time, this quickstart tracks the call count per server:
+
+- **First call**: *"I'd like to search the azure_doc service. Do you approve?"*
+- **Subsequent calls**: *"I need one more search for complete information. Should I continue?"*
+
+The counter resets when results are fully delivered or the user denies a request.
+
+### Silence During Tool Calls Must Be Filled
+
+MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses two layers:
+
+1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
+2. **Stall detection** (client-side, 15s timer): If the MCP call takes >15 seconds, the assistant proactively says *"Still waiting for results..."*.
+
+### Barge-In During MCP Calls
+
+Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message asking the model to check: *"Do you want to keep waiting or skip?"* The model handles the conversation naturally from there.
+
+### Response Collision Handling
+
+MCP flows generate rapid event sequences where `response.create` calls can collide with active responses. This quickstart defers collisions to the next `ResponseDone` event via a flag, ensuring tool results and approval prompts are never silently dropped.
 
 ## Prerequisites
 
@@ -51,27 +97,22 @@ dotnet run
 dotnet run -- --use-token-credential
 ```
 
-### Available Options
+## Sample Trigger Phrases
 
-- `--use-token-credential`: Use Azure authentication instead of API key
+| Say this | MCP Server | Approval | What happens |
+|---|---|---|---|
+| *"Can you summarize the GitHub repo azure-sdk-for-python?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
+| *"Search the Azure documentation for Voice Live API"* | Azure Docs | Voice prompt (`always`) | Assistant asks *"Do you approve?"*, waits for your *yes* or *no* |
 
-Configuration is managed via `appsettings.json` or environment variables (`AZURE_VOICELIVE_API_KEY`, `AZURE_VOICELIVE_ENDPOINT`, `AZURE_VOICELIVE_MODEL`, `AZURE_VOICELIVE_VOICE`).
+## Troubleshooting
 
-### Available Models
-
-- `gpt-realtime` - Latest GPT-realtime model (recommended)
-- See documentation for all available models
-
-## How It Works
-
-The sample extends the Model Quickstart pattern with MCP:
-
-1. **MCP Server Definitions**: Adds `VoiceLiveMcpServerDefinition` instances to `VoiceLiveSessionOptions.Tools`
-2. **Session Configuration**: Sends session config with model, voice, VAD, and MCP tools via `ConfigureSessionAsync`
-3. **Tool Discovery**: Voice Live connects to each MCP server and discovers available tools (`SessionUpdateMcpListToolsCompleted`)
-4. **Tool Execution**: When the model decides to call an MCP tool, the service executes the call (`SessionUpdateResponseMcpCallInProgress` / `SessionUpdateResponseMcpCallCompleted`)
-5. **Approval Flow**: For servers with `RequireApproval = "always"`, a `SessionResponseMcpApprovalRequestItem` is received and the user is prompted in the console
-6. **Approval Response**: The approval/denial is sent back via `SendCommandAsync` with raw JSON
+| Symptom | Resolution |
+|---|---|
+| Audio system check failed | Verify microphone and speakers are connected and configured. |
+| Missing endpoint/authentication error | Update `appsettings.json` or set environment variables. |
+| MCP tool discovery failed | Check that MCP server URLs are reachable from your network. |
+| Repeated approval prompts | Expected — the model may need multiple searches. Say *"no"* or *"stop"* to deny. |
+| Session hit maximum duration | VoiceLive sessions have a 30-minute limit. Restart the sample. |
 
 See [C# Samples README](../../README.md) for available voices, troubleshooting, and additional resources.
 

--- a/csharp/voice-live-quickstarts/MCPQuickstart/appsettings_sample.json
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/appsettings_sample.json
@@ -1,0 +1,9 @@
+{
+  "VoiceLive": {
+    "ApiKey": "your-voicelive-api-key",
+    "Endpoint": "https://your-endpoint.services.ai.azure.com/",
+    "Model": "gpt-realtime",
+    "Voice": "en-US-Ava:DragonHDLatestNeural",
+    "Instructions": "You are a helpful AI assistant with access to MCP tools. Use the tools to help answer user questions. Respond naturally and conversationally."
+  }
+}

--- a/java/README.md
+++ b/java/README.md
@@ -17,6 +17,17 @@ Demonstrates the new Voice Live + Foundry Agent flow, including creating an agen
 - Proactive greeting and barge-in handling
 - Conversation logging
 
+### [MCP Quickstart](./voice-live-quickstarts/MCPQuickstart/)
+
+Demonstrates MCP (Model Context Protocol) server integration with VoiceLive, enabling the assistant to use remote tools (DeepWiki, Azure Docs) during voice conversations.
+
+**Key Features:**
+
+- MCP server definitions using `MCPServer`
+- MCP tool discovery, execution, and failure event handling
+- Interactive console-based approval flow for sensitive tools
+- Flexible authentication (API key or Azure credentials)
+
 ### [Model Quickstart](./voice-live-quickstarts/ModelQuickstart/)
 
 Demonstrates direct integration with VoiceLive models for voice conversations without agent overhead.

--- a/java/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/java/voice-live-quickstarts/MCPQuickstart/README.md
@@ -12,7 +12,7 @@ Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-r
 - **Voice-Based Approval**: Instead of blocking on `Scanner` input, the assistant verbally asks *"Do you approve?"* and interprets the user's spoken *yes* or *no*
 - **Context-Aware Repeat Approvals**: When the model needs additional searches, the prompt changes to *"I need one more search. Should I continue?"*
 - **MCP Tool Announcements**: For auto-approved tools, the assistant says a brief acknowledgement while the call runs
-- **Barge-In Handling**: Interrupting during an MCP call triggers a *"Do you want to keep waiting or skip?"* inquiry
+- **Barge-In Handling**: Interrupting during an MCP call prompts the assistant to acknowledge and reassure the user
 - **MCP Stall Detection**: If a tool call takes >15 seconds, the assistant proactively tells the user it's still waiting
 
 ## Voice UX Considerations for MCP Integration
@@ -59,11 +59,11 @@ MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the a
 
 1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
 2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers generates natural filler. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline). The transcription model is also selected per pipeline: `azure-speech` for non-realtime, `whisper-1` for realtime.
-3. **Stall detection** (client-side, repeating 15s timer): Notifies the user every 15 seconds while an MCP call is running. After 30 seconds, offers the user a choice to keep waiting or move on.
+3. **Stall detection** (client-side, repeating 15s timer): Notifies the user up to 3 times that results are still pending. Note: MCP calls **cannot be cancelled** via the API — the call runs until the MCP server responds or the server-side timeout fires.
 
 ### Barge-In During MCP Calls
 
-Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message asking the model to check: *"Do you want to keep waiting or skip?"* The model handles the conversation naturally from there.
+Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message so the model can acknowledge the user and reassure them that results are on the way. Note: since MCP calls cannot be cancelled, the assistant cannot actually skip or abort a running tool call.
 
 ### Response Collision Handling
 

--- a/java/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/java/voice-live-quickstarts/MCPQuickstart/README.md
@@ -55,15 +55,26 @@ The counter resets when results are fully delivered or the user denies a request
 
 ### Silence During Tool Calls Must Be Filled
 
-MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses three layers:
+MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses two complementary layers to keep the user informed throughout:
 
-1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
-2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers generates natural filler. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline). The transcription model is also selected per pipeline: `azure-speech` for non-realtime, `whisper-1` for realtime.
-3. **Stall detection** (client-side, repeating 15s timer): Notifies the user up to 3 times that results are still pending. Note: MCP calls **cannot be cancelled** via the API — the call runs until the MCP server responds or the server-side timeout fires.
+1. **Tool announcements** (immediate, client-side): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates. This covers the first few seconds.
+
+2. **Stall detection** (client-side, repeating timer): If a tool call runs longer than expected, the assistant proactively tells the user it's still waiting. This quickstart uses a **10-second interval with a maximum of 3 notifications** — tune these values based on your expected MCP server latency:
+   - **Fast servers (< 5s)**: Stall timer rarely fires. Consider increasing the interval or reducing max notifications.
+   - **Medium servers (5–15s)**: The default 10s/3-max works well. The first notification arrives before most users lose patience.
+   - **Slow servers (15–60s+)**: Consider shorter intervals (e.g. 8s) or more notifications (e.g. 5) to keep the user engaged. However, note that MCP calls **cannot be cancelled** — the notifications are status updates, not actionable options.
+
+Together, these two layers ensure continuous feedback: the announcement handles seconds 0–5, and the stall timer covers 10s+ with periodic reassurance.
+
+### Batched Response After Tool Completion
+
+When the model makes multiple MCP calls in a single turn (common with search-heavy servers), this quickstart waits for **all calls to complete** before generating a response. This prevents partial results from being spoken prematurely and avoids the model making additional tool calls based on incomplete data.
+
+For approval-required servers, once the user approves the first call, subsequent calls to the **same server within the same turn are auto-approved** — avoiding repeated voice prompts for what is logically a single task.
 
 ### Barge-In During MCP Calls
 
-Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message so the model can acknowledge the user and reassure them that results are on the way. Note: since MCP calls cannot be cancelled, the assistant cannot actually skip or abort a running tool call.
+Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message so the model can acknowledge the user and respond to what they said. If the original MCP call completes later, its result is introduced as a **late result** (e.g. *"By the way, those results from earlier just came in..."*). Note: since MCP calls cannot be cancelled, the call continues running in the background regardless of what the user says.
 
 ### Response Collision Handling
 

--- a/java/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/java/voice-live-quickstarts/MCPQuickstart/README.md
@@ -1,0 +1,159 @@
+# MCP Quickstart
+
+> **For common setup instructions, troubleshooting, and detailed information, see the [Java Samples README](../../README.md)**
+
+This sample demonstrates **MCP (Model Context Protocol) server integration** with Voice Live using the Azure AI Voice Live SDK for Java.
+
+Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-realtime`) — but additionally configures remote MCP servers as tools, enabling the assistant to call external services (DeepWiki, Azure Docs) during the conversation and prompting the user for approval when required.
+
+## What Makes This Sample Unique
+
+This sample showcases:
+
+- **MCP Server Integration**: Configure remote MCP servers using `MCPServer` in the session tools list
+- **Approval Flow**: Interactive console-based approval for `require_approval: "always"` MCP tools
+- **MCP Event Handling**: Process MCP tool discovery, execution, and result events via `ServerEventType` values
+- **Flexible Authentication**: Supports both API key and Azure credential authentication
+- **Audio Processing**: Real-time microphone capture and speaker playback
+- **Voice Activity Detection**: Interrupt handling and turn detection
+
+## Prerequisites
+
+- [Java 11](https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html) or later
+- [Maven 3.6+](https://maven.apache.org/download.cgi)
+- [AI Foundry resource](https://learn.microsoft.com/azure/ai-services/multi-service-resource)
+- API key or [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) for authentication
+- Audio input/output devices (microphone and speakers)
+- See [Java Samples README](../../README.md) for common prerequisites
+
+## Quick Start
+
+1. **Update `application.properties`**:
+
+   Copy `application.properties.sample` to `application.properties` and fill in your values:
+
+   ```properties
+   # Required: Your VoiceLive endpoint URL
+   azure.voicelive.endpoint=https://your-endpoint.services.ai.azure.com/
+
+   # Required: Your API key (if using API key authentication)
+   azure.voicelive.api-key=your-api-key-here
+
+   # Optional: Model name (default: gpt-realtime)
+   # azure.voicelive.model=gpt-realtime
+
+   # Optional: Voice name (default: en-US-Ava:DragonHDLatestNeural)
+   # azure.voicelive.voice=en-US-Ava:DragonHDLatestNeural
+   ```
+
+2. **Build the project**:
+
+   ```bash
+   mvn clean install
+   ```
+
+3. **Run the sample**:
+
+   ```bash
+   # Run with API key (from application.properties)
+   mvn exec:java
+
+   # Run with Azure authentication
+   mvn exec:java -Dexec.args="--use-token-credential"
+   ```
+
+## Command Line Options
+
+```bash
+# Run with API key (from application.properties)
+mvn exec:java
+
+# Run with Azure authentication
+mvn exec:java -Dexec.args="--use-token-credential"
+
+# Run with custom model
+mvn exec:java -Dexec.args="--model gpt-realtime"
+
+# Run with custom voice
+mvn exec:java -Dexec.args="--voice en-US-Jenny:DragonHDLatestNeural"
+```
+
+### Available Options
+
+- `--api-key`: Azure VoiceLive API key (overrides application.properties)
+- `--endpoint`: Azure VoiceLive endpoint URL (overrides application.properties)
+- `--model`: VoiceLive model to use (default: "gpt-realtime")
+- `--voice`: Voice for the assistant (default: "en-US-Ava:DragonHDLatestNeural")
+- `--use-token-credential`: Use Azure authentication instead of API key
+
+### Available Models
+
+- `gpt-realtime` - Latest GPT-realtime model (recommended)
+- See documentation for all available models
+
+## How It Works
+
+The sample extends the Model Quickstart pattern with MCP:
+
+1. **MCP Server Definitions**: Adds `MCPServer` instances to `VoiceLiveSessionOptions` tools list via `defineMCPServers()`
+2. **Session Configuration**: Sends session config with model, voice, VAD, and MCP tools via `session.sendEvent()`
+3. **Tool Discovery**: Voice Live connects to each MCP server and discovers available tools (`MCP_LIST_TOOLS_COMPLETED`)
+4. **Tool Execution**: When the model decides to call an MCP tool, the service executes the call (`RESPONSE_MCP_CALL_IN_PROGRESS` / `RESPONSE_MCP_CALL_COMPLETED`)
+5. **Approval Flow**: For servers with `require_approval: "always"`, a `mcp_approval_request` conversation item is received and the user is prompted in the console
+6. **Approval Response**: The approval/denial is sent back via `session.sendEvent()` with `mcp_approval_response` JSON, followed by `response.create`
+
+## Troubleshooting
+
+### Common Issues
+
+**Microphone not found**:
+
+- Ensure your microphone is connected and properly configured
+- Check system audio settings and permissions
+- Try running the sample with administrator privileges
+
+**Authentication errors**:
+
+- Verify your API key or Azure credentials are correct
+- Ensure your endpoint URL is properly formatted
+- Check that your Azure subscription is active
+
+**MCP tool discovery failed**:
+
+- Check that MCP server URLs are reachable from your network
+- Verify firewall and proxy settings allow outbound HTTPS
+
+**Approval prompt not appearing**:
+
+- Only servers with `require_approval: "always"` trigger the prompt
+- The `deepwiki` server is configured with `"never"`, so calls proceed automatically
+
+For more troubleshooting guidance, see the [Java Samples README](../../README.md).
+
+## Additional Resources
+
+- [Azure AI Speech - Voice Live Documentation](https://learn.microsoft.com/azure/ai-services/speech-service/voice-live)
+- [VoiceLive SDK Documentation](https://learn.microsoft.com/java/api/overview/azure/ai-voicelive-readme)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [Support Guide](../../../SUPPORT.md)
+
+## Code Structure
+
+```text
+MCPQuickstart/
+├── src/main/java/MCPQuickstart.java  # Main application with all logic
+├── pom.xml                           # Maven project configuration
+├── application.properties            # Your configuration (create from sample)
+└── README.md                         # This file
+```
+
+## Next Steps
+
+- Explore the [Model Quickstart](../ModelQuickstart/) for the base pattern without MCP
+- Explore the [Agents New Quickstart](../AgentsNewQuickstart/) for agent-based conversations
+- Customize MCP server definitions for your own remote tools
+- Adjust approval policies per server based on trust level
+
+## Contributing
+
+Interested in contributing? Please see our [Contributing Guidelines](../../../SUPPORT.md#contributing).

--- a/java/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/java/voice-live-quickstarts/MCPQuickstart/README.md
@@ -109,7 +109,7 @@ MCP flows generate rapid event sequences where `response.create` calls can colli
 
 | Say this | MCP Server | Approval | What happens |
 |---|---|---|---|
-| *"Can you summarize the GitHub repo azure-sdk-for-python?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
+| *"What is the GitHub repo fastapi about?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
 | *"Search the Azure documentation for Voice Live API"* | Azure Docs | Voice prompt (`always`) | Assistant asks *"Do you approve?"*, waits for your *yes* or *no* |
 
 ## Troubleshooting

--- a/java/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/java/voice-live-quickstarts/MCPQuickstart/README.md
@@ -4,18 +4,62 @@
 
 This sample demonstrates **MCP (Model Context Protocol) server integration** with Voice Live using the Azure AI Voice Live SDK for Java.
 
-Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-realtime`) — but additionally configures remote MCP servers as tools, enabling the assistant to call external services (DeepWiki, Azure Docs) during the conversation and prompting the user for approval when required.
+Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-realtime`) — but additionally configures remote MCP servers as tools, enabling the assistant to call external services (DeepWiki, Azure Docs) during the conversation. It implements a **voice-based approval flow** where the assistant verbally asks the user for permission before using tools that require consent.
 
 ## What Makes This Sample Unique
 
-This sample showcases:
-
 - **MCP Server Integration**: Configure remote MCP servers using `MCPServer` in the session tools list
-- **Approval Flow**: Interactive console-based approval for `require_approval: "always"` MCP tools
-- **MCP Event Handling**: Process MCP tool discovery, execution, and result events via `ServerEventType` values
-- **Flexible Authentication**: Supports both API key and Azure credential authentication
-- **Audio Processing**: Real-time microphone capture and speaker playback
-- **Voice Activity Detection**: Interrupt handling and turn detection
+- **Voice-Based Approval**: Instead of blocking on `Scanner` input, the assistant verbally asks *"Do you approve?"* and interprets the user's spoken *yes* or *no*
+- **Context-Aware Repeat Approvals**: When the model needs additional searches, the prompt changes to *"I need one more search. Should I continue?"*
+- **MCP Tool Announcements**: For auto-approved tools, the assistant says a brief acknowledgement while the call runs
+- **Barge-In Handling**: Interrupting during an MCP call triggers a *"Do you want to keep waiting or skip?"* inquiry
+- **MCP Stall Detection**: If a tool call takes >15 seconds, the assistant proactively tells the user it's still waiting
+
+## Voice UX Considerations for MCP Integration
+
+Integrating MCP servers into a voice assistant introduces unique UX challenges that don't exist in text-based or console-based MCP clients. This quickstart demonstrates patterns to address them. When building your own voice-enabled MCP application, consider the following:
+
+### Tool Approval Must Be Voice-Native
+
+Console-based MCP samples typically use blocking `Scanner.nextLine()` for approval — fine for a terminal demo, but it freezes the audio pipeline and breaks the voice experience. In a voice UX, approvals should be handled conversationally:
+
+- Inject a system message instructing the model to **verbally ask for permission**
+- Parse the user's spoken response for clear intent (`yes`, `no`, `stop`, `cancel`)
+- Allow **barge-in** — the user should be able to say "yes" without waiting for the full approval prompt to finish
+
+This quickstart uses word-boundary regex (`\byes\b`, `\b(no|stop|cancel)\b`) to avoid false positives from words like "yesterday" or "nobody".
+
+### System Instructions Must Teach the Model About Approval
+
+The model needs explicit instructions about the approval flow. Without them, it may paraphrase the permission request into a generic *"Let me look that up"* — skipping the actual question. This quickstart includes in the system prompt:
+
+> *"Some tools require user approval. When you receive a system message asking you to request permission, you MUST clearly ask the user for their explicit approval. Never skip the approval question or assume permission is granted."*
+
+The per-request system messages use `"Say exactly:"` phrasing to prevent the model from rewording the question.
+
+### Repeated Tool Calls Need Contextual Messaging
+
+MCP servers like Azure Docs may require multiple searches to gather complete information. Each search triggers a separate approval if `require_approval: "always"`. Rather than asking the identical question each time, this quickstart tracks the call count per server:
+
+- **First call**: *"I'd like to search the azure_doc service. Do you approve?"*
+- **Subsequent calls**: *"I need one more search for complete information. Should I continue?"*
+
+The counter resets when results are fully delivered or the user denies a request.
+
+### Silence During Tool Calls Must Be Filled
+
+MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses two layers:
+
+1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
+2. **Stall detection** (client-side, 15s timer): If the MCP call takes >15 seconds, the assistant proactively says *"Still waiting for results..."*.
+
+### Barge-In During MCP Calls
+
+Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message asking the model to check: *"Do you want to keep waiting or skip?"* The model handles the conversation naturally from there.
+
+### Response Collision Handling
+
+MCP flows generate rapid event sequences where `response.create` calls can collide with active responses. This quickstart defers collisions to the next `RESPONSE_DONE` event via a flag, ensuring tool results and approval prompts are never silently dropped.
 
 ## Prerequisites
 
@@ -28,105 +72,48 @@ This sample showcases:
 
 ## Quick Start
 
-1. **Update `application.properties`**:
-
-   Copy `application.properties.sample` to `application.properties` and fill in your values:
+1. **Configure credentials** via environment variables or `application.properties`:
 
    ```properties
-   # Required: Your VoiceLive endpoint URL
    azure.voicelive.endpoint=https://your-endpoint.services.ai.azure.com/
-
-   # Required: Your API key (if using API key authentication)
    azure.voicelive.api-key=your-api-key-here
-
-   # Optional: Model name (default: gpt-realtime)
-   # azure.voicelive.model=gpt-realtime
-
-   # Optional: Voice name (default: en-US-Ava:DragonHDLatestNeural)
-   # azure.voicelive.voice=en-US-Ava:DragonHDLatestNeural
    ```
 
-2. **Build the project**:
+2. **Build and run**:
 
    ```bash
    mvn clean install
-   ```
-
-3. **Run the sample**:
-
-   ```bash
-   # Run with API key (from application.properties)
    mvn exec:java
 
-   # Run with Azure authentication
+   # Or with Azure authentication
    mvn exec:java -Dexec.args="--use-token-credential"
    ```
 
 ## Command Line Options
 
-```bash
-# Run with API key (from application.properties)
-mvn exec:java
-
-# Run with Azure authentication
-mvn exec:java -Dexec.args="--use-token-credential"
-
-# Run with custom model
-mvn exec:java -Dexec.args="--model gpt-realtime"
-
-# Run with custom voice
-mvn exec:java -Dexec.args="--voice en-US-Jenny:DragonHDLatestNeural"
-```
-
-### Available Options
-
 - `--api-key`: Azure VoiceLive API key (overrides application.properties)
 - `--endpoint`: Azure VoiceLive endpoint URL (overrides application.properties)
-- `--model`: VoiceLive model to use (default: "gpt-realtime")
-- `--voice`: Voice for the assistant (default: "en-US-Ava:DragonHDLatestNeural")
+- `--model`: VoiceLive model to use (default: `gpt-realtime`)
+- `--voice`: Voice for the assistant (default: `en-US-Ava:DragonHDLatestNeural`)
 - `--use-token-credential`: Use Azure authentication instead of API key
 
-### Available Models
+## Sample Trigger Phrases
 
-- `gpt-realtime` - Latest GPT-realtime model (recommended)
-- See documentation for all available models
-
-## How It Works
-
-The sample extends the Model Quickstart pattern with MCP:
-
-1. **MCP Server Definitions**: Adds `MCPServer` instances to `VoiceLiveSessionOptions` tools list via `defineMCPServers()`
-2. **Session Configuration**: Sends session config with model, voice, VAD, and MCP tools via `session.sendEvent()`
-3. **Tool Discovery**: Voice Live connects to each MCP server and discovers available tools (`MCP_LIST_TOOLS_COMPLETED`)
-4. **Tool Execution**: When the model decides to call an MCP tool, the service executes the call (`RESPONSE_MCP_CALL_IN_PROGRESS` / `RESPONSE_MCP_CALL_COMPLETED`)
-5. **Approval Flow**: For servers with `require_approval: "always"`, a `mcp_approval_request` conversation item is received and the user is prompted in the console
-6. **Approval Response**: The approval/denial is sent back via `session.sendEvent()` with `mcp_approval_response` JSON, followed by `response.create`
+| Say this | MCP Server | Approval | What happens |
+|---|---|---|---|
+| *"Can you summarize the GitHub repo azure-sdk-for-python?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
+| *"Search the Azure documentation for Voice Live API"* | Azure Docs | Voice prompt (`always`) | Assistant asks *"Do you approve?"*, waits for your *yes* or *no* |
 
 ## Troubleshooting
 
-### Common Issues
-
-**Microphone not found**:
-
-- Ensure your microphone is connected and properly configured
-- Check system audio settings and permissions
-- Try running the sample with administrator privileges
-
-**Authentication errors**:
-
-- Verify your API key or Azure credentials are correct
-- Ensure your endpoint URL is properly formatted
-- Check that your Azure subscription is active
-
-**MCP tool discovery failed**:
-
-- Check that MCP server URLs are reachable from your network
-- Verify firewall and proxy settings allow outbound HTTPS
-
-**Approval prompt not appearing**:
-
-- Only servers with `require_approval: "always"` trigger the prompt
-- The `deepwiki` server is configured with `"never"`, so calls proceed automatically
+| Symptom | Resolution |
+|---|---|
+| `❌ No compatible microphone found` | Verify microphone is connected and available to Java audio. |
+| Missing endpoint/authentication error | Set environment variables or update `application.properties`. |
+| MCP tool discovery failed | Check that MCP server URLs are reachable from your network. |
+| Repeated approval prompts | Expected — the model may need multiple searches. Say *"no"* or *"stop"* to deny. |
+| Session hit maximum duration | VoiceLive sessions have a 30-minute limit. Restart the sample. |
+| Maven build failures | Ensure Java 11+ and Maven 3.6+ are installed. |
 
 For more troubleshooting guidance, see the [Java Samples README](../../README.md).
 
@@ -136,24 +123,3 @@ For more troubleshooting guidance, see the [Java Samples README](../../README.md
 - [VoiceLive SDK Documentation](https://learn.microsoft.com/java/api/overview/azure/ai-voicelive-readme)
 - [Model Context Protocol](https://modelcontextprotocol.io/)
 - [Support Guide](../../../SUPPORT.md)
-
-## Code Structure
-
-```text
-MCPQuickstart/
-├── src/main/java/MCPQuickstart.java  # Main application with all logic
-├── pom.xml                           # Maven project configuration
-├── application.properties            # Your configuration (create from sample)
-└── README.md                         # This file
-```
-
-## Next Steps
-
-- Explore the [Model Quickstart](../ModelQuickstart/) for the base pattern without MCP
-- Explore the [Agents New Quickstart](../AgentsNewQuickstart/) for agent-based conversations
-- Customize MCP server definitions for your own remote tools
-- Adjust approval policies per server based on trust level
-
-## Contributing
-
-Interested in contributing? Please see our [Contributing Guidelines](../../../SUPPORT.md#contributing).

--- a/java/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/java/voice-live-quickstarts/MCPQuickstart/README.md
@@ -69,6 +69,16 @@ Users will naturally try to interrupt or ask *"Are you still there?"* during lon
 
 MCP flows generate rapid event sequences where `response.create` calls can collide with active responses. This quickstart defers collisions to the next `RESPONSE_DONE` event via a flag, ensuring tool results and approval prompts are never silently dropped.
 
+### MCP Server Selection: Latency Matters
+
+Not all MCP servers are well-suited for voice UX. Servers that respond quickly (< 5 seconds) provide a seamless experience, while slow servers (10–60+ seconds) create awkward silence even with stall notifications. When choosing MCP servers for a voice assistant:
+
+- **Prefer low-latency servers** — search APIs, simple lookups, and cached data sources work best
+- **Avoid servers that perform heavy computation** — large repo analysis, complex document retrieval, or multi-step workflows can take 30–60+ seconds, degrading the voice experience
+- **MCP calls cannot be cancelled** — once a call starts, it runs until the server responds or times out. There is no client-side or API-level cancellation mechanism
+- **Late results arrive out of context** — if the user moves on during a slow MCP call, the result arrives asynchronously and must be introduced as a late result, which can feel disjointed
+- **Consider whether async results are acceptable** for your use case. If users expect real-time answers, long-running MCP servers will frustrate them. If they expect a research-assistant style interaction where results trickle in, it may be acceptable
+
 ## Prerequisites
 
 - [Java 11](https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html) or later

--- a/java/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/java/voice-live-quickstarts/MCPQuickstart/README.md
@@ -17,7 +17,13 @@ Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-r
 
 ## Voice UX Considerations for MCP Integration
 
-Integrating MCP servers into a voice assistant introduces unique UX challenges that don't exist in text-based or console-based MCP clients. This quickstart demonstrates patterns to address them. When building your own voice-enabled MCP application, consider the following:
+Integrating MCP servers into a voice assistant introduces unique UX challenges that don't exist in text-based or console-based MCP clients.
+
+MCP servers can be configured with different approval policies:
+- **`require_approval: "never"`** — tool calls proceed automatically (e.g., DeepWiki in this sample)
+- **`require_approval: "always"`** — every tool call requires explicit user consent before execution (e.g., Azure Docs in this sample)
+
+In a text-based client, approval is typically a simple `y/n` console prompt. In a voice UX, this needs to be handled conversationally — and several additional challenges arise around latency, silence, and repeated calls. This quickstart demonstrates patterns to address them:
 
 ### Tool Approval Must Be Voice-Native
 
@@ -39,19 +45,21 @@ The per-request system messages use `"Say exactly:"` phrasing to prevent the mod
 
 ### Repeated Tool Calls Need Contextual Messaging
 
-MCP servers like Azure Docs may require multiple searches to gather complete information. Each search triggers a separate approval if `require_approval: "always"`. Rather than asking the identical question each time, this quickstart tracks the call count per server:
+MCP servers may require multiple searches to gather complete information. Each search triggers a separate approval if `require_approval="always"`. Rather than asking the identical question each time, this quickstart tracks the call count per server:
 
 - **First call**: *"I'd like to search the azure_doc service. Do you approve?"*
 - **Subsequent calls**: *"I need one more search for complete information. Should I continue?"*
+- **After 3 approved calls**: Auto-denied to prevent infinite loops — the model responds with what it has
 
 The counter resets when results are fully delivered or the user denies a request.
 
 ### Silence During Tool Calls Must Be Filled
 
-MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses two layers:
+MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses three layers:
 
 1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
-2. **Stall detection** (client-side, 15s timer): If the MCP call takes >15 seconds, the assistant proactively says *"Still waiting for results..."*.
+2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers generates natural filler. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline). The transcription model is also selected per pipeline: `azure-speech` for non-realtime, `whisper-1` for realtime.
+3. **Stall detection** (client-side, repeating 15s timer): Notifies the user every 15 seconds while an MCP call is running. After 30 seconds, offers the user a choice to keep waiting or move on.
 
 ### Barge-In During MCP Calls
 

--- a/java/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/java/voice-live-quickstarts/MCPQuickstart/README.md
@@ -1,4 +1,4 @@
-# MCP Quickstart
+# Java – MCP Quickstart
 
 > **For common setup instructions, troubleshooting, and detailed information, see the [Java Samples README](../../README.md)**
 
@@ -120,11 +120,13 @@ Not all MCP servers are well-suited for voice UX. Servers that respond quickly (
 
 ## Command Line Options
 
-- `--api-key`: Azure VoiceLive API key (overrides application.properties)
-- `--endpoint`: Azure VoiceLive endpoint URL (overrides application.properties)
-- `--model`: VoiceLive model to use (default: `gpt-realtime`)
-- `--voice`: Voice for the assistant (default: `en-US-Ava:DragonHDLatestNeural`)
-- `--use-token-credential`: Use Azure authentication instead of API key
+| Flag | Description |
+|---|---|
+| `--api-key` | Azure VoiceLive API key (overrides `application.properties`) |
+| `--endpoint` | Azure VoiceLive endpoint URL (overrides `application.properties`) |
+| `--model` | VoiceLive model to use (default: `gpt-realtime`) |
+| `--voice` | Voice for the assistant (default: `en-US-Ava:DragonHDLatestNeural`) |
+| `--use-token-credential` | Use Azure authentication instead of API key |
 
 ## Sample Trigger Phrases
 
@@ -132,6 +134,15 @@ Not all MCP servers are well-suited for voice UX. Servers that respond quickly (
 |---|---|---|---|
 | *"What is the GitHub repo fastapi about?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
 | *"Search the Azure documentation for Voice Live API"* | Azure Docs | Voice prompt (`always`) | Assistant asks *"Do you approve?"*, waits for your *yes* or *no* |
+
+## How It Works
+
+1. **MCP Server Definitions**: `MCPServer` instances added to the session tools list
+2. **Session Configuration**: `session.update` with model, voice, VAD, and MCP tools
+3. **Tool Discovery**: Voice Live connects to each MCP server and discovers available tools
+4. **Tool Announcements**: Auto-approved tool calls trigger a brief spoken acknowledgement
+5. **Voice Approval**: For `require_approval="always"` servers, a system message is injected prompting the model to ask verbally. The user's spoken response is parsed for *yes*/*no* using word-boundary regex
+6. **Result Delivery**: After MCP call completion, `response.create` kicks the model to speak the results
 
 ## Troubleshooting
 
@@ -148,7 +159,7 @@ For more troubleshooting guidance, see the [Java Samples README](../../README.md
 
 ## Additional Resources
 
-- [Azure AI Speech - Voice Live Documentation](https://learn.microsoft.com/azure/ai-services/speech-service/voice-live)
+- [Voice Live Documentation](https://learn.microsoft.com/azure/ai-services/speech-service/voice-live)
 - [VoiceLive SDK Documentation](https://learn.microsoft.com/java/api/overview/azure/ai-voicelive-readme)
 - [Model Context Protocol](https://modelcontextprotocol.io/)
 - [Support Guide](../../../SUPPORT.md)

--- a/java/voice-live-quickstarts/MCPQuickstart/application.properties.sample
+++ b/java/voice-live-quickstarts/MCPQuickstart/application.properties.sample
@@ -1,0 +1,18 @@
+# Azure VoiceLive Configuration
+# Copy this file to application.properties and fill in your values
+
+# Required: Your VoiceLive endpoint URL
+azure.voicelive.endpoint=https://your-endpoint.services.ai.azure.com/
+
+# Required: Your API key (if using API key authentication)
+# Comment this out if using Azure credential authentication
+azure.voicelive.api-key=your-api-key-here
+
+# Optional: Model name (default: gpt-realtime)
+# azure.voicelive.model=gpt-realtime
+
+# Optional: Voice name (default: en-US-Ava:DragonHDLatestNeural)
+# azure.voicelive.voice=en-US-Ava:DragonHDLatestNeural
+
+# Optional: API version (default: 2025-10-01)
+# azure.voicelive.api-version=2025-10-01

--- a/java/voice-live-quickstarts/MCPQuickstart/pom.xml
+++ b/java/voice-live-quickstarts/MCPQuickstart/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.azure.ai.voicelive</groupId>
+    <artifactId>mcp-quickstart</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>Azure VoiceLive MCP Quickstart</name>
+    <description>MCP quickstart sample for Azure AI VoiceLive SDK</description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- Azure VoiceLive SDK -->
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-ai-voicelive</artifactId>
+            <version>1.0.0-beta.5</version>
+        </dependency>
+
+        <!-- Azure Core -->
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core</artifactId>
+            <version>1.53.0</version>
+        </dependency>
+
+        <!-- Azure Identity for authentication -->
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+
+        <!-- Reactor Core for reactive programming -->
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.5.11</version>
+        </dependency>
+
+        <!-- SLF4J for logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>MCPQuickstart</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
+++ b/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
@@ -726,28 +726,36 @@ public final class MCPQuickstart {
     private static void startMcpStallTimer(SessionState state,
                                              VoiceLiveSessionAsyncClient session) {
         cancelMcpStallTimer(state);
-        state.mcpStallTimer = SCHEDULER.schedule(() -> {
-            if (state.mcpCallInProgress.get() > 0) {
-                try {
-                    sendSystemMessage(session,
-                        "The tool call is taking longer than expected. "
-                        + "Briefly let the user know you're still waiting for results.");
-                    session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
-                        .subscribeOn(Schedulers.boundedElastic())
-                        .subscribe(v -> {}, err -> {
-                            if (err.getMessage() != null
-                                && err.getMessage().toLowerCase().contains("active response")) {
-                                state.needsResponseCreate = true;
-                            }
-                        });
-                } catch (Exception e) {
-                    if (e.getMessage() != null
-                        && e.getMessage().toLowerCase().contains("active response")) {
-                        state.needsResponseCreate = true;
-                    }
+        final AtomicInteger stallCount = new AtomicInteger(0);
+        state.mcpStallTimer = SCHEDULER.scheduleAtFixedRate(() -> {
+            if (state.mcpCallInProgress.get() <= 0) {
+                cancelMcpStallTimer(state);
+                return;
+            }
+            int count = stallCount.incrementAndGet();
+            String msg = count == 1
+                ? "The tool call is taking longer than expected. "
+                  + "Briefly let the user know you're still waiting for results."
+                : "The tool call is taking very long. Ask the user: "
+                  + "would you like to keep waiting, or should I move on "
+                  + "and answer with what I know? Keep it short.";
+            try {
+                sendSystemMessage(session, msg);
+                session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
+                    .subscribeOn(Schedulers.boundedElastic())
+                    .subscribe(v -> {}, err -> {
+                        if (err.getMessage() != null
+                            && err.getMessage().toLowerCase().contains("active response")) {
+                            state.needsResponseCreate = true;
+                        }
+                    });
+            } catch (Exception e) {
+                if (e.getMessage() != null
+                    && e.getMessage().toLowerCase().contains("active response")) {
+                    state.needsResponseCreate = true;
                 }
             }
-        }, 15, TimeUnit.SECONDS);
+        }, 15, 15, TimeUnit.SECONDS);
     }
 
     /**

--- a/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
+++ b/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
@@ -557,6 +557,28 @@ public final class MCPQuickstart {
                 return;
             }
 
+            final int MAX_APPROVAL_CALLS_PER_TASK = 3;
+            int currentCount = state.approvalCallCount.getOrDefault(serverLabel, 0);
+            if (currentCount >= MAX_APPROVAL_CALLS_PER_TASK) {
+                System.out.println("   Auto-denied: " + serverLabel + "/" + functionName
+                    + " (max " + MAX_APPROVAL_CALLS_PER_TASK + " calls reached)");
+                try {
+                    String denyJson = String.format(
+                        "{\"type\":\"conversation.item.create\",\"item\":"
+                        + "{\"type\":\"mcp_approval_response\","
+                        + "\"approval_request_id\":\"%s\","
+                        + "\"approve\":false}}",
+                        approvalId);
+                    session.send(BinaryData.fromString(denyJson))
+                        .subscribeOn(Schedulers.boundedElastic())
+                        .subscribe(v -> {}, err ->
+                            System.err.println("Failed to send auto-deny: " + err.getMessage()));
+                } catch (Exception e) {
+                    System.err.println("Failed to send auto-deny: " + e.getMessage());
+                }
+                return;
+            }
+
             // If another approval is already pending, queue this one
             if (state.pendingApproval != null) {
                 state.approvalQueue.add(
@@ -712,9 +734,17 @@ public final class MCPQuickstart {
                         + "Briefly let the user know you're still waiting for results.");
                     session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
                         .subscribeOn(Schedulers.boundedElastic())
-                        .subscribe(v -> {}, err -> {});
+                        .subscribe(v -> {}, err -> {
+                            if (err.getMessage() != null
+                                && err.getMessage().toLowerCase().contains("active response")) {
+                                state.needsResponseCreate = true;
+                            }
+                        });
                 } catch (Exception e) {
-                    // best effort
+                    if (e.getMessage() != null
+                        && e.getMessage().toLowerCase().contains("active response")) {
+                        state.needsResponseCreate = true;
+                    }
                 }
             }
         }, 15, TimeUnit.SECONDS);

--- a/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
+++ b/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
@@ -356,8 +356,11 @@ public final class MCPQuickstart {
             .setCreateResponse(true);
 
         // Enable input audio transcription so we receive user speech as text
+        AudioInputTranscriptionOptionsModel transcriptionModel = config.model.toLowerCase().contains("realtime")
+            ? AudioInputTranscriptionOptionsModel.WHISPER_1
+            : AudioInputTranscriptionOptionsModel.fromString("azure-speech");
         AudioInputTranscriptionOptions transcriptionOptions =
-            new AudioInputTranscriptionOptions(AudioInputTranscriptionOptionsModel.WHISPER_1);
+            new AudioInputTranscriptionOptions(transcriptionModel);
 
         VoiceLiveSessionOptions options = new VoiceLiveSessionOptions()
             .setInstructions(config.instructions)
@@ -466,7 +469,7 @@ public final class MCPQuickstart {
                         // suppress
                     } else if (msg.toLowerCase().contains("interim response")) {
                         // non-fatal
-                    } else if (msg.toLowerCase().contains("active response in progress")) {
+                    } else if (msg.toLowerCase().contains("active response")) {
                         // expected during MCP flow
                     } else {
                         System.out.println("❌ Error: " + msg);

--- a/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
+++ b/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
@@ -38,8 +38,15 @@ import javax.sound.sampled.SourceDataLine;
 import javax.sound.sampled.TargetDataLine;
 
 import java.io.FileInputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -112,6 +119,9 @@ public final class MCPQuickstart {
 
     private static final Pattern YES_PATTERN = Pattern.compile("\\byes\\b", Pattern.CASE_INSENSITIVE);
     private static final Pattern NO_PATTERN = Pattern.compile("\\b(no|stop|cancel)\\b", Pattern.CASE_INSENSITIVE);
+
+    private static final String LOG_FILENAME = "conversation_"
+            + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")) + ".log";
 
     /**
      * Mutable session state shared across event handlers.
@@ -339,10 +349,10 @@ public final class MCPQuickstart {
 
         mcpTools.add(new MCPServer("deepwiki", "https://mcp.deepwiki.com/mcp")
             .setAllowedTools(Arrays.asList("read_wiki_structure", "ask_question"))
-            .setRequireApproval(BinaryData.fromString("\"never\"")));
+            .setRequireApproval(BinaryData.fromString("never")));
 
         mcpTools.add(new MCPServer("azure_doc", "https://learn.microsoft.com/api/mcp")
-            .setRequireApproval(BinaryData.fromString("\"always\"")));
+            .setRequireApproval(BinaryData.fromString("always")));
 
         return mcpTools;
     }
@@ -400,11 +410,29 @@ public final class MCPQuickstart {
         try {
             if (eventType == ServerEventType.SESSION_UPDATED) {
                 System.out.println("✓ Session updated - starting microphone");
+                writeLog("Session updated");
                 audioProcessor.startCapture();
 
             } else if (eventType == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STARTED) {
                 System.out.println("🎤 Listening...");
                 audioProcessor.skipPendingAudio();
+
+                // Cancel any active response — prevents duplicate result playback
+                // when the user interrupts during MCP result speech (matches C#/Python/JS)
+                if (state.responseActive) {
+                    session.send(BinaryData.fromString("{\"type\":\"response.cancel\"}"))
+                        .subscribeOn(Schedulers.boundedElastic())
+                        .subscribe(v -> {}, err -> {});
+                }
+
+                // Clear deferred response flags if no MCP calls are in progress.
+                // Without this, a stale needsResponseCreate from a collision during
+                // the approval flow causes the model to re-speak results after the
+                // user interrupts.
+                if (state.mcpCallInProgress.get() <= 0) {
+                    state.needsResponseCreate = false;
+                    state.mcpResultsPending = false;
+                }
 
                 // Reset approved-servers-this-turn when user starts a new topic
                 if (state.pendingApproval == null && state.mcpCallInProgress.get() <= 0) {
@@ -415,14 +443,12 @@ public final class MCPQuickstart {
                 if (state.mcpCallInProgress.get() > 0 && state.pendingApproval == null) {
                     state.staleMcpItems.addAll(state.activeMcpItems);
                     System.out.println("[barge-in] Marking " + state.activeMcpItems.size() + " MCP calls as stale");
-                    try {
-                        sendSystemMessage(session,
-                            "A tool call is still running in the background. The user just spoke. "
-                            + "Respond to what the user said. If a tool result arrives later, "
-                            + "briefly introduce it as a late result from an earlier request.");
-                    } catch (Exception e) {
-                        // best effort
-                    }
+                    sendSystemMessage(session,
+                        "A tool call is still running in the background. The user just spoke. "
+                        + "Respond to what the user said. If a tool result arrives later, "
+                        + "briefly introduce it as a late result from an earlier request.")
+                        .subscribeOn(Schedulers.boundedElastic())
+                        .subscribe(v -> {}, err -> {});
                 }
 
             } else if (eventType == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED) {
@@ -446,6 +472,7 @@ public final class MCPQuickstart {
             } else if (eventType == ServerEventType.RESPONSE_DONE) {
                 state.responseActive = false;
                 System.out.println("✅ Response complete");
+                writeLog("--- Response complete ---");
 
                 // If an approval prompt needs to be injected, do it now
                 if (state.approvalPromptNeeded && state.pendingApproval != null) {
@@ -478,6 +505,7 @@ public final class MCPQuickstart {
                 String eventJson = BinaryData.fromObject(event).toString();
                 String transcript = extractJsonField(eventJson, "transcript");
                 System.out.println("👤 You said:\t" + transcript);
+                writeLog("User Input:\t" + transcript);
 
                 // Interpret as an approval answer if we have a pending approval
                 if (state.pendingApproval != null) {
@@ -498,18 +526,22 @@ public final class MCPQuickstart {
                         // expected during MCP flow
                     } else {
                         System.out.println("❌ Error: " + msg);
+                        writeLog("ERROR: " + msg);
                     }
                 }
 
             // MCP-specific events
             } else if (eventType == ServerEventType.MCP_LIST_TOOLS_COMPLETED) {
                 System.out.println("🔧 MCP tools discovered successfully");
+                writeLog("MCP tools discovered successfully");
 
             } else if (eventType == ServerEventType.MCP_LIST_TOOLS_FAILED) {
                 System.out.println("❌ MCP tool discovery failed");
+                writeLog("ERROR: MCP tool discovery failed");
 
             } else if (eventType == ServerEventType.RESPONSE_MCP_CALL_IN_PROGRESS) {
                 System.out.println("⏳ MCP tool call in progress...");
+                writeLog("MCP call in progress");
                 state.mcpCallInProgress.incrementAndGet();
                 String inProgressJson = BinaryData.fromObject(event).toString();
                 String inProgressItemId = extractJsonField(inProgressJson, "item_id");
@@ -529,6 +561,7 @@ public final class MCPQuickstart {
                     state.handledMcpCompletions.add(itemId);
                     boolean isStale = itemId != null && state.staleMcpItems.remove(itemId);
                     System.out.println("✅ MCP tool call completed (stale=" + isStale + ")");
+                    writeLog("MCP call completed: " + itemId + " (stale=" + isStale + ")");
                     state.mcpItemToServer.remove(itemId);
 
                     // Reset approval counter if no more approvals pending
@@ -536,42 +569,42 @@ public final class MCPQuickstart {
                         state.approvalCallCount.clear();
                     }
 
-                    // If the user moved on during this call, tell the model it's a late result
+                    // If the user moved on during this call, tell the model it's a late result.
+                    // Chain any late-result context message with the response.create below
+                    // to ensure the system message arrives first.
+                    Mono<Void> preResponseMono = Mono.empty();
                     if (isStale) {
-                        try {
-                            sendSystemMessage(session,
-                                "This tool result is from an earlier request. The user has "
-                                + "since moved on. Briefly introduce it as a late result, e.g. "
-                                + "'By the way, those results from earlier just came in...' "
-                                + "then share the key findings concisely.");
-                        } catch (Exception e) {
-                            // best effort
-                        }
+                        preResponseMono = sendSystemMessage(session,
+                            "This tool result is from an earlier request. The user has "
+                            + "since moved on. Briefly introduce it as a late result, e.g. "
+                            + "'By the way, those results from earlier just came in...' "
+                            + "then share the key findings concisely.");
                     }
 
                     // Batch response: only call response.create when ALL MCP calls for this
                     // turn have completed. This prevents partial results and repeated tool calls.
                     if (state.pendingApproval == null && state.approvalQueue.isEmpty()
                             && state.mcpCallInProgress.get() <= 0) {
-                        try {
-                            session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
-                                .subscribeOn(Schedulers.boundedElastic())
-                                .subscribe(v -> {}, err -> {
-                                    if (err.getMessage().toLowerCase().contains("active response")) {
-                                        state.needsResponseCreate = true;
-                                    }
-                                });
-                        } catch (Exception e) {
-                            state.needsResponseCreate = true;
-                        }
+                        preResponseMono
+                            .then(session.send(BinaryData.fromString("{\"type\":\"response.create\"}")))
+                            .subscribeOn(Schedulers.boundedElastic())
+                            .subscribe(v -> {}, err -> {
+                                if (err.getMessage().toLowerCase().contains("active response")) {
+                                    state.needsResponseCreate = true;
+                                }
+                            });
                     } else {
+                        preResponseMono
+                            .subscribeOn(Schedulers.boundedElastic())
+                            .subscribe(v -> {}, err -> {});
                         state.mcpResultsPending = true;
-                        System.out.println("[mcp] MCP calls still in progress (" + state.mcpCallInProgress.get() + ") — deferring response");
+                        System.out.println("[mcp] MCP calls still in progress (" + state.mcpCallInProgress.get() + ") or approval pending — deferring response");
                     }
                 }
 
             } else if (eventType == ServerEventType.RESPONSE_MCP_CALL_FAILED) {
                 System.out.println("❌ MCP tool call failed");
+                writeLog("ERROR: MCP tool call failed");
                 String failedJson = BinaryData.fromObject(event).toString();
                 String failedItemId = extractJsonField(failedJson, "item_id");
                 state.mcpCallInProgress.updateAndGet(v -> Math.max(0, v - 1));
@@ -669,6 +702,7 @@ public final class MCPQuickstart {
             System.out.println();
             System.out.println("🔐 MCP Approval Request (voice-based):");
             System.out.println("   Server: " + serverLabel + "  Tool: " + functionName);
+            writeLog("Approval request: server=" + serverLabel + " tool=" + functionName);
 
             state.pendingApproval =
                 new SessionState.ApprovalInfo(approvalId, serverLabel, functionName);
@@ -689,15 +723,11 @@ public final class MCPQuickstart {
 
             // Announce to the user if this server doesn't require approval
             if (state.pendingApproval == null && !state.approvalServers.contains(serverLabel)) {
-                try {
-                    sendSystemMessage(session,
-                        "Briefly tell the user you're looking something up. One short sentence only.");
-                    session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
-                        .subscribeOn(Schedulers.boundedElastic())
-                        .subscribe(v -> {}, err -> {});
-                } catch (Exception e) {
-                    // best effort
-                }
+                sendSystemMessage(session,
+                    "Briefly tell the user you're looking something up. One short sentence only.")
+                    .then(session.send(BinaryData.fromString("{\"type\":\"response.create\"}")))
+                    .subscribeOn(Schedulers.boundedElastic())
+                    .subscribe(v -> {}, err -> {});
             }
         }
     }
@@ -724,15 +754,11 @@ public final class MCPQuickstart {
                 + "Should I continue? Please say yes or no.\"";
         }
 
-        try {
-            sendSystemMessage(session, prompt);
-            session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
-                .subscribeOn(Schedulers.boundedElastic())
-                .subscribe(v -> {}, err ->
-                    System.err.println("❌ Failed to send approval voice prompt: " + err.getMessage()));
-        } catch (Exception e) {
-            System.err.println("❌ Failed to send approval voice prompt: " + e.getMessage());
-        }
+        sendSystemMessage(session, prompt)
+            .then(session.send(BinaryData.fromString("{\"type\":\"response.create\"}")))
+            .subscribeOn(Schedulers.boundedElastic())
+            .subscribe(v -> {}, err ->
+                System.err.println("❌ Failed to send approval voice prompt: " + err.getMessage()));
     }
 
     /**
@@ -765,8 +791,10 @@ public final class MCPQuickstart {
         }
 
         System.out.println("   Voice approval: " + (approved ? "Approved ✅" : "Denied ❌"));
+        writeLog("Approval resolved: " + (approved ? "APPROVED" : "DENIED") + " for " + pending.serverLabel() + "/" + pending.functionName());
 
-        // Send approval/denial response via raw JSON
+        // Send approval/denial response via raw JSON.
+        // Chain processNextApproval after the send completes to avoid racing.
         String approvalJson = String.format(
             "{\"type\":\"conversation.item.create\",\"item\":"
             + "{\"type\":\"mcp_approval_response\","
@@ -777,12 +805,12 @@ public final class MCPQuickstart {
         session.send(BinaryData.fromString(approvalJson))
             .subscribeOn(Schedulers.boundedElastic())
             .subscribe(
-                v -> {},
-                error -> System.err.println("❌ Failed to send approval response: " + error.getMessage())
+                v -> processNextApproval(state, session),
+                error -> {
+                    System.err.println("❌ Failed to send approval response: " + error.getMessage());
+                    processNextApproval(state, session);
+                }
             );
-
-        // Process next queued approval, if any
-        processNextApproval(state, session);
     }
 
     /**
@@ -792,6 +820,26 @@ public final class MCPQuickstart {
                                               VoiceLiveSessionAsyncClient session) {
         SessionState.ApprovalInfo next = state.approvalQueue.poll();
         if (next == null) return;
+
+        // Auto-approve if user already approved this server earlier in the same turn
+        if (state.approvedServersThisTurn.contains(next.serverLabel())) {
+            System.out.println("   Auto-approved (queued): " + next.serverLabel() + "/" + next.functionName());
+            String approveJson = String.format(
+                "{\"type\":\"conversation.item.create\",\"item\":"
+                + "{\"type\":\"mcp_approval_response\","
+                + "\"approval_request_id\":\"%s\","
+                + "\"approve\":true}}",
+                next.approvalId());
+            session.send(BinaryData.fromString(approveJson))
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe(
+                    v -> processNextApproval(state, session),
+                    err -> {
+                        System.err.println("Failed to send queued auto-approve: " + err.getMessage());
+                        processNextApproval(state, session);
+                    });
+            return;
+        }
 
         state.pendingApproval = next;
         if (!state.responseActive) {
@@ -824,22 +872,15 @@ public final class MCPQuickstart {
             String msg = "The tool call is still running. "
                 + "Briefly reassure the user that you're still waiting for results. "
                 + "One short sentence only.";
-            try {
-                sendSystemMessage(session, msg);
-                session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
-                    .subscribeOn(Schedulers.boundedElastic())
-                    .subscribe(v -> {}, err -> {
-                        if (err.getMessage() != null
-                            && err.getMessage().toLowerCase().contains("active response")) {
-                            state.needsResponseCreate = true;
-                        }
-                    });
-            } catch (Exception e) {
-                if (e.getMessage() != null
-                    && e.getMessage().toLowerCase().contains("active response")) {
-                    state.needsResponseCreate = true;
-                }
-            }
+            sendSystemMessage(session, msg)
+                .then(session.send(BinaryData.fromString("{\"type\":\"response.create\"}")))
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe(v -> {}, err -> {
+                    if (err.getMessage() != null
+                        && err.getMessage().toLowerCase().contains("active response")) {
+                        state.needsResponseCreate = true;
+                    }
+                });
         }, 10, 10, TimeUnit.SECONDS);
     }
 
@@ -857,15 +898,31 @@ public final class MCPQuickstart {
 
     /**
      * Send a system message to the model via raw JSON.
+     * Returns a Mono so callers can chain subsequent sends sequentially,
+     * avoiding FAIL_NON_SERIALIZED errors from concurrent sends.
      */
-    private static void sendSystemMessage(VoiceLiveSessionAsyncClient session, String text) {
+    private static Mono<Void> sendSystemMessage(VoiceLiveSessionAsyncClient session, String text) {
         String escaped = text.replace("\\", "\\\\").replace("\"", "\\\"");
         String json = "{\"type\":\"conversation.item.create\",\"item\":"
             + "{\"type\":\"message\",\"role\":\"system\",\"content\":"
             + "[{\"type\":\"input_text\",\"text\":\"" + escaped + "\"}]}}";
-        session.send(BinaryData.fromString(json))
-            .subscribeOn(Schedulers.boundedElastic())
-            .subscribe(v -> {}, err -> {});
+        return session.send(BinaryData.fromString(json));
+    }
+
+    /**
+     * Write a line to the conversation log file.
+     */
+    private static void writeLog(String message) {
+        try {
+            Path logDir = Paths.get("logs");
+            Files.createDirectories(logDir);
+            try (PrintWriter writer = new PrintWriter(
+                    new FileWriter(logDir.resolve(LOG_FILENAME).toString(), true))) {
+                writer.println(message);
+            }
+        } catch (IOException e) {
+            System.err.println("Failed to write conversation log: " + e.getMessage());
+        }
     }
 
     /**

--- a/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
+++ b/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
@@ -6,6 +6,8 @@ import com.azure.ai.voicelive.VoiceLiveClientBuilder;
 import com.azure.ai.voicelive.VoiceLiveServiceVersion;
 import com.azure.ai.voicelive.VoiceLiveSessionAsyncClient;
 import com.azure.ai.voicelive.models.AudioEchoCancellation;
+import com.azure.ai.voicelive.models.AudioInputTranscriptionOptions;
+import com.azure.ai.voicelive.models.AudioInputTranscriptionOptionsModel;
 import com.azure.ai.voicelive.models.AudioNoiseReduction;
 import com.azure.ai.voicelive.models.AudioNoiseReductionType;
 import com.azure.ai.voicelive.models.AzureStandardVoice;
@@ -41,13 +43,22 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
-import java.util.Scanner;
+import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 
 /**
  * MCP Quickstart - demonstrates MCP server integration with the VoiceLive SDK.
@@ -72,7 +83,11 @@ public final class MCPQuickstart {
     private static final String DEFAULT_INSTRUCTIONS =
         "You are a helpful AI assistant with access to MCP tools. "
         + "Use the tools to help answer user questions. "
-        + "Respond naturally and conversationally.";
+        + "Respond naturally and conversationally. "
+        + "Some tools require user approval before they can be used. When you receive a "
+        + "system message asking you to request permission, you MUST clearly ask the user "
+        + "for their explicit approval before proceeding. Always wait for the user to say "
+        + "yes or no. Never skip the approval question or assume permission is granted.";
 
     private static final String ENV_ENDPOINT = "AZURE_VOICELIVE_ENDPOINT";
     private static final String ENV_API_KEY = "AZURE_VOICELIVE_API_KEY";
@@ -85,6 +100,49 @@ public final class MCPQuickstart {
 
     private MCPQuickstart() {
         throw new UnsupportedOperationException("Utility class");
+    }
+
+    private static final ScheduledExecutorService SCHEDULER = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "MCP-StallTimer");
+        t.setDaemon(true);
+        return t;
+    });
+
+    private static final Pattern YES_PATTERN = Pattern.compile("\\byes\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern NO_PATTERN = Pattern.compile("\\b(no|stop|cancel)\\b", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Mutable session state shared across event handlers.
+     * All fields are thread-safe (volatile or concurrent collections).
+     */
+    private static class SessionState {
+        volatile ApprovalInfo pendingApproval;
+        final Queue<ApprovalInfo> approvalQueue = new ConcurrentLinkedQueue<>();
+        volatile boolean approvalPromptNeeded;
+        final AtomicInteger mcpCallInProgress = new AtomicInteger(0);
+        final Set<String> handledMcpCompletions = ConcurrentHashMap.newKeySet();
+        volatile boolean needsResponseCreate;
+        final Map<String, Integer> approvalCallCount = new ConcurrentHashMap<>();
+        final Map<String, String> mcpItemToServer = new ConcurrentHashMap<>();
+        Set<String> approvalServers = Set.of();
+        volatile ScheduledFuture<?> mcpStallTimer;
+        volatile boolean responseActive;
+
+        static class ApprovalInfo {
+            final String approvalId;
+            final String serverLabel;
+            final String functionName;
+
+            ApprovalInfo(String approvalId, String serverLabel, String functionName) {
+                this.approvalId = approvalId;
+                this.serverLabel = serverLabel;
+                this.functionName = functionName;
+            }
+
+            String approvalId() { return approvalId; }
+            String serverLabel() { return serverLabel; }
+            String functionName() { return functionName; }
+        }
     }
 
     private static class AudioPlaybackPacket {
@@ -297,6 +355,10 @@ public final class MCPQuickstart {
             .setAutoTruncate(true)
             .setCreateResponse(true);
 
+        // Enable input audio transcription so we receive user speech as text
+        AudioInputTranscriptionOptions transcriptionOptions =
+            new AudioInputTranscriptionOptions(AudioInputTranscriptionOptionsModel.WHISPER_1);
+
         VoiceLiveSessionOptions options = new VoiceLiveSessionOptions()
             .setInstructions(config.instructions)
             .setVoice(BinaryData.fromObject(new AzureStandardVoice(config.voice)))
@@ -306,6 +368,7 @@ public final class MCPQuickstart {
             .setInputAudioSamplingRate(SAMPLE_RATE)
             .setInputAudioNoiseReduction(new AudioNoiseReduction(AudioNoiseReductionType.NEAR_FIELD))
             .setInputAudioEchoCancellation(new AudioEchoCancellation())
+            .setInputAudioTranscription(transcriptionOptions)
             .setTurnDetection(turnDetection);
 
         // Add MCP servers to the tools list
@@ -318,10 +381,11 @@ public final class MCPQuickstart {
 
     // <handle_mcp_events>
     /**
-     * Handle incoming server events, including MCP-specific events.
+     * Handle incoming server events, including MCP-specific events
+     * and voice-based approval flow.
      */
     private static void handleServerEvent(SessionUpdate event, AudioProcessor audioProcessor,
-                                           Scanner scanner, VoiceLiveSessionAsyncClient session) {
+                                           SessionState state, VoiceLiveSessionAsyncClient session) {
         ServerEventType eventType = event.getType();
 
         try {
@@ -333,8 +397,23 @@ public final class MCPQuickstart {
                 System.out.println("🎤 Listening...");
                 audioProcessor.skipPendingAudio();
 
+                // If an MCP call is running and no approval is pending, ask if user wants to skip
+                if (state.mcpCallInProgress.get() > 0 && state.pendingApproval == null) {
+                    try {
+                        sendSystemMessage(session,
+                            "A tool call is still running. The user just interrupted. "
+                            + "Briefly ask them: do you want to keep waiting for the result, "
+                            + "or skip it and move on? Keep it short.");
+                    } catch (Exception e) {
+                        // best effort
+                    }
+                }
+
             } else if (eventType == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED) {
                 System.out.println("🤔 Processing...");
+
+            } else if (eventType == ServerEventType.RESPONSE_CREATED) {
+                state.responseActive = true;
 
             } else if (eventType == ServerEventType.RESPONSE_AUDIO_DELTA) {
                 if (event instanceof SessionUpdateResponseAudioDelta) {
@@ -349,12 +428,47 @@ public final class MCPQuickstart {
                 System.out.println("🎤 Ready for next input...");
 
             } else if (eventType == ServerEventType.RESPONSE_DONE) {
+                state.responseActive = false;
                 System.out.println("✅ Response complete");
+
+                // If an approval prompt needs to be injected, do it now
+                if (state.approvalPromptNeeded && state.pendingApproval != null) {
+                    state.approvalPromptNeeded = false;
+                    sendApprovalVoicePrompt(state, session);
+                } else if (state.needsResponseCreate) {
+                    // Deferred response.create — retry now that no response is active
+                    state.needsResponseCreate = false;
+                    try {
+                        session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
+                            .subscribeOn(Schedulers.boundedElastic())
+                            .subscribe(v -> {}, err -> {});
+                    } catch (Exception e) {
+                        // best-effort retry
+                    }
+                }
+
+            // <voice_approval_transcription>
+            } else if (eventType == ServerEventType.CONVERSATION_ITEM_INPUT_AUDIO_TRANSCRIPTION_COMPLETED) {
+                String eventJson = BinaryData.fromObject(event).toString();
+                String transcript = extractJsonField(eventJson, "transcript");
+                System.out.println("👤 You said:\t" + transcript);
+
+                // Interpret as an approval answer if we have a pending approval
+                if (state.pendingApproval != null) {
+                    resolveVoiceApproval(transcript, state, session);
+                }
+            // </voice_approval_transcription>
 
             } else if (eventType == ServerEventType.ERROR) {
                 if (event instanceof SessionUpdateError) {
                     String msg = ((SessionUpdateError) event).getError().getMessage();
-                    if (!msg.contains("no active response")) {
+                    if (msg.contains("no active response")) {
+                        // suppress
+                    } else if (msg.toLowerCase().contains("interim response")) {
+                        // non-fatal
+                    } else if (msg.toLowerCase().contains("active response in progress")) {
+                        // expected during MCP flow
+                    } else {
                         System.out.println("❌ Error: " + msg);
                     }
                 }
@@ -368,16 +482,55 @@ public final class MCPQuickstart {
 
             } else if (eventType == ServerEventType.RESPONSE_MCP_CALL_IN_PROGRESS) {
                 System.out.println("⏳ MCP tool call in progress...");
+                state.mcpCallInProgress.incrementAndGet();
+                startMcpStallTimer(state, session);
 
             } else if (eventType == ServerEventType.RESPONSE_MCP_CALL_COMPLETED) {
-                System.out.println("✅ MCP tool call completed");
+                String eventJson = BinaryData.fromObject(event).toString();
+                String itemId = extractJsonField(eventJson, "item_id");
+                state.mcpCallInProgress.updateAndGet(v -> Math.max(0, v - 1));
+                cancelMcpStallTimer(state);
+
+                if (state.handledMcpCompletions.contains(itemId)) {
+                    // duplicate — ignore
+                } else {
+                    state.handledMcpCompletions.add(itemId);
+                    System.out.println("✅ MCP tool call completed");
+                    state.mcpItemToServer.remove(itemId);
+
+                    // Reset approval counter if no more approvals pending
+                    if (state.pendingApproval == null && state.approvalQueue.isEmpty()) {
+                        state.approvalCallCount.clear();
+                    }
+
+                    // Kick the model to speak the MCP output
+                    try {
+                        session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
+                            .subscribeOn(Schedulers.boundedElastic())
+                            .subscribe(v -> {}, err -> {
+                                if (err.getMessage().toLowerCase().contains("active response")) {
+                                    state.needsResponseCreate = true;
+                                }
+                            });
+                    } catch (Exception e) {
+                        state.needsResponseCreate = true;
+                    }
+                }
 
             } else if (eventType == ServerEventType.RESPONSE_MCP_CALL_FAILED) {
                 System.out.println("❌ MCP tool call failed");
+                state.mcpCallInProgress.updateAndGet(v -> Math.max(0, v - 1));
+                cancelMcpStallTimer(state);
+                try {
+                    session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
+                        .subscribeOn(Schedulers.boundedElastic())
+                        .subscribe(v -> {}, err -> {});
+                } catch (Exception e) {
+                    // best effort
+                }
 
             } else if (eventType == ServerEventType.CONVERSATION_ITEM_CREATED) {
-                // Check for MCP approval request in conversation items
-                handleMCPConversationItem(event, scanner, session);
+                handleMCPConversationItem(event, state, session);
             }
         } catch (Exception e) {
             System.err.println("❌ Error handling event: " + e.getMessage());
@@ -387,57 +540,209 @@ public final class MCPQuickstart {
 
     // <handle_approval>
     /**
-     * Handle MCP approval requests by prompting the user in the console
-     * and sending the approval/denial response back to the server.
+     * Handle MCP conversation items: approval requests, tool call announcements,
+     * and item-to-server tracking.
      */
-    private static void handleMCPConversationItem(SessionUpdate event, Scanner scanner,
+    private static void handleMCPConversationItem(SessionUpdate event, SessionState state,
                                                     VoiceLiveSessionAsyncClient session) {
-        // Parse the event JSON to check for MCP approval requests
         String eventJson = BinaryData.fromObject(event).toString();
 
         if (eventJson.contains("mcp_approval_request")) {
-            // Extract approval details from the event JSON for display
+            // Extract approval details
             String approvalId = extractJsonField(eventJson, "id");
             String serverLabel = extractJsonField(eventJson, "server_label");
-            String toolName = extractJsonField(eventJson, "name");
-            String arguments = extractJsonField(eventJson, "arguments");
+            String functionName = extractJsonField(eventJson, "name");
 
-            System.out.println();
-            System.out.println("🔐 MCP Approval Request:");
-            System.out.println("   Server:    " + serverLabel);
-            System.out.println("   Tool:      " + toolName);
-            System.out.println("   Arguments: " + arguments);
-
-            // Prompt the user for approval
-            boolean approved = false;
-            while (true) {
-                System.out.print("   Approve MCP call? (y/n): ");
-                String input = scanner.nextLine().trim().toLowerCase();
-                if ("y".equals(input)) { approved = true; break; }
-                if ("n".equals(input)) { approved = false; break; }
-                System.out.println("   Invalid input. Please type 'y' or 'n'.");
+            if ("unknown".equals(approvalId)) {
+                return;
             }
 
-            System.out.println("   Response: " + (approved ? "Approved ✅" : "Denied ❌"));
+            // If another approval is already pending, queue this one
+            if (state.pendingApproval != null) {
+                state.approvalQueue.add(
+                    new SessionState.ApprovalInfo(approvalId, serverLabel, functionName));
+                return;
+            }
 
-            // Send the approval or denial response back to the server.
-            // MCP approval responses use raw JSON via send(BinaryData) because
-            // the typed SDK classes do not yet cover mcp_approval_response.
-            String approvalJson = String.format(
-                "{\"type\":\"conversation.item.create\",\"item\":"
-                + "{\"type\":\"mcp_approval_response\","
-                + "\"approval_request_id\":\"%s\","
-                + "\"approve\":%s}}",
-                approvalId, approved);
+            System.out.println();
+            System.out.println("🔐 MCP Approval Request (voice-based):");
+            System.out.println("   Server: " + serverLabel + "  Tool: " + functionName);
 
-            session.send(BinaryData.fromString(approvalJson))
-                .then(session.send(BinaryData.fromString("{\"type\":\"response.create\"}")))
-                .subscribeOn(Schedulers.boundedElastic())
-                .subscribe(
-                    v -> {},
-                    error -> System.err.println("❌ Failed to send approval response: " + error.getMessage())
-                );
+            state.pendingApproval =
+                new SessionState.ApprovalInfo(approvalId, serverLabel, functionName);
+
+            if (!state.responseActive) {
+                sendApprovalVoicePrompt(state, session);
+            } else {
+                state.approvalPromptNeeded = true;
+            }
+
+        } else if (eventJson.contains("\"type\":\"mcp_call\"")) {
+            // Track MCP call items and announce non-approval tool calls
+            String itemId = extractJsonField(eventJson, "id");
+            String serverLabel = extractJsonField(eventJson, "server_label");
+            String functionName = extractJsonField(eventJson, "name");
+            System.out.println("🔧 MCP tool call: " + serverLabel + "/" + functionName);
+            state.mcpItemToServer.put(itemId, serverLabel + "/" + functionName);
+
+            // Announce to the user if this server doesn't require approval
+            if (state.pendingApproval == null && !state.approvalServers.contains(serverLabel)) {
+                try {
+                    sendSystemMessage(session,
+                        "Briefly tell the user you're looking something up. One short sentence only.");
+                    session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
+                        .subscribeOn(Schedulers.boundedElastic())
+                        .subscribe(v -> {}, err -> {});
+                } catch (Exception e) {
+                    // best effort
+                }
+            }
         }
+    }
+
+    /**
+     * Inject a system message asking the model to verbally request permission.
+     */
+    private static void sendApprovalVoicePrompt(SessionState state,
+                                                  VoiceLiveSessionAsyncClient session) {
+        SessionState.ApprovalInfo pending = state.pendingApproval;
+        if (pending == null) return;
+
+        int callCount = state.approvalCallCount.getOrDefault(pending.serverLabel(), 0);
+        state.approvalCallCount.put(pending.serverLabel(), callCount + 1);
+
+        String prompt;
+        if (callCount == 0) {
+            prompt = "You MUST ask the user for explicit permission before proceeding. "
+                + "Say exactly: \"I'd like to search the " + pending.serverLabel()
+                + " service for information. Do you approve? Please say yes or no.\"";
+        } else {
+            prompt = "You MUST ask the user for permission again. "
+                + "Say exactly: \"I need to do one more search to get complete information. "
+                + "Should I continue? Please say yes or no.\"";
+        }
+
+        try {
+            sendSystemMessage(session, prompt);
+            session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe(v -> {}, err ->
+                    System.err.println("❌ Failed to send approval voice prompt: " + err.getMessage()));
+        } catch (Exception e) {
+            System.err.println("❌ Failed to send approval voice prompt: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Interpret the user's spoken response as approval or denial.
+     */
+    private static void resolveVoiceApproval(String transcript, SessionState state,
+                                               VoiceLiveSessionAsyncClient session) {
+        SessionState.ApprovalInfo pending = state.pendingApproval;
+        if (pending == null) return;
+
+        String text = transcript.trim().toLowerCase();
+        boolean approved = YES_PATTERN.matcher(text).find();
+        boolean denied = NO_PATTERN.matcher(text).find();
+
+        if (!approved && !denied) {
+            // Ambiguous — ask again at next RESPONSE_DONE
+            state.approvalPromptNeeded = true;
+            return;
+        }
+        if (approved && denied) {
+            approved = false; // conflicting signals — deny for safety
+        }
+
+        state.pendingApproval = null;
+        if (!approved) {
+            state.approvalCallCount.clear();
+        }
+
+        System.out.println("   Voice approval: " + (approved ? "Approved ✅" : "Denied ❌"));
+
+        // Send approval/denial response via raw JSON
+        String approvalJson = String.format(
+            "{\"type\":\"conversation.item.create\",\"item\":"
+            + "{\"type\":\"mcp_approval_response\","
+            + "\"approval_request_id\":\"%s\","
+            + "\"approve\":%s}}",
+            pending.approvalId(), approved);
+
+        session.send(BinaryData.fromString(approvalJson))
+            .subscribeOn(Schedulers.boundedElastic())
+            .subscribe(
+                v -> {},
+                error -> System.err.println("❌ Failed to send approval response: " + error.getMessage())
+            );
+
+        // Process next queued approval, if any
+        processNextApproval(state, session);
+    }
+
+    /**
+     * Pop the next queued approval and ask via voice.
+     */
+    private static void processNextApproval(SessionState state,
+                                              VoiceLiveSessionAsyncClient session) {
+        SessionState.ApprovalInfo next = state.approvalQueue.poll();
+        if (next == null) return;
+
+        state.pendingApproval = next;
+        if (!state.responseActive) {
+            sendApprovalVoicePrompt(state, session);
+        } else {
+            state.approvalPromptNeeded = true;
+        }
+    }
+    // </handle_approval>
+
+    // <mcp_stall_detection>
+    /**
+     * Start a timer that verbally updates the user if an MCP call takes too long.
+     */
+    private static void startMcpStallTimer(SessionState state,
+                                             VoiceLiveSessionAsyncClient session) {
+        cancelMcpStallTimer(state);
+        state.mcpStallTimer = SCHEDULER.schedule(() -> {
+            if (state.mcpCallInProgress.get() > 0) {
+                try {
+                    sendSystemMessage(session,
+                        "The tool call is taking longer than expected. "
+                        + "Briefly let the user know you're still waiting for results.");
+                    session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
+                        .subscribeOn(Schedulers.boundedElastic())
+                        .subscribe(v -> {}, err -> {});
+                } catch (Exception e) {
+                    // best effort
+                }
+            }
+        }, 15, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Cancel the MCP stall timer if running.
+     */
+    private static void cancelMcpStallTimer(SessionState state) {
+        ScheduledFuture<?> timer = state.mcpStallTimer;
+        if (timer != null && !timer.isDone()) {
+            timer.cancel(false);
+        }
+        state.mcpStallTimer = null;
+    }
+    // </mcp_stall_detection>
+
+    /**
+     * Send a system message to the model via raw JSON.
+     */
+    private static void sendSystemMessage(VoiceLiveSessionAsyncClient session, String text) {
+        String escaped = text.replace("\\", "\\\\").replace("\"", "\\\"");
+        String json = "{\"type\":\"conversation.item.create\",\"item\":"
+            + "{\"type\":\"message\",\"role\":\"system\",\"content\":"
+            + "[{\"type\":\"input_text\",\"text\":\"" + escaped + "\"}]}}";
+        session.send(BinaryData.fromString(json))
+            .subscribeOn(Schedulers.boundedElastic())
+            .subscribe(v -> {}, err -> {});
     }
 
     /**
@@ -452,7 +757,6 @@ public final class MCPQuickstart {
         if (end < 0) return "unknown";
         return json.substring(start, end);
     }
-    // </handle_approval>
 
     private static boolean checkAudioSystem() {
         try {
@@ -488,7 +792,9 @@ public final class MCPQuickstart {
 
         System.out.println("🎙️ Starting Voice Assistant with MCP...");
 
-        Scanner scanner = new Scanner(System.in);
+        // Session state for voice-based MCP approval flow
+        SessionState state = new SessionState();
+        state.approvalServers = Set.of("azure_doc");
 
         try {
             VoiceLiveAsyncClient client;
@@ -521,7 +827,7 @@ public final class MCPQuickstart {
 
                     session.receiveEvents()
                         .subscribe(
-                            event -> handleServerEvent(event, audioProcessor, scanner, session),
+                            event -> handleServerEvent(event, audioProcessor, state, session),
                             error -> System.err.println("❌ Event error: " + error.getMessage())
                         );
 
@@ -536,7 +842,7 @@ public final class MCPQuickstart {
                     System.out.println("Try saying:");
                     System.out.println("  • 'Can you summarize the GitHub repo azure-sdk-for-java?'");
                     System.out.println("  • 'Search the Azure documentation for Voice Live API.'");
-                    System.out.println("You may need to approve some MCP tool calls in the console.");
+                    System.out.println("Approve MCP tool calls by voice — say 'yes' or 'no' when asked.");
                     System.out.println("Press Ctrl+C to exit");
                     System.out.println("=".repeat(70));
                     System.out.println();
@@ -544,6 +850,7 @@ public final class MCPQuickstart {
                     Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                         System.out.println("\n🛑 Shutting down...");
                         audioProcessor.shutdown();
+                        SCHEDULER.shutdownNow();
                     }));
 
                     return Mono.never();
@@ -551,13 +858,12 @@ public final class MCPQuickstart {
                 .doFinally(signalType -> {
                     AudioProcessor ap = audioProcessorRef.get();
                     if (ap != null) ap.shutdown();
+                    SCHEDULER.shutdownNow();
                 })
                 .block();
 
         } catch (Exception e) {
             System.err.println("❌ Fatal error: " + e.getMessage());
-        } finally {
-            scanner.close();
         }
     }
 }

--- a/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
+++ b/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
@@ -404,9 +404,9 @@ public final class MCPQuickstart {
                 if (state.mcpCallInProgress.get() > 0 && state.pendingApproval == null) {
                     try {
                         sendSystemMessage(session,
-                            "A tool call is still running. The user just interrupted. "
-                            + "Briefly ask them: do you want to keep waiting for the result, "
-                            + "or skip it and move on? Keep it short.");
+                            "A tool call is still running. The user just spoke. "
+                            + "Briefly acknowledge them and let them know you're "
+                            + "still waiting for results. One short sentence.");
                     } catch (Exception e) {
                         // best effort
                     }
@@ -738,12 +738,14 @@ public final class MCPQuickstart {
                 return;
             }
             int count = stallCount.incrementAndGet();
-            String msg = count == 1
-                ? "The tool call is taking longer than expected. "
-                  + "Briefly let the user know you're still waiting for results."
-                : "The tool call is taking very long. Ask the user: "
-                  + "would you like to keep waiting, or should I move on "
-                  + "and answer with what I know? Keep it short.";
+            if (count > 3) {
+                cancelMcpStallTimer(state);
+                return;
+            }
+            // MCP calls cannot be cancelled — only honest status updates are possible.
+            String msg = "The tool call is still running. "
+                + "Briefly reassure the user that you're still waiting for results. "
+                + "One short sentence only.";
             try {
                 sendSystemMessage(session, msg);
                 session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))

--- a/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
+++ b/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
@@ -463,6 +463,8 @@ public final class MCPQuickstart {
             // </voice_approval_transcription>
 
             } else if (eventType == ServerEventType.ERROR) {
+                // Reset response state — errors can terminate a response without RESPONSE_DONE
+                state.responseActive = false;
                 if (event instanceof SessionUpdateError) {
                     String msg = ((SessionUpdateError) event).getError().getMessage();
                     if (msg.contains("no active response")) {

--- a/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
+++ b/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
@@ -1,0 +1,523 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import com.azure.ai.voicelive.VoiceLiveAsyncClient;
+import com.azure.ai.voicelive.VoiceLiveClientBuilder;
+import com.azure.ai.voicelive.VoiceLiveServiceVersion;
+import com.azure.ai.voicelive.VoiceLiveSessionAsyncClient;
+import com.azure.ai.voicelive.models.AudioEchoCancellation;
+import com.azure.ai.voicelive.models.AudioNoiseReduction;
+import com.azure.ai.voicelive.models.AudioNoiseReductionType;
+import com.azure.ai.voicelive.models.AzureStandardVoice;
+import com.azure.ai.voicelive.models.ClientEventSessionUpdate;
+import com.azure.ai.voicelive.models.InputAudioFormat;
+import com.azure.ai.voicelive.models.InteractionModality;
+import com.azure.ai.voicelive.models.MCPServer;
+import com.azure.ai.voicelive.models.OutputAudioFormat;
+import com.azure.ai.voicelive.models.ServerEventType;
+import com.azure.ai.voicelive.models.ServerVadTurnDetection;
+import com.azure.ai.voicelive.models.SessionUpdate;
+import com.azure.ai.voicelive.models.SessionUpdateError;
+import com.azure.ai.voicelive.models.SessionUpdateResponseAudioDelta;
+import com.azure.ai.voicelive.models.VoiceLiveSessionOptions;
+import com.azure.ai.voicelive.models.VoiceLiveToolDefinition;
+import com.azure.core.credential.KeyCredential;
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.util.BinaryData;
+import com.azure.identity.AzureCliCredentialBuilder;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.DataLine;
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.SourceDataLine;
+import javax.sound.sampled.TargetDataLine;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.Scanner;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * MCP Quickstart - demonstrates MCP server integration with the VoiceLive SDK.
+ * Shows how to define MCP servers, handle MCP tool calls, and implement
+ * an approval flow for tool calls that require user consent.
+ *
+ * <p><strong>Environment Variables Required:</strong></p>
+ * <ul>
+ *   <li>AZURE_VOICELIVE_ENDPOINT - The VoiceLive service endpoint URL</li>
+ *   <li>AZURE_VOICELIVE_API_KEY - The API key (required if not using --use-token-credential)</li>
+ * </ul>
+ *
+ * <p><strong>How to Run:</strong></p>
+ * <pre>{@code
+ * mvn compile exec:java -Dexec.mainClass="MCPQuickstart" -q
+ * }</pre>
+ */
+public final class MCPQuickstart {
+
+    private static final String DEFAULT_MODEL = "gpt-realtime";
+    private static final String DEFAULT_VOICE = "en-US-Ava:DragonHDLatestNeural";
+    private static final String DEFAULT_INSTRUCTIONS =
+        "You are a helpful AI assistant with access to MCP tools. "
+        + "Use the tools to help answer user questions. "
+        + "Respond naturally and conversationally.";
+
+    private static final String ENV_ENDPOINT = "AZURE_VOICELIVE_ENDPOINT";
+    private static final String ENV_API_KEY = "AZURE_VOICELIVE_API_KEY";
+
+    private static final int SAMPLE_RATE = 24000;
+    private static final int CHANNELS = 1;
+    private static final int SAMPLE_SIZE_BITS = 16;
+    private static final int CHUNK_SIZE = 1200;
+    private static final int AUDIO_BUFFER_SIZE_MULTIPLIER = 4;
+
+    private MCPQuickstart() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    private static class AudioPlaybackPacket {
+        final int sequenceNumber;
+        final byte[] audioData;
+
+        AudioPlaybackPacket(int sequenceNumber, byte[] audioData) {
+            this.sequenceNumber = sequenceNumber;
+            this.audioData = audioData;
+        }
+    }
+
+    /**
+     * Audio processor for real-time capture and playback.
+     */
+    private static class AudioProcessor {
+        private final VoiceLiveSessionAsyncClient session;
+        private final AudioFormat audioFormat;
+
+        private TargetDataLine microphone;
+        private SourceDataLine speaker;
+        private final AtomicBoolean isCapturing = new AtomicBoolean(false);
+        private final AtomicBoolean isPlaying = new AtomicBoolean(false);
+        private final BlockingQueue<AudioPlaybackPacket> playbackQueue = new LinkedBlockingQueue<>();
+        private final AtomicInteger nextSequenceNumber = new AtomicInteger(0);
+        private final AtomicInteger playbackBase = new AtomicInteger(0);
+
+        AudioProcessor(VoiceLiveSessionAsyncClient session) {
+            this.session = session;
+            this.audioFormat = new AudioFormat(
+                AudioFormat.Encoding.PCM_SIGNED,
+                SAMPLE_RATE, SAMPLE_SIZE_BITS, CHANNELS,
+                CHANNELS * SAMPLE_SIZE_BITS / 8, SAMPLE_RATE, false
+            );
+        }
+
+        void startCapture() {
+            if (isCapturing.get()) return;
+
+            try {
+                DataLine.Info micInfo = new DataLine.Info(TargetDataLine.class, audioFormat);
+                microphone = (TargetDataLine) AudioSystem.getLine(micInfo);
+                microphone.open(audioFormat, CHUNK_SIZE * AUDIO_BUFFER_SIZE_MULTIPLIER);
+                microphone.start();
+                isCapturing.set(true);
+
+                Thread captureThread = new Thread(this::captureAudioLoop, "VoiceLive-AudioCapture");
+                captureThread.setDaemon(true);
+                captureThread.start();
+                System.out.println("🎤 Microphone capture started");
+            } catch (LineUnavailableException e) {
+                throw new RuntimeException("Failed to initialize microphone", e);
+            }
+        }
+
+        void startPlayback() {
+            if (isPlaying.get()) return;
+
+            try {
+                DataLine.Info speakerInfo = new DataLine.Info(SourceDataLine.class, audioFormat);
+                speaker = (SourceDataLine) AudioSystem.getLine(speakerInfo);
+                speaker.open(audioFormat, CHUNK_SIZE * AUDIO_BUFFER_SIZE_MULTIPLIER);
+                speaker.start();
+                isPlaying.set(true);
+
+                Thread playbackThread = new Thread(this::playbackAudioLoop, "VoiceLive-AudioPlayback");
+                playbackThread.setDaemon(true);
+                playbackThread.start();
+                System.out.println("🔊 Audio playback started");
+            } catch (LineUnavailableException e) {
+                throw new RuntimeException("Failed to initialize speaker", e);
+            }
+        }
+
+        private void captureAudioLoop() {
+            byte[] buffer = new byte[CHUNK_SIZE * 2];
+            while (isCapturing.get() && microphone != null) {
+                try {
+                    int bytesRead = microphone.read(buffer, 0, buffer.length);
+                    if (bytesRead > 0) {
+                        byte[] audioChunk = Arrays.copyOf(buffer, bytesRead);
+                        session.sendInputAudio(BinaryData.fromBytes(audioChunk))
+                            .subscribeOn(Schedulers.boundedElastic())
+                            .subscribe(v -> {}, error -> {
+                                if (!error.getMessage().contains("cancelled")) {
+                                    System.err.println("❌ Error sending audio: " + error.getMessage());
+                                }
+                            });
+                    }
+                } catch (Exception e) {
+                    if (isCapturing.get()) {
+                        System.err.println("❌ Error in audio capture: " + e.getMessage());
+                    }
+                    break;
+                }
+            }
+        }
+
+        private void playbackAudioLoop() {
+            while (isPlaying.get()) {
+                try {
+                    AudioPlaybackPacket packet = playbackQueue.take();
+                    if (packet.audioData == null) break;
+                    if (packet.sequenceNumber < playbackBase.get()) continue;
+                    if (speaker != null && speaker.isOpen()) {
+                        speaker.write(packet.audioData, 0, packet.audioData.length);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+
+        void queueAudio(byte[] audioData) {
+            if (audioData != null && audioData.length > 0) {
+                int seqNum = nextSequenceNumber.getAndIncrement();
+                playbackQueue.offer(new AudioPlaybackPacket(seqNum, audioData));
+            }
+        }
+
+        void skipPendingAudio() {
+            playbackBase.set(nextSequenceNumber.get());
+            playbackQueue.clear();
+            if (speaker != null && speaker.isOpen()) speaker.flush();
+        }
+
+        void shutdown() {
+            isCapturing.set(false);
+            if (microphone != null) { microphone.stop(); microphone.close(); microphone = null; }
+            isPlaying.set(false);
+            playbackQueue.offer(new AudioPlaybackPacket(-1, null));
+            if (speaker != null) { speaker.stop(); speaker.close(); speaker = null; }
+            System.out.println("🔇 Audio processor shut down");
+        }
+    }
+
+    private static class Config {
+        String endpoint;
+        String apiKey;
+        String model = DEFAULT_MODEL;
+        String voice = DEFAULT_VOICE;
+        String instructions = DEFAULT_INSTRUCTIONS;
+        boolean useTokenCredential = false;
+
+        static Config load(String[] args) {
+            Config config = new Config();
+            Properties props = loadProperties();
+            if (props != null) {
+                config.endpoint = props.getProperty("azure.voicelive.endpoint");
+                config.apiKey = props.getProperty("azure.voicelive.api-key");
+                config.model = props.getProperty("azure.voicelive.model", DEFAULT_MODEL);
+                config.voice = props.getProperty("azure.voicelive.voice", DEFAULT_VOICE);
+            }
+            if (System.getenv(ENV_ENDPOINT) != null) config.endpoint = System.getenv(ENV_ENDPOINT);
+            if (System.getenv(ENV_API_KEY) != null) config.apiKey = System.getenv(ENV_API_KEY);
+
+            for (int i = 0; i < args.length; i++) {
+                switch (args[i]) {
+                    case "--endpoint": if (i + 1 < args.length) config.endpoint = args[++i]; break;
+                    case "--api-key": if (i + 1 < args.length) config.apiKey = args[++i]; break;
+                    case "--model": if (i + 1 < args.length) config.model = args[++i]; break;
+                    case "--voice": if (i + 1 < args.length) config.voice = args[++i]; break;
+                    case "--use-token-credential": config.useTokenCredential = true; break;
+                }
+            }
+            return config;
+        }
+    }
+
+    private static Properties loadProperties() {
+        Properties props = new Properties();
+        try (InputStream input = new FileInputStream("application.properties")) {
+            props.load(input);
+            return props;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    // <define_mcp_servers>
+    /**
+     * Define MCP servers that Voice Live can use during the session.
+     * Each server is an MCPServer instance added to the session options tools list.
+     */
+    private static List<VoiceLiveToolDefinition> defineMCPServers() {
+        List<VoiceLiveToolDefinition> mcpTools = new ArrayList<>();
+
+        mcpTools.add(new MCPServer("deepwiki", "https://mcp.deepwiki.com/mcp")
+            .setAllowedTools(Arrays.asList("read_wiki_structure", "ask_question"))
+            .setRequireApproval(BinaryData.fromString("\"never\"")));
+
+        mcpTools.add(new MCPServer("azure_doc", "https://learn.microsoft.com/api/mcp")
+            .setRequireApproval(BinaryData.fromString("\"always\"")));
+
+        return mcpTools;
+    }
+    // </define_mcp_servers>
+
+    // <configure_session>
+    /**
+     * Create session configuration with MCP servers in the tools list.
+     */
+    private static VoiceLiveSessionOptions createSessionOptions(Config config) {
+        ServerVadTurnDetection turnDetection = new ServerVadTurnDetection()
+            .setThreshold(0.5)
+            .setPrefixPaddingMs(300)
+            .setSilenceDurationMs(500)
+            .setInterruptResponse(true)
+            .setAutoTruncate(true)
+            .setCreateResponse(true);
+
+        VoiceLiveSessionOptions options = new VoiceLiveSessionOptions()
+            .setInstructions(config.instructions)
+            .setVoice(BinaryData.fromObject(new AzureStandardVoice(config.voice)))
+            .setModalities(Arrays.asList(InteractionModality.TEXT, InteractionModality.AUDIO))
+            .setInputAudioFormat(InputAudioFormat.PCM16)
+            .setOutputAudioFormat(OutputAudioFormat.PCM16)
+            .setInputAudioSamplingRate(SAMPLE_RATE)
+            .setInputAudioNoiseReduction(new AudioNoiseReduction(AudioNoiseReductionType.NEAR_FIELD))
+            .setInputAudioEchoCancellation(new AudioEchoCancellation())
+            .setTurnDetection(turnDetection);
+
+        // Add MCP servers to the tools list
+        List<VoiceLiveToolDefinition> mcpServers = defineMCPServers();
+        options.setTools(mcpServers);
+
+        return options;
+    }
+    // </configure_session>
+
+    // <handle_mcp_events>
+    /**
+     * Handle incoming server events, including MCP-specific events.
+     */
+    private static void handleServerEvent(SessionUpdate event, AudioProcessor audioProcessor,
+                                           Scanner scanner, VoiceLiveSessionAsyncClient session) {
+        ServerEventType eventType = event.getType();
+
+        try {
+            if (eventType == ServerEventType.SESSION_UPDATED) {
+                System.out.println("✓ Session updated - starting microphone");
+                audioProcessor.startCapture();
+
+            } else if (eventType == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STARTED) {
+                System.out.println("🎤 Listening...");
+                audioProcessor.skipPendingAudio();
+
+            } else if (eventType == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED) {
+                System.out.println("🤔 Processing...");
+
+            } else if (eventType == ServerEventType.RESPONSE_AUDIO_DELTA) {
+                if (event instanceof SessionUpdateResponseAudioDelta) {
+                    SessionUpdateResponseAudioDelta audioEvent = (SessionUpdateResponseAudioDelta) event;
+                    byte[] audioData = audioEvent.getDelta();
+                    if (audioData != null && audioData.length > 0) {
+                        audioProcessor.queueAudio(audioData);
+                    }
+                }
+
+            } else if (eventType == ServerEventType.RESPONSE_AUDIO_DONE) {
+                System.out.println("🎤 Ready for next input...");
+
+            } else if (eventType == ServerEventType.RESPONSE_DONE) {
+                System.out.println("✅ Response complete");
+
+            } else if (eventType == ServerEventType.ERROR) {
+                if (event instanceof SessionUpdateError) {
+                    String msg = ((SessionUpdateError) event).getError().getMessage();
+                    if (!msg.contains("no active response")) {
+                        System.out.println("❌ Error: " + msg);
+                    }
+                }
+
+            // MCP-specific events
+            } else if (eventType == ServerEventType.MCP_LIST_TOOLS_COMPLETED) {
+                System.out.println("🔧 MCP tools discovered successfully");
+
+            } else if (eventType == ServerEventType.MCP_LIST_TOOLS_FAILED) {
+                System.out.println("❌ MCP tool discovery failed");
+
+            } else if (eventType == ServerEventType.RESPONSE_MCP_CALL_IN_PROGRESS) {
+                System.out.println("⏳ MCP tool call in progress...");
+
+            } else if (eventType == ServerEventType.RESPONSE_MCP_CALL_COMPLETED) {
+                System.out.println("✅ MCP tool call completed");
+
+            } else if (eventType == ServerEventType.RESPONSE_MCP_CALL_FAILED) {
+                System.out.println("❌ MCP tool call failed");
+
+            } else if (eventType == ServerEventType.CONVERSATION_ITEM_CREATED) {
+                // Check for MCP approval request in conversation items
+                handleMCPConversationItem(event, scanner, session);
+            }
+        } catch (Exception e) {
+            System.err.println("❌ Error handling event: " + e.getMessage());
+        }
+    }
+    // </handle_mcp_events>
+
+    // <handle_approval>
+    /**
+     * Handle MCP approval requests by prompting the user in the console.
+     */
+    private static void handleMCPConversationItem(SessionUpdate event, Scanner scanner,
+                                                    VoiceLiveSessionAsyncClient session) {
+        // Parse the event JSON to check for MCP approval requests
+        String eventJson = BinaryData.fromObject(event).toString();
+
+        if (eventJson.contains("mcp_approval_request")) {
+            System.out.println();
+            System.out.println("🔐 MCP Approval Request received");
+            System.out.println("   (Check the event details in the log)");
+
+            // Prompt the user for approval
+            boolean approved = false;
+            while (true) {
+                System.out.print("   Approve MCP call? (y/n): ");
+                String input = scanner.nextLine().trim().toLowerCase();
+                if ("y".equals(input)) { approved = true; break; }
+                if ("n".equals(input)) { approved = false; break; }
+                System.out.println("   Invalid input. Please type 'y' or 'n'.");
+            }
+
+            System.out.println("   Response: " + (approved ? "Approved" : "Denied"));
+        }
+    }
+    // </handle_approval>
+
+    private static boolean checkAudioSystem() {
+        try {
+            AudioFormat format = new AudioFormat(SAMPLE_RATE, SAMPLE_SIZE_BITS, CHANNELS, true, false);
+            if (!AudioSystem.isLineSupported(new DataLine.Info(TargetDataLine.class, format))) {
+                System.err.println("❌ No compatible microphone found");
+                return false;
+            }
+            if (!AudioSystem.isLineSupported(new DataLine.Info(SourceDataLine.class, format))) {
+                System.err.println("❌ No compatible speaker found");
+                return false;
+            }
+            System.out.println("✓ Audio system check passed");
+            return true;
+        } catch (Exception e) {
+            System.err.println("❌ Audio system check failed: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public static void main(String[] args) {
+        Config config = Config.load(args);
+
+        if (config.endpoint == null) {
+            System.err.println("❌ Missing endpoint. Set AZURE_VOICELIVE_ENDPOINT or pass --endpoint.");
+            return;
+        }
+        if (!config.useTokenCredential && config.apiKey == null) {
+            System.err.println("❌ No authentication. Set AZURE_VOICELIVE_API_KEY or use --use-token-credential.");
+            return;
+        }
+        if (!checkAudioSystem()) return;
+
+        System.out.println("🎙️ Starting Voice Assistant with MCP...");
+
+        Scanner scanner = new Scanner(System.in);
+
+        try {
+            VoiceLiveAsyncClient client;
+            if (config.useTokenCredential) {
+                TokenCredential credential = new AzureCliCredentialBuilder().build();
+                client = new VoiceLiveClientBuilder()
+                    .endpoint(config.endpoint)
+                    .credential(credential)
+                    .serviceVersion(VoiceLiveServiceVersion.V2026_01_01_PREVIEW)
+                    .buildAsyncClient();
+                System.out.println("🔑 Using Token Credential authentication");
+            } else {
+                client = new VoiceLiveClientBuilder()
+                    .endpoint(config.endpoint)
+                    .credential(new KeyCredential(config.apiKey))
+                    .serviceVersion(VoiceLiveServiceVersion.V2026_01_01_PREVIEW)
+                    .buildAsyncClient();
+                System.out.println("🔑 Using API Key authentication");
+            }
+
+            VoiceLiveSessionOptions sessionOptions = createSessionOptions(config);
+            AtomicReference<AudioProcessor> audioProcessorRef = new AtomicReference<>();
+
+            client.startSession(config.model)
+                .flatMap(session -> {
+                    System.out.println("✓ Session started");
+
+                    AudioProcessor audioProcessor = new AudioProcessor(session);
+                    audioProcessorRef.set(audioProcessor);
+
+                    session.receiveEvents()
+                        .subscribe(
+                            event -> handleServerEvent(event, audioProcessor, scanner, session),
+                            error -> System.err.println("❌ Event error: " + error.getMessage())
+                        );
+
+                    ClientEventSessionUpdate updateEvent = new ClientEventSessionUpdate(sessionOptions);
+                    session.sendEvent(updateEvent).subscribe();
+
+                    audioProcessor.startPlayback();
+
+                    System.out.println();
+                    System.out.println("=".repeat(70));
+                    System.out.println("🎤 VOICE ASSISTANT WITH MCP READY");
+                    System.out.println("Try saying:");
+                    System.out.println("  • 'Can you summarize the GitHub repo azure-sdk-for-java?'");
+                    System.out.println("  • 'Search the Azure documentation for Voice Live API.'");
+                    System.out.println("You may need to approve some MCP tool calls in the console.");
+                    System.out.println("Press Ctrl+C to exit");
+                    System.out.println("=".repeat(70));
+                    System.out.println();
+
+                    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                        System.out.println("\n🛑 Shutting down...");
+                        audioProcessor.shutdown();
+                    }));
+
+                    return Mono.never();
+                })
+                .doFinally(signalType -> {
+                    AudioProcessor ap = audioProcessorRef.get();
+                    if (ap != null) ap.shutdown();
+                })
+                .block();
+
+        } catch (Exception e) {
+            System.err.println("❌ Fatal error: " + e.getMessage());
+        } finally {
+            scanner.close();
+        }
+    }
+}

--- a/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
+++ b/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
@@ -131,6 +131,8 @@ public final class MCPQuickstart {
         volatile boolean responseActive;
         final Set<String> activeMcpItems = ConcurrentHashMap.newKeySet();
         final Set<String> staleMcpItems = ConcurrentHashMap.newKeySet();
+        volatile boolean mcpResultsPending;
+        final Set<String> approvedServersThisTurn = ConcurrentHashMap.newKeySet();
 
         static class ApprovalInfo {
             final String approvalId;
@@ -404,6 +406,11 @@ public final class MCPQuickstart {
                 System.out.println("🎤 Listening...");
                 audioProcessor.skipPendingAudio();
 
+                // Reset approved-servers-this-turn when user starts a new topic
+                if (state.pendingApproval == null && state.mcpCallInProgress.get() <= 0) {
+                    state.approvedServersThisTurn.clear();
+                }
+
                 // If an MCP call is running and no approval is pending, mark as stale
                 if (state.mcpCallInProgress.get() > 0 && state.pendingApproval == null) {
                     state.staleMcpItems.addAll(state.activeMcpItems);
@@ -444,6 +451,16 @@ public final class MCPQuickstart {
                 if (state.approvalPromptNeeded && state.pendingApproval != null) {
                     state.approvalPromptNeeded = false;
                     sendApprovalVoicePrompt(state, session);
+                // If MCP results are pending and all calls are now done, create response
+                } else if (state.mcpResultsPending && state.mcpCallInProgress.get() <= 0 && state.pendingApproval == null) {
+                    state.mcpResultsPending = false;
+                    try {
+                        session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
+                            .subscribeOn(Schedulers.boundedElastic())
+                            .subscribe(v -> {}, err -> {});
+                    } catch (Exception e) {
+                        // best-effort
+                    }
                 } else if (state.needsResponseCreate) {
                     // Deferred response.create — retry now that no response is active
                     state.needsResponseCreate = false;
@@ -532,17 +549,24 @@ public final class MCPQuickstart {
                         }
                     }
 
-                    // Kick the model to speak the MCP output
-                    try {
-                        session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
-                            .subscribeOn(Schedulers.boundedElastic())
-                            .subscribe(v -> {}, err -> {
-                                if (err.getMessage().toLowerCase().contains("active response")) {
-                                    state.needsResponseCreate = true;
-                                }
-                            });
-                    } catch (Exception e) {
-                        state.needsResponseCreate = true;
+                    // Batch response: only call response.create when ALL MCP calls for this
+                    // turn have completed. This prevents partial results and repeated tool calls.
+                    if (state.pendingApproval == null && state.approvalQueue.isEmpty()
+                            && state.mcpCallInProgress.get() <= 0) {
+                        try {
+                            session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
+                                .subscribeOn(Schedulers.boundedElastic())
+                                .subscribe(v -> {}, err -> {
+                                    if (err.getMessage().toLowerCase().contains("active response")) {
+                                        state.needsResponseCreate = true;
+                                    }
+                                });
+                        } catch (Exception e) {
+                            state.needsResponseCreate = true;
+                        }
+                    } else {
+                        state.mcpResultsPending = true;
+                        System.out.println("[mcp] MCP calls still in progress (" + state.mcpCallInProgress.get() + ") — deferring response");
                     }
                 }
 
@@ -610,6 +634,27 @@ public final class MCPQuickstart {
                             System.err.println("Failed to send auto-deny: " + err.getMessage()));
                 } catch (Exception e) {
                     System.err.println("Failed to send auto-deny: " + e.getMessage());
+                }
+                return;
+            }
+
+            // Auto-approve if user already approved this server earlier in the same turn
+            if (state.approvedServersThisTurn.contains(serverLabel)) {
+                System.out.println("   Auto-approved: " + serverLabel + "/" + functionName
+                    + " (already approved this turn)");
+                try {
+                    String approveJson = String.format(
+                        "{\"type\":\"conversation.item.create\",\"item\":"
+                        + "{\"type\":\"mcp_approval_response\","
+                        + "\"approval_request_id\":\"%s\","
+                        + "\"approve\":true}}",
+                        approvalId);
+                    session.send(BinaryData.fromString(approveJson))
+                        .subscribeOn(Schedulers.boundedElastic())
+                        .subscribe(v -> {}, err ->
+                            System.err.println("Failed to send auto-approve: " + err.getMessage()));
+                } catch (Exception e) {
+                    System.err.println("Failed to send auto-approve: " + e.getMessage());
                 }
                 return;
             }
@@ -712,8 +757,11 @@ public final class MCPQuickstart {
         }
 
         state.pendingApproval = null;
-        if (!approved) {
+        if (approved) {
+            state.approvedServersThisTurn.add(pending.serverLabel());
+        } else {
             state.approvalCallCount.clear();
+            state.approvedServersThisTurn.remove(pending.serverLabel());
         }
 
         System.out.println("   Voice approval: " + (approved ? "Approved ✅" : "Denied ❌"));

--- a/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
+++ b/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
@@ -87,7 +87,9 @@ public final class MCPQuickstart {
         + "Some tools require user approval before they can be used. When you receive a "
         + "system message asking you to request permission, you MUST clearly ask the user "
         + "for their explicit approval before proceeding. Always wait for the user to say "
-        + "yes or no. Never skip the approval question or assume permission is granted.";
+        + "yes or no. Never skip the approval question or assume permission is granted. "
+        + "If a tool result arrives after the conversation has moved to a different topic, "
+        + "briefly introduce it as a late result before sharing the findings.";
 
     private static final String ENV_ENDPOINT = "AZURE_VOICELIVE_ENDPOINT";
     private static final String ENV_API_KEY = "AZURE_VOICELIVE_API_KEY";
@@ -127,6 +129,8 @@ public final class MCPQuickstart {
         Set<String> approvalServers = Set.of();
         volatile ScheduledFuture<?> mcpStallTimer;
         volatile boolean responseActive;
+        final Set<String> activeMcpItems = ConcurrentHashMap.newKeySet();
+        final Set<String> staleMcpItems = ConcurrentHashMap.newKeySet();
 
         static class ApprovalInfo {
             final String approvalId;
@@ -400,13 +404,15 @@ public final class MCPQuickstart {
                 System.out.println("🎤 Listening...");
                 audioProcessor.skipPendingAudio();
 
-                // If an MCP call is running and no approval is pending, ask if user wants to skip
+                // If an MCP call is running and no approval is pending, mark as stale
                 if (state.mcpCallInProgress.get() > 0 && state.pendingApproval == null) {
+                    state.staleMcpItems.addAll(state.activeMcpItems);
+                    System.out.println("[barge-in] Marking " + state.activeMcpItems.size() + " MCP calls as stale");
                     try {
                         sendSystemMessage(session,
-                            "A tool call is still running. The user just spoke. "
-                            + "Briefly acknowledge them and let them know you're "
-                            + "still waiting for results. One short sentence.");
+                            "A tool call is still running in the background. The user just spoke. "
+                            + "Respond to what the user said. If a tool result arrives later, "
+                            + "briefly introduce it as a late result from an earlier request.");
                     } catch (Exception e) {
                         // best effort
                     }
@@ -488,24 +494,42 @@ public final class MCPQuickstart {
             } else if (eventType == ServerEventType.RESPONSE_MCP_CALL_IN_PROGRESS) {
                 System.out.println("⏳ MCP tool call in progress...");
                 state.mcpCallInProgress.incrementAndGet();
+                String inProgressJson = BinaryData.fromObject(event).toString();
+                String inProgressItemId = extractJsonField(inProgressJson, "item_id");
+                if (inProgressItemId != null) state.activeMcpItems.add(inProgressItemId);
                 startMcpStallTimer(state, session);
 
             } else if (eventType == ServerEventType.RESPONSE_MCP_CALL_COMPLETED) {
                 String eventJson = BinaryData.fromObject(event).toString();
                 String itemId = extractJsonField(eventJson, "item_id");
                 state.mcpCallInProgress.updateAndGet(v -> Math.max(0, v - 1));
+                if (itemId != null) state.activeMcpItems.remove(itemId);
                 cancelMcpStallTimer(state);
 
                 if (state.handledMcpCompletions.contains(itemId)) {
                     // duplicate — ignore
                 } else {
                     state.handledMcpCompletions.add(itemId);
-                    System.out.println("✅ MCP tool call completed");
+                    boolean isStale = itemId != null && state.staleMcpItems.remove(itemId);
+                    System.out.println("✅ MCP tool call completed (stale=" + isStale + ")");
                     state.mcpItemToServer.remove(itemId);
 
                     // Reset approval counter if no more approvals pending
                     if (state.pendingApproval == null && state.approvalQueue.isEmpty()) {
                         state.approvalCallCount.clear();
+                    }
+
+                    // If the user moved on during this call, tell the model it's a late result
+                    if (isStale) {
+                        try {
+                            sendSystemMessage(session,
+                                "This tool result is from an earlier request. The user has "
+                                + "since moved on. Briefly introduce it as a late result, e.g. "
+                                + "'By the way, those results from earlier just came in...' "
+                                + "then share the key findings concisely.");
+                        } catch (Exception e) {
+                            // best effort
+                        }
                     }
 
                     // Kick the model to speak the MCP output
@@ -524,7 +548,13 @@ public final class MCPQuickstart {
 
             } else if (eventType == ServerEventType.RESPONSE_MCP_CALL_FAILED) {
                 System.out.println("❌ MCP tool call failed");
+                String failedJson = BinaryData.fromObject(event).toString();
+                String failedItemId = extractJsonField(failedJson, "item_id");
                 state.mcpCallInProgress.updateAndGet(v -> Math.max(0, v - 1));
+                if (failedItemId != null) {
+                    state.activeMcpItems.remove(failedItemId);
+                    state.staleMcpItems.remove(failedItemId);
+                }
                 cancelMcpStallTimer(state);
                 try {
                     session.send(BinaryData.fromString("{\"type\":\"response.create\"}"))
@@ -762,7 +792,7 @@ public final class MCPQuickstart {
                     state.needsResponseCreate = true;
                 }
             }
-        }, 15, 15, TimeUnit.SECONDS);
+        }, 10, 10, TimeUnit.SECONDS);
     }
 
     /**

--- a/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
+++ b/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
@@ -387,7 +387,8 @@ public final class MCPQuickstart {
 
     // <handle_approval>
     /**
-     * Handle MCP approval requests by prompting the user in the console.
+     * Handle MCP approval requests by prompting the user in the console
+     * and sending the approval/denial response back to the server.
      */
     private static void handleMCPConversationItem(SessionUpdate event, Scanner scanner,
                                                     VoiceLiveSessionAsyncClient session) {
@@ -395,9 +396,17 @@ public final class MCPQuickstart {
         String eventJson = BinaryData.fromObject(event).toString();
 
         if (eventJson.contains("mcp_approval_request")) {
+            // Extract approval details from the event JSON for display
+            String approvalId = extractJsonField(eventJson, "id");
+            String serverLabel = extractJsonField(eventJson, "server_label");
+            String toolName = extractJsonField(eventJson, "name");
+            String arguments = extractJsonField(eventJson, "arguments");
+
             System.out.println();
-            System.out.println("🔐 MCP Approval Request received");
-            System.out.println("   (Check the event details in the log)");
+            System.out.println("🔐 MCP Approval Request:");
+            System.out.println("   Server:    " + serverLabel);
+            System.out.println("   Tool:      " + toolName);
+            System.out.println("   Arguments: " + arguments);
 
             // Prompt the user for approval
             boolean approved = false;
@@ -409,8 +418,39 @@ public final class MCPQuickstart {
                 System.out.println("   Invalid input. Please type 'y' or 'n'.");
             }
 
-            System.out.println("   Response: " + (approved ? "Approved" : "Denied"));
+            System.out.println("   Response: " + (approved ? "Approved ✅" : "Denied ❌"));
+
+            // Send the approval or denial response back to the server.
+            // MCP approval responses use raw JSON via send(BinaryData) because
+            // the typed SDK classes do not yet cover mcp_approval_response.
+            String approvalJson = String.format(
+                "{\"type\":\"conversation.item.create\",\"item\":"
+                + "{\"type\":\"mcp_approval_response\","
+                + "\"approval_request_id\":\"%s\","
+                + "\"approve\":%s}}",
+                approvalId, approved);
+
+            session.send(BinaryData.fromString(approvalJson))
+                .then(session.send(BinaryData.fromString("{\"type\":\"response.create\"}")))
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe(
+                    v -> {},
+                    error -> System.err.println("❌ Failed to send approval response: " + error.getMessage())
+                );
         }
+    }
+
+    /**
+     * Extract a simple string field value from a JSON string.
+     */
+    private static String extractJsonField(String json, String fieldName) {
+        String pattern = "\"" + fieldName + "\":\"";
+        int start = json.indexOf(pattern);
+        if (start < 0) return "unknown";
+        start += pattern.length();
+        int end = json.indexOf("\"", start);
+        if (end < 0) return "unknown";
+        return json.substring(start, end);
     }
     // </handle_approval>
 

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -17,6 +17,16 @@ A Node.js quickstart demonstrating the Voice Live + Foundry Agent v2 flow, inclu
 - Explicit microphone device selection
 - Barge-in handling and conversation logging
 
+### [MCP Quickstart](./voice-live-quickstarts/MCPQuickstart/)
+
+A Node.js quickstart demonstrating MCP (Model Context Protocol) server integration with Voice Live, enabling the assistant to use remote tools (DeepWiki, Azure Docs) during voice conversations.
+
+**Key Features:**
+- MCP server definitions with configurable approval policies
+- MCP tool discovery, execution, and failure event handling
+- Interactive console-based approval flow for sensitive tools
+- Barge-in handling and conversation logging
+
 ### [Model Quickstart](./voice-live-quickstarts/ModelQuickstart/)
 
 A Node.js quickstart demonstrating direct Voice Live model integration without Foundry agent orchestration.
@@ -113,6 +123,7 @@ All samples require:
 | Sample | Requirements |
 |--------|--------------|
 | Agents New Quickstart | [Node.js 18+](https://nodejs.org/) with npm |
+| MCP Quickstart | [Node.js 18+](https://nodejs.org/) with npm |
 | Model Quickstart | [Node.js 18+](https://nodejs.org/) with npm |
 | Basic Web Voice Assistant | [Node.js 18+](https://nodejs.org/) with npm |
 | Voice Live Avatar | [Docker](https://www.docker.com/get-started) |

--- a/javascript/voice-live-quickstarts/AgentsNewQuickstart/README.md
+++ b/javascript/voice-live-quickstarts/AgentsNewQuickstart/README.md
@@ -180,6 +180,7 @@ Press **Ctrl+C** to exit gracefully.
 |---|---|
 | `Set VOICELIVE_ENDPOINT, AGENT_NAME, and PROJECT_NAME` | Check your `.env` file contains all required variables. |
 | SoX not found / microphone errors | Ensure SoX is installed and available on your `PATH`. |
+| `sox has exited with error code 1` | SoX cannot find the default recording device. Run `--list-audio-devices` to see available devices, then pass the device name with `--audio-input-device`. |
 | Authentication errors | Run `az login` and ensure your account has access to the Foundry project. |
 | Agent not found | Run `create-agent-with-voicelive.js` first to create the agent, or verify `AGENT_NAME` matches an existing agent. |
 | `ERR_USE_AFTER_CLOSE` on exit | This is expected when pressing Ctrl+C; the process exits cleanly. |

--- a/javascript/voice-live-quickstarts/AgentsNewQuickstart/voice-live-with-agent-v2.js
+++ b/javascript/voice-live-quickstarts/AgentsNewQuickstart/voice-live-with-agent-v2.js
@@ -221,7 +221,7 @@ class AudioProcessor {
 
     if (this._speaker && !this._speaker.destroyed) {
       try {
-        this._speaker.end();
+        this._speaker.destroy();
       } catch {
         /* ignore */
       }

--- a/javascript/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/README.md
@@ -1,5 +1,7 @@
 # JavaScript – MCP Quickstart
 
+> **For common setup instructions, troubleshooting, and detailed information, see the [JavaScript Samples README](../../README.md)**
+
 This sample demonstrates **MCP (Model Context Protocol) server integration** with Voice Live using the Azure AI Voice Live SDK for JavaScript (Node.js).
 
 Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-realtime`) — but additionally configures remote MCP servers as tools, enabling the assistant to call external services (DeepWiki, Azure Docs) during the conversation. It implements a **voice-based approval flow** where the assistant verbally asks the user for permission before using tools that require consent.
@@ -74,6 +76,15 @@ For approval-required servers, once the user approves the first call, subsequent
 
 Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message so the model can acknowledge the user and respond to what they said. If the original MCP call completes later, its result is introduced as a **late result** (e.g. *"By the way, those results from earlier just came in..."*). Note: since MCP calls cannot be cancelled, the call continues running in the background regardless of what the user says.
 
+Barge-in in the MCP quickstart is more complex than in the Model or Agents quickstarts. Those simpler samples have a trivial `onResponseDone` handler (just reset flags), so cancelling a response is straightforward — the cancelled response's `onResponseDone` is a harmless no-op. In the MCP quickstart, `onResponseDone` processes **deferred actions** — pending approval prompts, queued MCP results, and deferred `response.create` calls. Without protection, the cancelled response's `onResponseDone` would immediately trigger a new response that overlaps the user's speech.
+
+To prevent this, the quickstart uses a `_bargeInActive` flag:
+1. **Set `true`** in `onInputAudioBufferSpeechStarted` just before calling `response.cancel`
+2. **Checked** at the top of `onResponseDone` — if set, all deferred processing is skipped and the flag is cleared
+3. All deferred flags (`_needsResponseCreate`, `_mcpResultsPending`) are also cleared unconditionally on barge-in
+
+This ensures the cancelled response exits cleanly without side effects, and the user's new turn drives the next response.
+
 ### Response Collision Handling
 
 MCP flows generate rapid event sequences where `response.create` calls can collide with active responses. This quickstart defers collisions to the next `onResponseDone` event via a flag, ensuring tool results and approval prompts are never silently dropped.
@@ -100,56 +111,77 @@ Not all MCP servers are well-suited for voice UX. Servers that respond quickly (
   - API key authentication, or
   - Azure CLI authentication (`az login`) for `DefaultAzureCredential`
 
-## Setup
+## Quick Start
 
-- **Install dependencies**:
+1. **Install dependencies**:
+   ```bash
+   npm install
+   ```
 
-```bash
-npm install
-```
+   If native audio modules cannot compile in your environment, you can still run a cloud connectivity smoke test with `--no-audio`. For automated Windows setup (Node.js, SoX, Build Tools), see the [helper scripts](../helper-scripts/).
 
-If native audio modules cannot compile in your environment, you can still run a cloud connectivity smoke test with `--no-audio`. For automated Windows setup (Node.js, SoX, Build Tools), see the [helper scripts](../helper-scripts/).
-
-- **Create a `.env` file** in this folder:
+2. **Create a `.env` file** in this folder:
 
 ```plaintext
 AZURE_VOICELIVE_ENDPOINT=https://<your-endpoint>.services.ai.azure.com/
 AZURE_VOICELIVE_API_KEY=<your-api-key>
 AZURE_VOICELIVE_MODEL=gpt-realtime
 AZURE_VOICELIVE_VOICE=en-US-Ava:DragonHDLatestNeural
+
+# Optional
+# AUDIO_INPUT_DEVICE=Microphone
 ```
 
-## Run
+3. **Run the sample**:
+   ```bash
+   node mcp-quickstart.js
+   # or with Azure authentication:
+   az login
+   node mcp-quickstart.js --use-token-credential
+   ```
 
-### API key authentication
+## Run Examples
+
+### With explicit microphone device (Windows/SoX)
 
 ```bash
-node mcp-quickstart.js
+node mcp-quickstart.js --audio-input-device "Microphone (Yeti X)"
 ```
 
-### Azure credential authentication
+### List available audio input devices (Windows)
 
 ```bash
-az login
-node mcp-quickstart.js --use-token-credential
+node mcp-quickstart.js --list-audio-devices
 ```
 
-### Smoke test without local audio devices/build tools
+### Smoke test without local audio devices
 
 ```bash
 node mcp-quickstart.js --no-audio
 ```
 
+### Show all CLI options
+
+```bash
+node mcp-quickstart.js --help
+```
+
 ## Command Line Options
 
-- `--api-key`: Azure Voice Live API key
-- `--endpoint`: Azure Voice Live endpoint URL
-- `--model`: Voice Live model to use (default: `gpt-realtime`)
-- `--voice`: Voice for the assistant (default: `en-US-Ava:DragonHDLatestNeural`)
-- `--instructions`: System instructions for the model session
-- `--audio-input-device`: Explicit SoX input device name (use when default device is not configured)
-- `--use-token-credential`: Use `DefaultAzureCredential` instead of API key
-- `--no-audio`: Connect and configure session without mic/speaker (for smoke tests)
+All settings can be provided via environment variables (`.env`) or CLI flags. CLI flags take precedence.
+
+| Flag | Description |
+|---|---|
+| `--api-key` | Azure Voice Live API key |
+| `--endpoint` | Azure Voice Live endpoint URL |
+| `--model` | Voice Live model to use (default: `gpt-realtime`) |
+| `--voice` | Voice for the assistant (default: `en-US-Ava:DragonHDLatestNeural`) |
+| `--instructions` | System instructions for the model session |
+| `--audio-input-device` | Explicit SoX input device name (use when default device is not configured) |
+| `--list-audio-devices` | List available audio input devices on Windows and exit |
+| `--use-token-credential` | Use `DefaultAzureCredential` instead of API key |
+| `--no-audio` | Connect and configure session without mic/speaker (smoke test) |
+| `-h, --help` | Show help text |
 
 ## Sample Trigger Phrases
 
@@ -158,12 +190,26 @@ node mcp-quickstart.js --no-audio
 | *"What is the GitHub repo fastapi about?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
 | *"Search the Azure documentation for Voice Live API"* | Azure Docs | Voice prompt (`always`) | Assistant asks *"Do you approve?"*, waits for your *yes* or *no* |
 
+## How It Works
+
+1. **MCP Server Definitions**: MCP server tool objects added to the session tools array
+2. **Session Configuration**: `session.update` with model, voice, VAD, and MCP tools
+3. **Tool Discovery**: Voice Live connects to each MCP server and discovers available tools
+4. **Tool Announcements**: Auto-approved tool calls trigger a brief spoken acknowledgement
+5. **Voice Approval**: For `require_approval="always"` servers, a system message is injected prompting the model to ask verbally. The user's spoken response is parsed for *yes*/*no* using word-boundary regex
+6. **Result Delivery**: After MCP call completion, `response.create` kicks the model to speak the results
+
+## Known Limitations
+
+- **Brief audio overlap on barge-in**: When interrupting the assistant, a short burst of audio (50–200ms) may continue playing before stopping. This is inherent to the Node.js `speaker` module — once PCM data has been handed off to the OS audio driver buffer, it cannot be flushed from userspace JavaScript. The quickstart minimizes this by using `destroy()` (immediate discard) instead of `end()` (graceful drain) and by suppressing deferred response creation via the `_bargeInActive` flag, but a small overlap is unavoidable at the Node.js level.
+
 ## Troubleshooting
 
 | Symptom | Resolution |
 | --- | --- |
 | Missing endpoint/authentication error | Verify `.env` values or pass CLI arguments. |
 | SoX not found / microphone errors | Ensure SoX is installed and on your `PATH`. |
+| `sox has exited with error code 1` | SoX cannot find the default recording device. Run `--list-audio-devices` to see available devices, then pass the device name with `--audio-input-device`. |
 | `Audio dependencies are unavailable` | Install Visual Studio Build Tools with **Desktop development with C++**, then reinstall (`npm install --include=optional`). |
 | MCP tool discovery failed | Check that MCP server URLs are reachable from your network. |
 | Repeated approval prompts | Expected — the model may need multiple searches. Say *"no"* or *"stop"* to deny. |

--- a/javascript/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/README.md
@@ -67,6 +67,16 @@ Users will naturally try to interrupt or ask *"Are you still there?"* during lon
 
 MCP flows generate rapid event sequences where `response.create` calls can collide with active responses. This quickstart defers collisions to the next `onResponseDone` event via a flag, ensuring tool results and approval prompts are never silently dropped.
 
+### MCP Server Selection: Latency Matters
+
+Not all MCP servers are well-suited for voice UX. Servers that respond quickly (< 5 seconds) provide a seamless experience, while slow servers (10–60+ seconds) create awkward silence even with stall notifications. When choosing MCP servers for a voice assistant:
+
+- **Prefer low-latency servers** — search APIs, simple lookups, and cached data sources work best
+- **Avoid servers that perform heavy computation** — large repo analysis, complex document retrieval, or multi-step workflows can take 30–60+ seconds, degrading the voice experience
+- **MCP calls cannot be cancelled** — once a call starts, it runs until the server responds or times out. There is no client-side or API-level cancellation mechanism
+- **Late results arrive out of context** — if the user moves on during a slow MCP call, the result arrives asynchronously and must be introduced as a late result, which can feel disjointed
+- **Consider whether async results are acceptable** for your use case. If users expect real-time answers, long-running MCP servers will frustrate them. If they expect a research-assistant style interaction where results trickle in, it may be acceptable
+
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) 18 or later

--- a/javascript/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/README.md
@@ -53,15 +53,26 @@ The counter resets when results are fully delivered or the user denies a request
 
 ### Silence During Tool Calls Must Be Filled
 
-MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses three layers:
+MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses two complementary layers to keep the user informed throughout:
 
-1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
-2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers generates natural filler. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline). The transcription model is also selected per pipeline: `azure-speech` for non-realtime, `whisper-1` for realtime.
-3. **Stall detection** (client-side, repeating 15s timer): Notifies the user up to 3 times that results are still pending. Note: MCP calls **cannot be cancelled** via the API — the call runs until the MCP server responds or the server-side timeout fires.
+1. **Tool announcements** (immediate, client-side): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates. This covers the first few seconds.
+
+2. **Stall detection** (client-side, repeating timer): If a tool call runs longer than expected, the assistant proactively tells the user it's still waiting. This quickstart uses a **10-second interval with a maximum of 3 notifications** — tune these values based on your expected MCP server latency:
+   - **Fast servers (< 5s)**: Stall timer rarely fires. Consider increasing the interval or reducing max notifications.
+   - **Medium servers (5–15s)**: The default 10s/3-max works well. The first notification arrives before most users lose patience.
+   - **Slow servers (15–60s+)**: Consider shorter intervals (e.g. 8s) or more notifications (e.g. 5) to keep the user engaged. However, note that MCP calls **cannot be cancelled** — the notifications are status updates, not actionable options.
+
+Together, these two layers ensure continuous feedback: the announcement handles seconds 0–5, and the stall timer covers 10s+ with periodic reassurance.
+
+### Batched Response After Tool Completion
+
+When the model makes multiple MCP calls in a single turn (common with search-heavy servers), this quickstart waits for **all calls to complete** before generating a response. This prevents partial results from being spoken prematurely and avoids the model making additional tool calls based on incomplete data.
+
+For approval-required servers, once the user approves the first call, subsequent calls to the **same server within the same turn are auto-approved** — avoiding repeated voice prompts for what is logically a single task.
 
 ### Barge-In During MCP Calls
 
-Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message so the model can acknowledge the user and reassure them that results are on the way. Note: since MCP calls cannot be cancelled, the assistant cannot actually skip or abort a running tool call.
+Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message so the model can acknowledge the user and respond to what they said. If the original MCP call completes later, its result is introduced as a **late result** (e.g. *"By the way, those results from earlier just came in..."*). Note: since MCP calls cannot be cancelled, the call continues running in the background regardless of what the user says.
 
 ### Response Collision Handling
 

--- a/javascript/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/README.md
@@ -10,7 +10,7 @@ Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-r
 - **Voice-Based Approval**: Instead of blocking on a console prompt, the assistant verbally asks *"Do you approve?"* and interprets the user's spoken *yes* or *no*
 - **Context-Aware Repeat Approvals**: When the model needs additional searches, the prompt changes to *"I need one more search. Should I continue?"*
 - **MCP Tool Announcements**: For auto-approved tools, the assistant says a brief acknowledgement while the call runs
-- **Barge-In Handling**: Interrupting during an MCP call triggers a *"Do you want to keep waiting or skip?"* inquiry
+- **Barge-In Handling**: Interrupting during an MCP call prompts the assistant to acknowledge and reassure the user
 - **MCP Stall Detection**: If a tool call takes >15 seconds, the assistant proactively tells the user it's still waiting
 
 ## Voice UX Considerations for MCP Integration
@@ -57,11 +57,11 @@ MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the a
 
 1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
 2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers generates natural filler. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline). The transcription model is also selected per pipeline: `azure-speech` for non-realtime, `whisper-1` for realtime.
-3. **Stall detection** (client-side, repeating 15s timer): Notifies the user every 15 seconds while an MCP call is running. After 30 seconds, offers the user a choice to keep waiting or move on.
+3. **Stall detection** (client-side, repeating 15s timer): Notifies the user up to 3 times that results are still pending. Note: MCP calls **cannot be cancelled** via the API — the call runs until the MCP server responds or the server-side timeout fires.
 
 ### Barge-In During MCP Calls
 
-Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message asking the model to check: *"Do you want to keep waiting or skip?"* The model handles the conversation naturally from there.
+Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message so the model can acknowledge the user and reassure them that results are on the way. Note: since MCP calls cannot be cancelled, the assistant cannot actually skip or abort a running tool call.
 
 ### Response Collision Handling
 

--- a/javascript/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/README.md
@@ -2,7 +2,62 @@
 
 This sample demonstrates **MCP (Model Context Protocol) server integration** with Voice Live using the Azure AI Voice Live SDK for JavaScript (Node.js).
 
-Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-realtime`) — but additionally configures remote MCP servers as tools, enabling the assistant to call external services (DeepWiki, Azure Docs) during the conversation and prompting the user for approval when required.
+Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-realtime`) — but additionally configures remote MCP servers as tools, enabling the assistant to call external services (DeepWiki, Azure Docs) during the conversation. It implements a **voice-based approval flow** where the assistant verbally asks the user for permission before using tools that require consent.
+
+## What Makes This Sample Unique
+
+- **MCP Server Integration**: Configure remote MCP servers as session tools via raw tool objects
+- **Voice-Based Approval**: Instead of blocking on a console prompt, the assistant verbally asks *"Do you approve?"* and interprets the user's spoken *yes* or *no*
+- **Context-Aware Repeat Approvals**: When the model needs additional searches, the prompt changes to *"I need one more search. Should I continue?"*
+- **MCP Tool Announcements**: For auto-approved tools, the assistant says a brief acknowledgement while the call runs
+- **Barge-In Handling**: Interrupting during an MCP call triggers a *"Do you want to keep waiting or skip?"* inquiry
+- **MCP Stall Detection**: If a tool call takes >15 seconds, the assistant proactively tells the user it's still waiting
+
+## Voice UX Considerations for MCP Integration
+
+Integrating MCP servers into a voice assistant introduces unique UX challenges that don't exist in text-based or console-based MCP clients. This quickstart demonstrates patterns to address them. When building your own voice-enabled MCP application, consider the following:
+
+### Tool Approval Must Be Voice-Native
+
+Console-based MCP samples typically use blocking `input()` or `readline` for approval — fine for a terminal demo, but it freezes the audio pipeline and breaks the voice experience. In a voice UX, approvals should be handled conversationally:
+
+- Inject a system message instructing the model to **verbally ask for permission**
+- Parse the user's spoken response for clear intent (`yes`, `no`, `stop`, `cancel`)
+- Allow **barge-in** — the user should be able to say "yes" without waiting for the full approval prompt to finish
+
+This quickstart uses word-boundary regex (`\byes\b`, `\b(no|stop|cancel)\b`) to avoid false positives from words like "yesterday" or "nobody".
+
+### System Instructions Must Teach the Model About Approval
+
+The model needs explicit instructions about the approval flow. Without them, it may paraphrase the permission request into a generic *"Let me look that up"* — skipping the actual question. This quickstart includes in the system prompt:
+
+> *"Some tools require user approval. When you receive a system message asking you to request permission, you MUST clearly ask the user for their explicit approval. Never skip the approval question or assume permission is granted."*
+
+The per-request system messages use `"Say exactly:"` phrasing to prevent the model from rewording the question.
+
+### Repeated Tool Calls Need Contextual Messaging
+
+MCP servers like Azure Docs may require multiple searches to gather complete information. Each search triggers a separate approval if `require_approval: "always"`. Rather than asking the identical question each time, this quickstart tracks the call count per server:
+
+- **First call**: *"I'd like to search the azure_doc service. Do you approve?"*
+- **Subsequent calls**: *"I need one more search for complete information. Should I continue?"*
+
+The counter resets when results are fully delivered or the user denies a request.
+
+### Silence During Tool Calls Must Be Filled
+
+MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses two layers:
+
+1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
+2. **Stall detection** (client-side, 15s timer): If the MCP call takes >15 seconds, the assistant proactively says *"Still waiting for results..."*.
+
+### Barge-In During MCP Calls
+
+Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message asking the model to check: *"Do you want to keep waiting or skip?"* The model handles the conversation naturally from there.
+
+### Response Collision Handling
+
+MCP flows generate rapid event sequences where `response.create` calls can collide with active responses. This quickstart defers collisions to the next `onResponseDone` event via a flag, ensuring tool results and approval prompts are never silently dropped.
 
 ## Prerequisites
 
@@ -33,9 +88,6 @@ AZURE_VOICELIVE_ENDPOINT=https://<your-endpoint>.services.ai.azure.com/
 AZURE_VOICELIVE_API_KEY=<your-api-key>
 AZURE_VOICELIVE_MODEL=gpt-realtime
 AZURE_VOICELIVE_VOICE=en-US-Ava:DragonHDLatestNeural
-AZURE_VOICELIVE_INSTRUCTIONS=You are a helpful AI assistant with access to MCP tools. Use the tools to help answer user questions. Respond naturally and conversationally.
-# Optional (Windows/SoX): explicit microphone device name
-# AUDIO_INPUT_DEVICE=Microphone
 ```
 
 ## Run
@@ -70,24 +122,12 @@ node mcp-quickstart.js --no-audio
 - `--use-token-credential`: Use `DefaultAzureCredential` instead of API key
 - `--no-audio`: Connect and configure session without mic/speaker (for smoke tests)
 
-## What This Sample Demonstrates
+## Sample Trigger Phrases
 
-- Direct model session with MCP servers added to the tools list
-- Session configuration for:
-  - text + audio modalities
-  - PCM16 input/output audio
-  - server VAD turn detection
-  - echo cancellation + noise reduction
-  - input audio transcription (`azure-speech`)
-- **MCP-specific features:**
-  - Defining MCP servers with `type: "mcp"` in the tools array
-  - `require_approval: "never"` vs `"always"` per server
-  - `allowed_tools` to restrict which tools are exposed
-  - MCP tool discovery events (`onMcpListToolsCompleted` / `onMcpListToolsFailed`)
-  - MCP tool call events (`onResponseMcpCallInProgress` / `onResponseMcpCallCompleted` / `onResponseMcpCallFailed`)
-  - Interactive approval flow for `mcp_approval_request` conversation items
-- Real-time microphone streaming and speaker playback
-- Barge-in handling (`response.cancel` when user interrupts)
+| Say this | MCP Server | Approval | What happens |
+|---|---|---|---|
+| *"Can you summarize the GitHub repo azure-sdk-for-python?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
+| *"Search the Azure documentation for Voice Live API"* | Azure Docs | Voice prompt (`always`) | Assistant asks *"Do you approve?"*, waits for your *yes* or *no* |
 
 ## Troubleshooting
 
@@ -96,9 +136,9 @@ node mcp-quickstart.js --no-audio
 | Missing endpoint/authentication error | Verify `.env` values or pass CLI arguments. |
 | SoX not found / microphone errors | Ensure SoX is installed and on your `PATH`. |
 | `Audio dependencies are unavailable` | Install Visual Studio Build Tools with **Desktop development with C++**, then reinstall (`npm install --include=optional`). |
-| Authentication errors with token credential | Run `az login` and verify resource access. |
 | MCP tool discovery failed | Check that MCP server URLs are reachable from your network. |
-| Approval prompt not appearing | Only servers with `require_approval: "always"` trigger the prompt. |
+| Repeated approval prompts | Expected — the model may need multiple searches. Say *"no"* or *"stop"* to deny. |
+| Session hit maximum duration | VoiceLive sessions have a 30-minute limit. Restart the sample. |
 | `ERR_USE_AFTER_CLOSE` during shutdown | This can occur during Ctrl+C and is treated as a normal shutdown. |
 
 ## Additional Resources

--- a/javascript/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/README.md
@@ -134,7 +134,7 @@ node mcp-quickstart.js --no-audio
 
 | Say this | MCP Server | Approval | What happens |
 |---|---|---|---|
-| *"Can you summarize the GitHub repo azure-sdk-for-python?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
+| *"What is the GitHub repo fastapi about?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
 | *"Search the Azure documentation for Voice Live API"* | Azure Docs | Voice prompt (`always`) | Assistant asks *"Do you approve?"*, waits for your *yes* or *no* |
 
 ## Troubleshooting

--- a/javascript/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/README.md
@@ -1,0 +1,109 @@
+# JavaScript – MCP Quickstart
+
+This sample demonstrates **MCP (Model Context Protocol) server integration** with Voice Live using the Azure AI Voice Live SDK for JavaScript (Node.js).
+
+Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-realtime`) — but additionally configures remote MCP servers as tools, enabling the assistant to call external services (DeepWiki, Azure Docs) during the conversation and prompting the user for approval when required.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 18 or later
+- A working microphone and speakers
+- [SoX](http://sox.sourceforge.net/) installed and available on your `PATH` (used by `node-record-lpcm16`)
+  - **Windows**: Download from the SoX website or install with `choco install sox`
+  - **macOS**: `brew install sox`
+  - **Linux**: `sudo apt-get install sox`
+- Voice Live endpoint and either:
+  - API key authentication, or
+  - Azure CLI authentication (`az login`) for `DefaultAzureCredential`
+
+## Setup
+
+- **Install dependencies**:
+
+```bash
+npm install
+```
+
+If native audio modules cannot compile in your environment, you can still run a cloud connectivity smoke test with `--no-audio`. For automated Windows setup (Node.js, SoX, Build Tools), see the [helper scripts](../helper-scripts/).
+
+- **Create a `.env` file** in this folder:
+
+```plaintext
+AZURE_VOICELIVE_ENDPOINT=https://<your-endpoint>.services.ai.azure.com/
+AZURE_VOICELIVE_API_KEY=<your-api-key>
+AZURE_VOICELIVE_MODEL=gpt-realtime
+AZURE_VOICELIVE_VOICE=en-US-Ava:DragonHDLatestNeural
+AZURE_VOICELIVE_INSTRUCTIONS=You are a helpful AI assistant with access to MCP tools. Use the tools to help answer user questions. Respond naturally and conversationally.
+# Optional (Windows/SoX): explicit microphone device name
+# AUDIO_INPUT_DEVICE=Microphone
+```
+
+## Run
+
+### API key authentication
+
+```bash
+node mcp-quickstart.js
+```
+
+### Azure credential authentication
+
+```bash
+az login
+node mcp-quickstart.js --use-token-credential
+```
+
+### Smoke test without local audio devices/build tools
+
+```bash
+node mcp-quickstart.js --no-audio
+```
+
+## Command Line Options
+
+- `--api-key`: Azure Voice Live API key
+- `--endpoint`: Azure Voice Live endpoint URL
+- `--model`: Voice Live model to use (default: `gpt-realtime`)
+- `--voice`: Voice for the assistant (default: `en-US-Ava:DragonHDLatestNeural`)
+- `--instructions`: System instructions for the model session
+- `--audio-input-device`: Explicit SoX input device name (use when default device is not configured)
+- `--use-token-credential`: Use `DefaultAzureCredential` instead of API key
+- `--no-audio`: Connect and configure session without mic/speaker (for smoke tests)
+
+## What This Sample Demonstrates
+
+- Direct model session with MCP servers added to the tools list
+- Session configuration for:
+  - text + audio modalities
+  - PCM16 input/output audio
+  - server VAD turn detection
+  - echo cancellation + noise reduction
+  - input audio transcription (`azure-speech`)
+- **MCP-specific features:**
+  - Defining MCP servers with `type: "mcp"` in the tools array
+  - `require_approval: "never"` vs `"always"` per server
+  - `allowed_tools` to restrict which tools are exposed
+  - MCP tool discovery events (`onMcpListToolsCompleted` / `onMcpListToolsFailed`)
+  - MCP tool call events (`onResponseMcpCallInProgress` / `onResponseMcpCallCompleted` / `onResponseMcpCallFailed`)
+  - Interactive approval flow for `mcp_approval_request` conversation items
+- Real-time microphone streaming and speaker playback
+- Barge-in handling (`response.cancel` when user interrupts)
+
+## Troubleshooting
+
+| Symptom | Resolution |
+| --- | --- |
+| Missing endpoint/authentication error | Verify `.env` values or pass CLI arguments. |
+| SoX not found / microphone errors | Ensure SoX is installed and on your `PATH`. |
+| `Audio dependencies are unavailable` | Install Visual Studio Build Tools with **Desktop development with C++**, then reinstall (`npm install --include=optional`). |
+| Authentication errors with token credential | Run `az login` and verify resource access. |
+| MCP tool discovery failed | Check that MCP server URLs are reachable from your network. |
+| Approval prompt not appearing | Only servers with `require_approval: "always"` trigger the prompt. |
+| `ERR_USE_AFTER_CLOSE` during shutdown | This can occur during Ctrl+C and is treated as a normal shutdown. |
+
+## Additional Resources
+
+- [Voice Live Documentation](https://learn.microsoft.com/azure/ai-services/speech-service/voice-live)
+- [JavaScript SDK Documentation](https://learn.microsoft.com/javascript/api/overview/azure/ai-voicelive-readme)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [Support Guide](../../../SUPPORT.md)

--- a/javascript/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/README.md
@@ -15,7 +15,13 @@ Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-r
 
 ## Voice UX Considerations for MCP Integration
 
-Integrating MCP servers into a voice assistant introduces unique UX challenges that don't exist in text-based or console-based MCP clients. This quickstart demonstrates patterns to address them. When building your own voice-enabled MCP application, consider the following:
+Integrating MCP servers into a voice assistant introduces unique UX challenges that don't exist in text-based or console-based MCP clients.
+
+MCP servers can be configured with different approval policies:
+- **`require_approval: "never"`** — tool calls proceed automatically (e.g., DeepWiki in this sample)
+- **`require_approval: "always"`** — every tool call requires explicit user consent before execution (e.g., Azure Docs in this sample)
+
+In a text-based client, approval is typically a simple `y/n` console prompt. In a voice UX, this needs to be handled conversationally — and several additional challenges arise around latency, silence, and repeated calls. This quickstart demonstrates patterns to address them:
 
 ### Tool Approval Must Be Voice-Native
 
@@ -37,19 +43,21 @@ The per-request system messages use `"Say exactly:"` phrasing to prevent the mod
 
 ### Repeated Tool Calls Need Contextual Messaging
 
-MCP servers like Azure Docs may require multiple searches to gather complete information. Each search triggers a separate approval if `require_approval: "always"`. Rather than asking the identical question each time, this quickstart tracks the call count per server:
+MCP servers may require multiple searches to gather complete information. Each search triggers a separate approval if `require_approval="always"`. Rather than asking the identical question each time, this quickstart tracks the call count per server:
 
 - **First call**: *"I'd like to search the azure_doc service. Do you approve?"*
 - **Subsequent calls**: *"I need one more search for complete information. Should I continue?"*
+- **After 3 approved calls**: Auto-denied to prevent infinite loops — the model responds with what it has
 
 The counter resets when results are fully delivered or the user denies a request.
 
 ### Silence During Tool Calls Must Be Filled
 
-MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses two layers:
+MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses three layers:
 
 1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
-2. **Stall detection** (client-side, 15s timer): If the MCP call takes >15 seconds, the assistant proactively says *"Still waiting for results..."*.
+2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers generates natural filler. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline). The transcription model is also selected per pipeline: `azure-speech` for non-realtime, `whisper-1` for realtime.
+3. **Stall detection** (client-side, repeating 15s timer): Notifies the user every 15 seconds while an MCP call is running. After 30 seconds, offers the user a choice to keep waiting or move on.
 
 ### Barge-In During MCP Calls
 

--- a/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
@@ -391,7 +391,7 @@ class MCPVoiceAssistant {
 
         if (this._mcpCallInProgress > 0 && this._pendingApproval === null) {
           try {
-            await session.addConversationItem({ type: "message", role: "system", content: [{ type: "input_text", text: "A tool call is still running. The user just interrupted. Briefly ask them: do you want to keep waiting for the result, or skip it and move on? Keep it short." }] });
+            await session.addConversationItem({ type: "message", role: "system", content: [{ type: "input_text", text: "A tool call is still running. The user just spoke. Briefly acknowledge them and let them know you're still waiting for results. One short sentence." }] });
           } catch {}
         }
       },
@@ -644,15 +644,19 @@ class MCPVoiceAssistant {
   _startMcpStallTimer(session) {
     this._cancelMcpStallTimer();
     let stallCount = 0;
+    const MCP_STALL_MAX_NOTIFICATIONS = 3;
     this._mcpStallTimer = setInterval(async () => {
       if (this._mcpCallInProgress <= 0) {
         this._cancelMcpStallTimer();
         return;
       }
       stallCount++;
-      const msg = stallCount === 1
-        ? "The tool call is taking longer than expected. Briefly let the user know you're still waiting for results."
-        : "The tool call is taking very long. Ask the user: would you like to keep waiting, or should I move on and answer with what I know? Keep it short.";
+      if (stallCount > MCP_STALL_MAX_NOTIFICATIONS) {
+        this._cancelMcpStallTimer();
+        return;
+      }
+      // MCP calls cannot be cancelled — only honest status updates are possible.
+      const msg = "The tool call is still running. Briefly reassure the user that you're still waiting for results. One short sentence only.";
       try {
         await session.addConversationItem({ type: "message", role: "system", content: [{ type: "input_text", text: msg }] });
         await session.sendEvent({ type: "response.create" });

--- a/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
@@ -1,0 +1,653 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import "dotenv/config";
+import { VoiceLiveClient } from "@azure/ai-voicelive";
+import { AzureKeyCredential } from "@azure/core-auth";
+import { DefaultAzureCredential } from "@azure/identity";
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+
+function printUsage() {
+  console.log("Usage: node mcp-quickstart.js [options]");
+  console.log("");
+  console.log("Options:");
+  console.log("  --api-key <key>             VoiceLive API key");
+  console.log("  --endpoint <url>            VoiceLive endpoint URL");
+  console.log("  --model <name>              Model to use (default: gpt-realtime)");
+  console.log(
+    "  --voice <name>              Voice (default: en-US-Ava:DragonHDLatestNeural)",
+  );
+  console.log("  --instructions <text>       System instructions for the assistant");
+  console.log("  --audio-input-device <name> Explicit SoX input device name (Windows)");
+  console.log("  --use-token-credential      Use Azure credential instead of API key");
+  console.log("  --no-audio                  Connect and configure session without mic/speaker");
+  console.log("  -h, --help                  Show this help text");
+}
+
+function parseArguments(argv) {
+  const parsed = {
+    apiKey: process.env.AZURE_VOICELIVE_API_KEY,
+    endpoint: process.env.AZURE_VOICELIVE_ENDPOINT,
+    model: process.env.AZURE_VOICELIVE_MODEL ?? "gpt-realtime",
+    voice:
+      process.env.AZURE_VOICELIVE_VOICE ?? "en-US-Ava:DragonHDLatestNeural",
+    instructions:
+      process.env.AZURE_VOICELIVE_INSTRUCTIONS ??
+      "You are a helpful AI assistant with access to MCP tools. Use the tools to help answer user questions. Respond naturally and conversationally.",
+    audioInputDevice: process.env.AUDIO_INPUT_DEVICE,
+    useTokenCredential: false,
+    noAudio: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--api-key":
+        parsed.apiKey = argv[++i];
+        break;
+      case "--endpoint":
+        parsed.endpoint = argv[++i];
+        break;
+      case "--model":
+        parsed.model = argv[++i];
+        break;
+      case "--voice":
+        parsed.voice = argv[++i];
+        break;
+      case "--instructions":
+        parsed.instructions = argv[++i];
+        break;
+      case "--audio-input-device":
+        parsed.audioInputDevice = argv[++i];
+        break;
+      case "--use-token-credential":
+        parsed.useTokenCredential = true;
+        break;
+      case "--no-audio":
+        parsed.noAudio = true;
+        break;
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        break;
+      default:
+        if (arg?.startsWith("-")) {
+          throw new Error(`Unknown option: ${arg}`);
+        }
+        break;
+    }
+  }
+
+  return parsed;
+}
+
+function resolveVoiceConfig(voiceName) {
+  const looksLikeAzureVoice = voiceName.includes("-") || voiceName.includes(":");
+  if (looksLikeAzureVoice) {
+    return { type: "azure-standard", name: voiceName };
+  }
+  return { type: "openai", name: voiceName };
+}
+
+class AudioProcessor {
+  constructor(enableAudio = true, inputDevice = undefined) {
+    this._enableAudio = enableAudio;
+    this._inputDevice = inputDevice;
+    this._recorder = null;
+    this._soxProcess = null;
+    this._speaker = null;
+    this._skipSeq = 0;
+    this._nextSeq = 0;
+    this._recordModule = null;
+    this._speakerCtor = null;
+  }
+
+  async _ensureAudioModulesLoaded() {
+    if (!this._enableAudio) return;
+    if (this._recordModule && this._speakerCtor) return;
+
+    try {
+      const recordModule = await import("node-record-lpcm16");
+      const speakerModule = await import("speaker");
+      this._recordModule = recordModule.default;
+      this._speakerCtor = speakerModule.default;
+    } catch {
+      throw new Error(
+        "Audio dependencies are unavailable. Install optional packages (node-record-lpcm16, speaker) " +
+        "and required native build tools, or run with --no-audio for connectivity-only validation.",
+      );
+    }
+  }
+
+  async startCapture(session) {
+    if (!this._enableAudio) {
+      console.log("[audio] --no-audio enabled: microphone capture skipped");
+      return;
+    }
+    if (this._recorder || this._soxProcess) return;
+
+    if (this._inputDevice) {
+      console.log(`[audio] Using explicit input device: ${this._inputDevice}`);
+
+      const soxArgs = [
+        "-q", "-t", "waveaudio", this._inputDevice,
+        "-r", "24000", "-c", "1", "-e", "signed-integer", "-b", "16",
+        "-t", "raw", "-",
+      ];
+
+      this._soxProcess = spawn("sox", soxArgs, {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      this._soxProcess.stdout.on("data", (chunk) => {
+        if (session.isConnected) {
+          session.sendAudio(new Uint8Array(chunk)).catch(() => {});
+        }
+      });
+
+      this._soxProcess.stderr.on("data", (data) => {
+        const msg = data.toString().trim();
+        if (msg) console.error(`[audio] sox stderr: ${msg}`);
+      });
+
+      this._soxProcess.on("error", (error) => {
+        console.error(`[audio] SoX process error: ${error?.message ?? error}`);
+      });
+
+      this._soxProcess.on("close", (code) => {
+        if (code !== 0) console.error(`[audio] SoX exited with code ${code}`);
+        this._soxProcess = null;
+      });
+
+      console.log("[audio] Microphone capture started");
+      return;
+    }
+
+    await this._ensureAudioModulesLoaded();
+
+    const recorderOptions = {
+      sampleRate: 24000,
+      channels: 1,
+      audioType: "raw",
+      recorder: "sox",
+      encoding: "signed-integer",
+      bitwidth: 16,
+    };
+
+    this._recorder = this._recordModule.record(recorderOptions);
+    const recorderStream = this._recorder.stream();
+
+    recorderStream.on("data", (chunk) => {
+      if (session.isConnected) {
+        session.sendAudio(new Uint8Array(chunk)).catch(() => {});
+      }
+    });
+
+    recorderStream.on("error", (error) => {
+      console.error(`[audio] Recorder stream error: ${error?.message ?? error}`);
+    });
+
+    console.log("[audio] Microphone capture started");
+  }
+
+  async startPlayback() {
+    if (!this._enableAudio) {
+      console.log("[audio] --no-audio enabled: speaker playback skipped");
+      return;
+    }
+    if (this._speaker) return;
+    await this._resetSpeaker();
+    console.log("[audio] Playback ready");
+  }
+
+  queueAudio(base64Delta) {
+    const seq = this._nextSeq++;
+    if (seq < this._skipSeq) return;
+    const chunk = Buffer.from(base64Delta, "base64");
+    if (this._speaker && !this._speaker.destroyed) {
+      this._speaker.write(chunk);
+    }
+  }
+
+  skipPendingAudio() {
+    if (!this._enableAudio) return;
+    this._skipSeq = this._nextSeq++;
+    this._resetSpeaker().catch(() => {});
+  }
+
+  shutdown() {
+    if (this._soxProcess) {
+      try { this._soxProcess.kill(); } catch { /* no-op */ }
+      this._soxProcess = null;
+    }
+    if (this._recorder) {
+      this._recorder.stop();
+      this._recorder = null;
+    }
+    if (this._speaker) {
+      this._speaker.end();
+      this._speaker = null;
+    }
+    console.log("[audio] Audio processor shut down");
+  }
+
+  async _resetSpeaker() {
+    await this._ensureAudioModulesLoaded();
+    if (this._speaker && !this._speaker.destroyed) {
+      try { this._speaker.end(); } catch { /* no-op */ }
+    }
+    this._speaker = new this._speakerCtor({
+      channels: 1,
+      bitDepth: 16,
+      sampleRate: 24000,
+      signed: true,
+    });
+    this._speaker.on("error", () => {});
+  }
+}
+
+// <define_mcp_servers>
+/**
+ * Define MCP servers that Voice Live can use during the session.
+ * Each server is an MCPTool object added to the session tools array.
+ */
+function defineMCPServers() {
+  return [
+    {
+      type: "mcp",
+      server_label: "deepwiki",
+      server_url: "https://mcp.deepwiki.com/mcp",
+      allowed_tools: ["read_wiki_structure", "ask_question"],
+      require_approval: "never",
+    },
+    {
+      type: "mcp",
+      server_label: "azure_doc",
+      server_url: "https://learn.microsoft.com/api/mcp",
+      require_approval: "always",
+    },
+  ];
+}
+// </define_mcp_servers>
+
+class MCPVoiceAssistant {
+  constructor(options) {
+    this.endpoint = options.endpoint;
+    this.credential = options.credential;
+    this.model = options.model;
+    this.voice = options.voice;
+    this.instructions = options.instructions;
+    this.audioInputDevice = options.audioInputDevice;
+    this.noAudio = options.noAudio;
+
+    this._session = null;
+    this._subscription = null;
+    this._audio = new AudioProcessor(!options.noAudio, options.audioInputDevice);
+    this._activeResponse = false;
+    this._responseApiDone = false;
+    this._rl = null;
+  }
+
+  // <configure_session>
+  /**
+   * Configure the session with MCP servers in the tools list.
+   */
+  async _setupSession() {
+    console.log("[session] Configuring session with MCP tools...");
+
+    const mcpServers = defineMCPServers();
+
+    await this._session.updateSession({
+      model: this.model,
+      modalities: ["text", "audio"],
+      instructions: this.instructions,
+      voice: resolveVoiceConfig(this.voice),
+      inputAudioFormat: "pcm16",
+      outputAudioFormat: "pcm16",
+      turnDetection: {
+        type: "server_vad",
+        threshold: 0.5,
+        prefixPaddingInMs: 300,
+        silenceDurationInMs: 500,
+      },
+      inputAudioEchoCancellation: { type: "server_echo_cancellation" },
+      inputAudioNoiseReduction: { type: "azure_deep_noise_suppression" },
+      inputAudioTranscription: { model: "azure-speech" },
+      tools: mcpServers,
+    });
+
+    console.log("[session] Session configuration with MCP tools sent");
+  }
+  // </configure_session>
+
+  // <handle_mcp_events>
+  /**
+   * Subscribe to session events, including MCP-specific events.
+   */
+  _subscribeToEvents(session) {
+    this._subscription = session.subscribe({
+      onSessionUpdated: async (event, context) => {
+        const s = event.session;
+        const model = s?.model;
+        const voice = s?.voice;
+        console.log(`[session] Session ready: ${context.sessionId}`);
+        console.log(
+          `  Model: ${typeof model === "string" ? model : model?.toString?.() ?? ""}`,
+        );
+        console.log(`  Voice: ${voice?.name ?? ""}`);
+      },
+
+      onConversationItemInputAudioTranscriptionCompleted: async (event) => {
+        const transcript = event.transcript ?? "";
+        console.log(`👤 You said:\t${transcript}`);
+      },
+
+      onResponseTextDone: async (event) => {
+        const text = event.text ?? "";
+        console.log(`🤖 Assistant text:\t${text}`);
+      },
+
+      onResponseAudioTranscriptDone: async (event) => {
+        const transcript = event.transcript ?? "";
+        console.log(`🤖 Assistant audio transcript:\t${transcript}`);
+      },
+
+      onInputAudioBufferSpeechStarted: async () => {
+        console.log("🎤 Listening...");
+        this._audio.skipPendingAudio();
+
+        if (this._activeResponse && !this._responseApiDone) {
+          try {
+            await session.sendEvent({ type: "response.cancel" });
+          } catch (err) {
+            const msg = err?.message ?? "";
+            if (!msg.toLowerCase().includes("no active response")) {
+              console.warn("[barge-in] Cancel failed:", msg);
+            }
+          }
+        }
+      },
+
+      onInputAudioBufferSpeechStopped: async () => {
+        console.log("🤔 Processing...");
+      },
+
+      onResponseCreated: async () => {
+        this._activeResponse = true;
+        this._responseApiDone = false;
+      },
+
+      onResponseAudioDelta: async (event) => {
+        if (event.delta) {
+          this._audio.queueAudio(event.delta);
+        }
+      },
+
+      onResponseAudioDone: async () => {
+        console.log("🎤 Ready for next input...");
+      },
+
+      onResponseDone: async () => {
+        console.log("✅ Response complete");
+        this._activeResponse = false;
+        this._responseApiDone = true;
+      },
+
+      onServerError: async (event) => {
+        const msg = event.error?.message ?? "";
+        if (msg.includes("Cancellation failed: no active response")) return;
+        console.error(`❌ VoiceLive error: ${msg}`);
+      },
+
+      // MCP-specific event handlers
+      onMcpListToolsCompleted: async (event) => {
+        const serverLabel = event.server_label ?? "unknown";
+        console.log(`🔧 MCP tools discovered for server "${serverLabel}"`);
+      },
+
+      onMcpListToolsFailed: async (event) => {
+        const serverLabel = event.server_label ?? "unknown";
+        console.error(`❌ MCP tool discovery failed for server "${serverLabel}"`);
+      },
+
+      onResponseMcpCallInProgress: async (event) => {
+        console.log("⏳ MCP tool call in progress...");
+      },
+
+      onResponseMcpCallArgumentsDone: async (event) => {
+        const name = event.name ?? "";
+        console.log(`📋 MCP tool call arguments ready: ${name}`);
+      },
+
+      onResponseMcpCallCompleted: async (event) => {
+        console.log("✅ MCP tool call completed");
+      },
+
+      onResponseMcpCallFailed: async (event) => {
+        console.error("❌ MCP tool call failed");
+      },
+
+      onConversationItemCreated: async (event) => {
+        const item = event.item;
+        if (item?.type === "mcp_approval_request") {
+          await this._handleApprovalRequest(item, session);
+        }
+      },
+    });
+  }
+  // </handle_mcp_events>
+
+  // <handle_approval>
+  /**
+   * Handle MCP approval requests by prompting the user in the console.
+   */
+  async _handleApprovalRequest(item, session) {
+    const approvalId = item.id ?? "unknown";
+    const serverLabel = item.server_label ?? "unknown";
+    const toolName = item.name ?? "unknown";
+
+    console.log();
+    console.log("🔐 MCP Approval Request");
+    console.log(`   Server: ${serverLabel}`);
+    console.log(`   Tool: ${toolName}`);
+    console.log(`   Approval ID: ${approvalId}`);
+
+    const approved = await this._promptForApproval();
+
+    console.log(`   Response: ${approved ? "Approved ✅" : "Denied ❌"}`);
+
+    try {
+      await session.sendEvent({
+        type: "conversation.item.create",
+        item: {
+          type: "mcp_approval_response",
+          approval_request_id: approvalId,
+          approve: approved,
+        },
+      });
+      await session.sendEvent({ type: "response.create" });
+    } catch (err) {
+      console.error("❌ Failed to send approval response:", err.message);
+    }
+  }
+
+  async _promptForApproval() {
+    if (!this._rl) {
+      this._rl = createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+    }
+
+    return new Promise((resolve) => {
+      const ask = () => {
+        this._rl.question("   Approve MCP call? (y/n): ", (answer) => {
+          const input = answer.trim().toLowerCase();
+          if (input === "y") { resolve(true); return; }
+          if (input === "n") { resolve(false); return; }
+          console.log("   Invalid input. Please type 'y' or 'n'.");
+          ask();
+        });
+      };
+      ask();
+    });
+  }
+  // </handle_approval>
+
+  async start() {
+    const client = new VoiceLiveClient(this.endpoint, this.credential, {
+      apiVersion: "2026-01-01-preview",
+    });
+    const session = client.createSession({ model: this.model });
+    this._session = session;
+
+    console.log(
+      `[init] Connecting to VoiceLive with model "${this.model}" at "${this.endpoint}" ...`,
+    );
+
+    this._subscribeToEvents(session);
+
+    await session.connect();
+    console.log("[init] Connected to VoiceLive session websocket");
+
+    await this._setupSession();
+
+    await this._audio.startPlayback();
+    await this._audio.startCapture(session);
+
+    console.log("\n" + "=".repeat(70));
+    console.log("🎤 VOICE ASSISTANT WITH MCP READY");
+    console.log("Try saying:");
+    console.log('  • "Can you summarize the GitHub repo azure-sdk-for-java?"');
+    console.log('  • "Search the Azure documentation for Voice Live API."');
+    console.log("You may need to approve some MCP tool calls in the console.");
+    console.log("Press Ctrl+C to exit");
+    console.log("=".repeat(70) + "\n");
+
+    if (this.noAudio) {
+      setTimeout(() => {
+        process.emit("SIGINT");
+      }, 6000);
+    }
+
+    await new Promise((resolve) => {
+      const onSignal = () => resolve();
+      process.once("SIGINT", onSignal);
+      process.once("SIGTERM", onSignal);
+
+      const poll = setInterval(() => {
+        if (!session.isConnected) {
+          clearInterval(poll);
+          resolve();
+        }
+      }, 500);
+    });
+
+    await this.shutdown();
+  }
+
+  async shutdown() {
+    if (this._rl) {
+      this._rl.close();
+      this._rl = null;
+    }
+
+    if (this._subscription) {
+      await this._subscription.close();
+      this._subscription = null;
+    }
+
+    if (this._session) {
+      try {
+        await this._session.disconnect();
+      } catch {
+        // ignore disconnect errors during shutdown
+      }
+
+      this._audio.shutdown();
+
+      try {
+        await this._session.dispose();
+      } catch {
+        // ignore dispose errors during shutdown
+      }
+
+      this._session = null;
+    }
+  }
+}
+
+async function main() {
+  let args;
+  try {
+    args = parseArguments(process.argv.slice(2));
+  } catch (err) {
+    console.error(`❌ ${err.message}`);
+    printUsage();
+    process.exit(1);
+  }
+
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  if (!args.endpoint) {
+    console.error(
+      "❌ Missing endpoint. Set AZURE_VOICELIVE_ENDPOINT or pass --endpoint.",
+    );
+    process.exit(1);
+  }
+
+  if (!args.apiKey && !args.useTokenCredential) {
+    console.error("❌ No authentication provided.");
+    console.error(
+      "Provide --api-key / AZURE_VOICELIVE_API_KEY or use --use-token-credential.",
+    );
+    process.exit(1);
+  }
+
+  const credential = args.useTokenCredential
+    ? new DefaultAzureCredential()
+    : new AzureKeyCredential(args.apiKey);
+
+  console.log("Configuration:");
+  console.log(`  AZURE_VOICELIVE_ENDPOINT: ${args.endpoint}`);
+  console.log(`  AZURE_VOICELIVE_MODEL: ${args.model}`);
+  console.log(`  AZURE_VOICELIVE_VOICE: ${args.voice}`);
+  console.log(`  AUDIO_INPUT_DEVICE: ${args.audioInputDevice ?? "(not set)"}`);
+  console.log(`  No audio mode: ${args.noAudio ? "enabled" : "disabled"}`);
+  console.log(
+    `  Authentication: ${args.useTokenCredential ? "DefaultAzureCredential" : "API Key"}`,
+  );
+
+  const assistant = new MCPVoiceAssistant({
+    endpoint: args.endpoint,
+    credential,
+    model: args.model,
+    voice: args.voice,
+    instructions: args.instructions,
+    audioInputDevice: args.audioInputDevice,
+    noAudio: args.noAudio,
+  });
+
+  try {
+    await assistant.start();
+  } catch (err) {
+    if (err?.code === "ERR_USE_AFTER_CLOSE") return;
+    console.error("Fatal error:", err);
+    process.exit(1);
+  }
+}
+
+console.log("🎙️  Voice Assistant with MCP - Azure VoiceLive SDK");
+console.log("=".repeat(70));
+main().then(
+  () => console.log("\n👋 Voice assistant shut down. Goodbye!"),
+  (err) => {
+    console.error("Unhandled error:", err);
+    process.exit(1);
+  },
+);

--- a/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
@@ -6,7 +6,6 @@ import { VoiceLiveClient } from "@azure/ai-voicelive";
 import { AzureKeyCredential } from "@azure/core-auth";
 import { DefaultAzureCredential } from "@azure/identity";
 import { spawn } from "node:child_process";
-import { createInterface } from "node:readline";
 
 function printUsage() {
   console.log("Usage: node mcp-quickstart.js [options]");
@@ -34,7 +33,7 @@ function parseArguments(argv) {
       process.env.AZURE_VOICELIVE_VOICE ?? "en-US-Ava:DragonHDLatestNeural",
     instructions:
       process.env.AZURE_VOICELIVE_INSTRUCTIONS ??
-      "You are a helpful AI assistant with access to MCP tools. Use the tools to help answer user questions. Respond naturally and conversationally.",
+      "You are a helpful AI assistant with access to MCP tools. Always respond in English. When a user asks a question, use the appropriate tool once to find information, then summarize the results conversationally. IMPORTANT: Never call the same tool more than once per user question. After receiving a tool result, always respond to the user with what you found — do not search again. Some tools require user approval before they can be used. When you receive a system message asking you to request permission, you MUST clearly ask the user for their explicit approval before proceeding. Always wait for the user to say yes or no. Never skip the approval question or assume permission is granted.",
     audioInputDevice: process.env.AUDIO_INPUT_DEVICE,
     useTokenCredential: false,
     noAudio: false,
@@ -287,7 +286,16 @@ class MCPVoiceAssistant {
     this._audio = new AudioProcessor(!options.noAudio, options.audioInputDevice);
     this._activeResponse = false;
     this._responseApiDone = false;
-    this._rl = null;
+    this._pendingApproval = null;
+    this._approvalQueue = [];
+    this._approvalPromptNeeded = false;
+    this._mcpCallInProgress = 0;
+    this._handledMcpCompletions = new Set();
+    this._needsResponseCreate = false;
+    this._approvalCallCount = {};
+    this._mcpItemToServer = {};
+    this._approvalServers = new Set();
+    this._mcpStallTimer = null;
   }
 
   // <configure_session>
@@ -298,6 +306,10 @@ class MCPVoiceAssistant {
     console.log("[session] Configuring session with MCP tools...");
 
     const mcpServers = defineMCPServers();
+
+    this._approvalServers = new Set(
+      mcpServers.filter(s => s.require_approval === "always").map(s => s.server_label)
+    );
 
     await this._session.updateSession({
       model: this.model,
@@ -342,6 +354,9 @@ class MCPVoiceAssistant {
       onConversationItemInputAudioTranscriptionCompleted: async (event) => {
         const transcript = event.transcript ?? "";
         console.log(`👤 You said:\t${transcript}`);
+        if (this._pendingApproval !== null) {
+          await this._resolveVoiceApproval(transcript, session);
+        }
       },
 
       onResponseTextDone: async (event) => {
@@ -358,6 +373,11 @@ class MCPVoiceAssistant {
         console.log("🎤 Listening...");
         this._audio.skipPendingAudio();
 
+        // Only reset approval counter if no approval pending
+        if (this._pendingApproval === null) {
+          this._approvalCallCount = {};
+        }
+
         if (this._activeResponse && !this._responseApiDone) {
           try {
             await session.sendEvent({ type: "response.cancel" });
@@ -367,6 +387,12 @@ class MCPVoiceAssistant {
               console.warn("[barge-in] Cancel failed:", msg);
             }
           }
+        }
+
+        if (this._mcpCallInProgress > 0 && this._pendingApproval === null) {
+          try {
+            await session.sendEvent({ type: "conversation.item.create", item: { type: "message", role: "system", content: [{ type: "input_text", text: "A tool call is still running. The user just interrupted. Briefly ask them: do you want to keep waiting for the result, or skip it and move on? Keep it short." }] } });
+          } catch {}
         }
       },
 
@@ -393,11 +419,24 @@ class MCPVoiceAssistant {
         console.log("✅ Response complete");
         this._activeResponse = false;
         this._responseApiDone = true;
+
+        if (this._approvalPromptNeeded && this._pendingApproval !== null) {
+          this._approvalPromptNeeded = false;
+          await this._sendApprovalVoicePrompt(session);
+        } else if (this._needsResponseCreate) {
+          this._needsResponseCreate = false;
+          try { await session.sendEvent({ type: "response.create" }); } catch {}
+        }
       },
 
       onServerError: async (event) => {
         const msg = event.error?.message ?? "";
         if (msg.includes("Cancellation failed: no active response")) return;
+        if (msg.toLowerCase().includes("interim response")) {
+          console.log("[session] Interim response not supported (non-fatal)");
+          return;
+        }
+        if (msg.toLowerCase().includes("active response in progress")) return;
         console.error(`❌ VoiceLive error: ${msg}`);
       },
 
@@ -414,6 +453,8 @@ class MCPVoiceAssistant {
 
       onResponseMcpCallInProgress: async (event) => {
         console.log("⏳ MCP tool call in progress...");
+        this._mcpCallInProgress++;
+        this._startMcpStallTimer(session);
       },
 
       onResponseMcpCallArgumentsDone: async (event) => {
@@ -422,15 +463,46 @@ class MCPVoiceAssistant {
       },
 
       onResponseMcpCallCompleted: async (event) => {
+        const itemId = event.item_id ?? "";
+        this._mcpCallInProgress = Math.max(0, this._mcpCallInProgress - 1);
+        this._cancelMcpStallTimer();
+        if (this._handledMcpCompletions.has(itemId)) return;
+        this._handledMcpCompletions.add(itemId);
         console.log("✅ MCP tool call completed");
+        delete this._mcpItemToServer[itemId];
+        if (this._pendingApproval === null && this._approvalQueue.length === 0) {
+          this._approvalCallCount = {};
+        }
+        try {
+          await session.sendEvent({ type: "response.create" });
+        } catch (e) {
+          if (e?.message?.toLowerCase().includes("active response")) {
+            this._needsResponseCreate = true;
+          }
+        }
       },
 
       onResponseMcpCallFailed: async (event) => {
         console.error("❌ MCP tool call failed");
+        this._mcpCallInProgress = Math.max(0, this._mcpCallInProgress - 1);
+        this._cancelMcpStallTimer();
+        try { await session.sendEvent({ type: "response.create" }); } catch {}
       },
 
       onConversationItemCreated: async (event) => {
         const item = event.item;
+        if (item?.type === "mcp_call") {
+          const sl = item.server_label ?? "";
+          const fn = item.name ?? "";
+          this._mcpItemToServer[item.id] = `${sl}/${fn}`;
+          console.log(`🔧 MCP tool call: ${sl}/${fn}`);
+          if (!this._pendingApproval && !this._approvalServers.has(sl)) {
+            try {
+              await session.sendEvent({ type: "conversation.item.create", item: { type: "message", role: "system", content: [{ type: "input_text", text: "Briefly tell the user you're looking something up. One short sentence only." }] } });
+              await session.sendEvent({ type: "response.create" });
+            } catch {}
+          }
+        }
         if (item?.type === "mcp_approval_request") {
           await this._handleApprovalRequest(item, session);
         }
@@ -441,22 +513,87 @@ class MCPVoiceAssistant {
 
   // <handle_approval>
   /**
-   * Handle MCP approval requests by prompting the user in the console.
+   * Handle MCP approval requests via voice-based approval flow.
    */
   async _handleApprovalRequest(item, session) {
     const approvalId = item.id ?? "unknown";
     const serverLabel = item.server_label ?? "unknown";
-    const toolName = item.name ?? "unknown";
+    const functionName = item.name ?? "unknown";
 
     console.log();
     console.log("🔐 MCP Approval Request");
     console.log(`   Server: ${serverLabel}`);
-    console.log(`   Tool: ${toolName}`);
+    console.log(`   Tool: ${functionName}`);
     console.log(`   Approval ID: ${approvalId}`);
 
-    const approved = await this._promptForApproval();
+    if (this._pendingApproval !== null) {
+      this._approvalQueue.push({ approvalId, serverLabel, functionName });
+      console.log("   (queued — another approval is pending)");
+      return;
+    }
 
-    console.log(`   Response: ${approved ? "Approved ✅" : "Denied ❌"}`);
+    this._pendingApproval = { approvalId, serverLabel, functionName };
+
+    if (!this._activeResponse) {
+      await this._sendApprovalVoicePrompt(session);
+    } else {
+      this._approvalPromptNeeded = true;
+    }
+  }
+
+  async _sendApprovalVoicePrompt(session) {
+    const pending = this._pendingApproval;
+    if (!pending) return;
+
+    const server = pending.serverLabel;
+    const count = this._approvalCallCount[server] ?? 0;
+    this._approvalCallCount[server] = count + 1;
+
+    let prompt;
+    if (count === 0) {
+      prompt = `You MUST ask the user for explicit permission before proceeding. Say exactly: "I'd like to search the ${server} service for information. Do you approve? Please say yes or no."`;
+    } else {
+      prompt = `You MUST ask the user for permission again. Say exactly: "I need to do one more search to get complete information. Should I continue? Please say yes or no."`;
+    }
+
+    try {
+      await session.sendEvent({
+        type: "conversation.item.create",
+        item: {
+          type: "message",
+          role: "system",
+          content: [{ type: "input_text", text: prompt }],
+        },
+      });
+      await session.sendEvent({ type: "response.create" });
+    } catch (err) {
+      console.error("❌ Failed to send approval voice prompt:", err?.message ?? err);
+    }
+  }
+
+  async _resolveVoiceApproval(transcript, session) {
+    if (this._pendingApproval === null) return;
+
+    const lower = transcript.toLowerCase();
+    const yesMatch = /\byes\b/.test(lower);
+    const noMatch = /\b(no|stop|cancel)\b/.test(lower);
+
+    if (!yesMatch && !noMatch) {
+      // Ambiguous — will re-prompt at next response.done
+      this._approvalPromptNeeded = true;
+      return;
+    }
+
+    const approved = yesMatch && !noMatch;
+    const { approvalId } = this._pendingApproval;
+
+    console.log(`   Voice response: ${approved ? "Approved ✅" : "Denied ❌"}`);
+
+    this._pendingApproval = null;
+
+    if (!approved) {
+      this._approvalCallCount = {};
+    }
 
     try {
       await session.sendEvent({
@@ -467,34 +604,44 @@ class MCPVoiceAssistant {
           approve: approved,
         },
       });
-      await session.sendEvent({ type: "response.create" });
     } catch (err) {
-      console.error("❌ Failed to send approval response:", err.message);
+      console.error("❌ Failed to send approval response:", err?.message ?? err);
     }
+
+    await this._processNextApproval(session);
   }
 
-  async _promptForApproval() {
-    if (!this._rl) {
-      this._rl = createInterface({
-        input: process.stdin,
-        output: process.stdout,
-      });
-    }
+  async _processNextApproval(session) {
+    if (this._approvalQueue.length === 0) return;
 
-    return new Promise((resolve) => {
-      const ask = () => {
-        this._rl.question("   Approve MCP call? (y/n): ", (answer) => {
-          const input = answer.trim().toLowerCase();
-          if (input === "y") { resolve(true); return; }
-          if (input === "n") { resolve(false); return; }
-          console.log("   Invalid input. Please type 'y' or 'n'.");
-          ask();
-        });
-      };
-      ask();
-    });
+    this._pendingApproval = this._approvalQueue.shift();
+
+    if (!this._activeResponse) {
+      await this._sendApprovalVoicePrompt(session);
+    } else {
+      this._approvalPromptNeeded = true;
+    }
   }
   // </handle_approval>
+
+  _startMcpStallTimer(session) {
+    this._cancelMcpStallTimer();
+    this._mcpStallTimer = setTimeout(async () => {
+      if (this._mcpCallInProgress > 0) {
+        try {
+          await session.sendEvent({ type: "conversation.item.create", item: { type: "message", role: "system", content: [{ type: "input_text", text: "The tool call is taking longer than expected. Briefly let the user know you're still waiting for results." }] } });
+          await session.sendEvent({ type: "response.create" });
+        } catch {}
+      }
+    }, 15000);
+  }
+
+  _cancelMcpStallTimer() {
+    if (this._mcpStallTimer) {
+      clearTimeout(this._mcpStallTimer);
+      this._mcpStallTimer = null;
+    }
+  }
 
   async start() {
     const client = new VoiceLiveClient(this.endpoint, this.credential, {
@@ -522,7 +669,7 @@ class MCPVoiceAssistant {
     console.log("Try saying:");
     console.log('  • "Can you summarize the GitHub repo azure-sdk-for-java?"');
     console.log('  • "Search the Azure documentation for Voice Live API."');
-    console.log("You may need to approve some MCP tool calls in the console.");
+    console.log("You may need to approve some MCP tool calls by voice.");
     console.log("Press Ctrl+C to exit");
     console.log("=".repeat(70) + "\n");
 
@@ -549,10 +696,7 @@ class MCPVoiceAssistant {
   }
 
   async shutdown() {
-    if (this._rl) {
-      this._rl.close();
-      this._rl = null;
-    }
+    this._cancelMcpStallTimer();
 
     if (this._subscription) {
       await this._subscription.close();

--- a/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
@@ -298,6 +298,8 @@ class MCPVoiceAssistant {
     this._mcpStallTimer = null;
     this._activeMcpItems = new Set();
     this._staleMcpItems = new Set();
+    this._mcpResultsPending = false;
+    this._approvedServersThisTurn = new Set();
   }
 
   // <configure_session>
@@ -380,6 +382,11 @@ class MCPVoiceAssistant {
         // pending/queued approvals remain) or on denial (in _resolveVoiceApproval).
         // Resetting on every speech-start would let the model retry denied calls.
 
+        // Reset approved-servers-this-turn when user starts a new topic
+        if (this._pendingApproval === null && this._mcpCallInProgress <= 0) {
+          this._approvedServersThisTurn.clear();
+        }
+
         if (this._activeResponse && !this._responseApiDone) {
           try {
             await session.sendEvent({ type: "response.cancel" });
@@ -427,6 +434,9 @@ class MCPVoiceAssistant {
         if (this._approvalPromptNeeded && this._pendingApproval !== null) {
           this._approvalPromptNeeded = false;
           await this._sendApprovalVoicePrompt(session);
+        } else if (this._mcpResultsPending && this._mcpCallInProgress <= 0 && this._pendingApproval === null) {
+          this._mcpResultsPending = false;
+          try { await session.sendEvent({ type: "response.create" }); } catch {}
         } else if (this._needsResponseCreate) {
           this._needsResponseCreate = false;
           try { await session.sendEvent({ type: "response.create" }); } catch {}
@@ -491,12 +501,19 @@ class MCPVoiceAssistant {
           } catch {}
         }
 
-        try {
-          await session.sendEvent({ type: "response.create" });
-        } catch (e) {
-          if (e?.message?.toLowerCase().includes("active response")) {
-            this._needsResponseCreate = true;
+        // Batch response: only call response.create when ALL MCP calls for this
+        // turn have completed. This prevents partial results and repeated tool calls.
+        if (this._mcpCallInProgress <= 0 && this._pendingApproval === null && this._approvalQueue.length === 0) {
+          try {
+            await session.sendEvent({ type: "response.create" });
+          } catch (e) {
+            if (e?.message?.toLowerCase().includes("active response")) {
+              this._needsResponseCreate = true;
+            }
           }
+        } else {
+          this._mcpResultsPending = true;
+          console.log(`[mcp] MCP calls still in progress (${this._mcpCallInProgress}) — deferring response`);
         }
       },
 
@@ -566,6 +583,24 @@ class MCPVoiceAssistant {
       return;
     }
 
+    // Auto-approve if user already approved this server earlier in the same turn
+    if (this._approvedServersThisTurn.has(serverLabel)) {
+      console.log(`   Auto-approved: ${serverLabel}/${functionName} (already approved this turn)`);
+      try {
+        await session.sendEvent({
+          type: "conversation.item.create",
+          item: {
+            type: "mcp_approval_response",
+            approval_request_id: approvalId,
+            approve: true,
+          },
+        });
+      } catch (err) {
+        console.warn("Failed to send auto-approve:", err?.message ?? err);
+      }
+      return;
+    }
+
     if (this._pendingApproval !== null) {
       this._approvalQueue.push({ approvalId, serverLabel, functionName });
       console.log("   (queued — another approval is pending)");
@@ -622,14 +657,17 @@ class MCPVoiceAssistant {
     }
 
     const approved = yesMatch && !noMatch;
-    const { approvalId } = this._pendingApproval;
+    const { approvalId, serverLabel } = this._pendingApproval;
 
     console.log(`   Voice response: ${approved ? "Approved ✅" : "Denied ❌"}`);
 
     this._pendingApproval = null;
 
-    if (!approved) {
+    if (approved) {
+      this._approvedServersThisTurn.add(serverLabel);
+    } else {
       this._approvalCallCount = {};
+      this._approvedServersThisTurn.delete(serverLabel);
     }
 
     try {

--- a/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
@@ -526,6 +526,25 @@ class MCPVoiceAssistant {
     console.log(`   Tool: ${functionName}`);
     console.log(`   Approval ID: ${approvalId}`);
 
+    const MAX_APPROVAL_CALLS_PER_TASK = 3;
+    const currentCount = this._approvalCallCount[serverLabel] ?? 0;
+    if (currentCount >= MAX_APPROVAL_CALLS_PER_TASK) {
+      console.log(`   Auto-denied: ${serverLabel}/${functionName} (max ${MAX_APPROVAL_CALLS_PER_TASK} calls reached)`);
+      try {
+        await session.sendEvent({
+          type: "conversation.item.create",
+          item: {
+            type: "mcp_approval_response",
+            approval_request_id: approvalId,
+            approve: false,
+          },
+        });
+      } catch (err) {
+        console.warn("Failed to send auto-deny:", err?.message ?? err);
+      }
+      return;
+    }
+
     if (this._pendingApproval !== null) {
       this._approvalQueue.push({ approvalId, serverLabel, functionName });
       console.log("   (queued — another approval is pending)");
@@ -631,7 +650,11 @@ class MCPVoiceAssistant {
         try {
           await session.sendEvent({ type: "conversation.item.create", item: { type: "message", role: "system", content: [{ type: "input_text", text: "The tool call is taking longer than expected. Briefly let the user know you're still waiting for results." }] } });
           await session.sendEvent({ type: "response.create" });
-        } catch {}
+        } catch (e) {
+          if (e?.message?.toLowerCase().includes("active response")) {
+            this._needsResponseCreate = true;
+          }
+        }
       }
     }, 15000);
   }

--- a/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
@@ -326,7 +326,7 @@ class MCPVoiceAssistant {
       },
       inputAudioEchoCancellation: { type: "server_echo_cancellation" },
       inputAudioNoiseReduction: { type: "azure_deep_noise_suppression" },
-      inputAudioTranscription: { model: "azure-speech" },
+      inputAudioTranscription: { model: this.model.toLowerCase().includes("realtime") ? "whisper-1" : "azure-speech" },
       tools: mcpServers,
     });
 
@@ -436,7 +436,7 @@ class MCPVoiceAssistant {
           console.log("[session] Interim response not supported (non-fatal)");
           return;
         }
-        if (msg.toLowerCase().includes("active response in progress")) return;
+        if (msg.toLowerCase().includes("active response")) return;
         console.error(`❌ VoiceLive error: ${msg}`);
       },
 

--- a/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
@@ -373,10 +373,10 @@ class MCPVoiceAssistant {
         console.log("🎤 Listening...");
         this._audio.skipPendingAudio();
 
-        // Only reset approval counter if no approval pending
-        if (this._pendingApproval === null) {
-          this._approvalCallCount = {};
-        }
+        // Do NOT reset _approvalCallCount here — the counter should only
+        // reset on task completion (in onResponseMcpCallCompleted when no
+        // pending/queued approvals remain) or on denial (in _resolveVoiceApproval).
+        // Resetting on every speech-start would let the model retry denied calls.
 
         if (this._activeResponse && !this._responseApiDone) {
           try {
@@ -391,7 +391,7 @@ class MCPVoiceAssistant {
 
         if (this._mcpCallInProgress > 0 && this._pendingApproval === null) {
           try {
-            await session.sendEvent({ type: "conversation.item.create", item: { type: "message", role: "system", content: [{ type: "input_text", text: "A tool call is still running. The user just interrupted. Briefly ask them: do you want to keep waiting for the result, or skip it and move on? Keep it short." }] } });
+            await session.addConversationItem({ type: "message", role: "system", content: [{ type: "input_text", text: "A tool call is still running. The user just interrupted. Briefly ask them: do you want to keep waiting for the result, or skip it and move on? Keep it short." }] });
           } catch {}
         }
       },
@@ -498,7 +498,7 @@ class MCPVoiceAssistant {
           console.log(`🔧 MCP tool call: ${sl}/${fn}`);
           if (!this._pendingApproval && !this._approvalServers.has(sl)) {
             try {
-              await session.sendEvent({ type: "conversation.item.create", item: { type: "message", role: "system", content: [{ type: "input_text", text: "Briefly tell the user you're looking something up. One short sentence only." }] } });
+              await session.addConversationItem({ type: "message", role: "system", content: [{ type: "input_text", text: "Briefly tell the user you're looking something up. One short sentence only." }] });
               await session.sendEvent({ type: "response.create" });
             } catch {}
           }
@@ -576,13 +576,10 @@ class MCPVoiceAssistant {
     }
 
     try {
-      await session.sendEvent({
-        type: "conversation.item.create",
-        item: {
-          type: "message",
-          role: "system",
-          content: [{ type: "input_text", text: prompt }],
-        },
+      await session.addConversationItem({
+        type: "message",
+        role: "system",
+        content: [{ type: "input_text", text: prompt }],
       });
       await session.sendEvent({ type: "response.create" });
     } catch (err) {
@@ -656,7 +653,7 @@ class MCPVoiceAssistant {
         ? "The tool call is taking longer than expected. Briefly let the user know you're still waiting for results."
         : "The tool call is taking very long. Ask the user: would you like to keep waiting, or should I move on and answer with what I know? Keep it short.";
       try {
-        await session.sendEvent({ type: "conversation.item.create", item: { type: "message", role: "system", content: [{ type: "input_text", text: msg }] } });
+        await session.addConversationItem({ type: "message", role: "system", content: [{ type: "input_text", text: msg }] });
         await session.sendEvent({ type: "response.create" });
       } catch (e) {
         if (e?.message?.toLowerCase().includes("active response")) {

--- a/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
@@ -33,7 +33,7 @@ function parseArguments(argv) {
       process.env.AZURE_VOICELIVE_VOICE ?? "en-US-Ava:DragonHDLatestNeural",
     instructions:
       process.env.AZURE_VOICELIVE_INSTRUCTIONS ??
-      "You are a helpful AI assistant with access to MCP tools. Always respond in English. When a user asks a question, use the appropriate tool once to find information, then summarize the results conversationally. IMPORTANT: Never call the same tool more than once per user question. After receiving a tool result, always respond to the user with what you found — do not search again. Some tools require user approval before they can be used. When you receive a system message asking you to request permission, you MUST clearly ask the user for their explicit approval before proceeding. Always wait for the user to say yes or no. Never skip the approval question or assume permission is granted.",
+      "You are a helpful AI assistant with access to MCP tools. Always respond in English. When a user asks a question, use the appropriate tool once to find information, then summarize the results conversationally. IMPORTANT: Never call the same tool more than once per user question. After receiving a tool result, always respond to the user with what you found — do not search again. Some tools require user approval before they can be used. When you receive a system message asking you to request permission, you MUST clearly ask the user for their explicit approval before proceeding. Always wait for the user to say yes or no. Never skip the approval question or assume permission is granted. If a tool result arrives after the conversation has moved to a different topic, briefly introduce it as a late result before sharing the findings.",
     audioInputDevice: process.env.AUDIO_INPUT_DEVICE,
     useTokenCredential: false,
     noAudio: false,
@@ -296,6 +296,8 @@ class MCPVoiceAssistant {
     this._mcpItemToServer = {};
     this._approvalServers = new Set();
     this._mcpStallTimer = null;
+    this._activeMcpItems = new Set();
+    this._staleMcpItems = new Set();
   }
 
   // <configure_session>
@@ -390,8 +392,10 @@ class MCPVoiceAssistant {
         }
 
         if (this._mcpCallInProgress > 0 && this._pendingApproval === null) {
+          this._staleMcpItems = new Set([...this._staleMcpItems, ...this._activeMcpItems]);
+          console.log(`[barge-in] Marking ${this._activeMcpItems.size} MCP calls as stale`);
           try {
-            await session.addConversationItem({ type: "message", role: "system", content: [{ type: "input_text", text: "A tool call is still running. The user just spoke. Briefly acknowledge them and let them know you're still waiting for results. One short sentence." }] });
+            await session.addConversationItem({ type: "message", role: "system", content: [{ type: "input_text", text: "A tool call is still running in the background. The user just spoke. Respond to what the user said. If a tool result arrives later, briefly introduce it as a late result from an earlier request." }] });
           } catch {}
         }
       },
@@ -455,6 +459,7 @@ class MCPVoiceAssistant {
       onResponseMcpCallInProgress: async (event) => {
         console.log("⏳ MCP tool call in progress...");
         this._mcpCallInProgress++;
+        this._activeMcpItems.add(event.item_id);
         this._startMcpStallTimer(session);
       },
 
@@ -466,14 +471,26 @@ class MCPVoiceAssistant {
       onResponseMcpCallCompleted: async (event) => {
         const itemId = event.item_id ?? "";
         this._mcpCallInProgress = Math.max(0, this._mcpCallInProgress - 1);
+        this._activeMcpItems.delete(itemId);
         this._cancelMcpStallTimer();
         if (this._handledMcpCompletions.has(itemId)) return;
         this._handledMcpCompletions.add(itemId);
-        console.log("✅ MCP tool call completed");
+
+        const isStale = this._staleMcpItems.has(itemId);
+        this._staleMcpItems.delete(itemId);
+        console.log(`✅ MCP tool call completed (stale=${isStale})`);
+
         delete this._mcpItemToServer[itemId];
         if (this._pendingApproval === null && this._approvalQueue.length === 0) {
           this._approvalCallCount = {};
         }
+
+        if (isStale) {
+          try {
+            await session.addConversationItem({ type: "message", role: "system", content: [{ type: "input_text", text: "This tool result is from an earlier request. The user has since moved on. Briefly introduce it as a late result, e.g. 'By the way, those results from earlier just came in...' then share the key findings concisely." }] });
+          } catch {}
+        }
+
         try {
           await session.sendEvent({ type: "response.create" });
         } catch (e) {
@@ -484,8 +501,11 @@ class MCPVoiceAssistant {
       },
 
       onResponseMcpCallFailed: async (event) => {
+        const itemId = event.item_id ?? "";
         console.error("❌ MCP tool call failed");
         this._mcpCallInProgress = Math.max(0, this._mcpCallInProgress - 1);
+        this._activeMcpItems.delete(itemId);
+        this._staleMcpItems.delete(itemId);
         this._cancelMcpStallTimer();
         try { await session.sendEvent({ type: "response.create" }); } catch {}
       },
@@ -665,7 +685,7 @@ class MCPVoiceAssistant {
           this._needsResponseCreate = true;
         }
       }
-    }, 15000);
+    }, 10000);
   }
 
   _cancelMcpStallTimer() {

--- a/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
@@ -431,6 +431,9 @@ class MCPVoiceAssistant {
 
       onServerError: async (event) => {
         const msg = event.error?.message ?? "";
+        // Reset response state — errors can terminate a response without onResponseDone
+        this._activeResponse = false;
+        this._responseApiDone = true;
         if (msg.includes("Cancellation failed: no active response")) return;
         if (msg.toLowerCase().includes("interim response")) {
           console.log("[session] Interim response not supported (non-fatal)");

--- a/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
@@ -645,15 +645,22 @@ class MCPVoiceAssistant {
 
   _startMcpStallTimer(session) {
     this._cancelMcpStallTimer();
-    this._mcpStallTimer = setTimeout(async () => {
-      if (this._mcpCallInProgress > 0) {
-        try {
-          await session.sendEvent({ type: "conversation.item.create", item: { type: "message", role: "system", content: [{ type: "input_text", text: "The tool call is taking longer than expected. Briefly let the user know you're still waiting for results." }] } });
-          await session.sendEvent({ type: "response.create" });
-        } catch (e) {
-          if (e?.message?.toLowerCase().includes("active response")) {
-            this._needsResponseCreate = true;
-          }
+    let stallCount = 0;
+    this._mcpStallTimer = setInterval(async () => {
+      if (this._mcpCallInProgress <= 0) {
+        this._cancelMcpStallTimer();
+        return;
+      }
+      stallCount++;
+      const msg = stallCount === 1
+        ? "The tool call is taking longer than expected. Briefly let the user know you're still waiting for results."
+        : "The tool call is taking very long. Ask the user: would you like to keep waiting, or should I move on and answer with what I know? Keep it short.";
+      try {
+        await session.sendEvent({ type: "conversation.item.create", item: { type: "message", role: "system", content: [{ type: "input_text", text: msg }] } });
+        await session.sendEvent({ type: "response.create" });
+      } catch (e) {
+        if (e?.message?.toLowerCase().includes("active response")) {
+          this._needsResponseCreate = true;
         }
       }
     }, 15000);
@@ -661,7 +668,7 @@ class MCPVoiceAssistant {
 
   _cancelMcpStallTimer() {
     if (this._mcpStallTimer) {
-      clearTimeout(this._mcpStallTimer);
+      clearInterval(this._mcpStallTimer);
       this._mcpStallTimer = null;
     }
   }

--- a/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
@@ -6,6 +6,25 @@ import { VoiceLiveClient } from "@azure/ai-voicelive";
 import { AzureKeyCredential } from "@azure/core-auth";
 import { DefaultAzureCredential } from "@azure/identity";
 import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, appendFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const logsDir = join(__dirname, "logs");
+if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true });
+
+const timestamp = new Date()
+  .toISOString()
+  .replace(/[:.]/g, "-")
+  .replace("T", "_")
+  .slice(0, 19);
+const conversationLogFile = join(logsDir, `conversation_${timestamp}.log`);
+
+function writeConversationLog(message) {
+  appendFileSync(conversationLogFile, message + "\n", "utf-8");
+}
 
 function printUsage() {
   console.log("Usage: node mcp-quickstart.js [options]");
@@ -19,6 +38,7 @@ function printUsage() {
   );
   console.log("  --instructions <text>       System instructions for the assistant");
   console.log("  --audio-input-device <name> Explicit SoX input device name (Windows)");
+  console.log("  --list-audio-devices        List available audio input devices and exit");
   console.log("  --use-token-credential      Use Azure credential instead of API key");
   console.log("  --no-audio                  Connect and configure session without mic/speaker");
   console.log("  -h, --help                  Show this help text");
@@ -35,6 +55,7 @@ function parseArguments(argv) {
       process.env.AZURE_VOICELIVE_INSTRUCTIONS ??
       "You are a helpful AI assistant with access to MCP tools. Always respond in English. When a user asks a question, use the appropriate tool once to find information, then summarize the results conversationally. IMPORTANT: Never call the same tool more than once per user question. After receiving a tool result, always respond to the user with what you found — do not search again. Some tools require user approval before they can be used. When you receive a system message asking you to request permission, you MUST clearly ask the user for their explicit approval before proceeding. Always wait for the user to say yes or no. Never skip the approval question or assume permission is granted. If a tool result arrives after the conversation has moved to a different topic, briefly introduce it as a late result before sharing the findings.",
     audioInputDevice: process.env.AUDIO_INPUT_DEVICE,
+    listAudioDevices: false,
     useTokenCredential: false,
     noAudio: false,
     help: false,
@@ -61,6 +82,9 @@ function parseArguments(argv) {
       case "--audio-input-device":
         parsed.audioInputDevice = argv[++i];
         break;
+      case "--list-audio-devices":
+        parsed.listAudioDevices = true;
+        break;
       case "--use-token-credential":
         parsed.useTokenCredential = true;
         break;
@@ -80,6 +104,42 @@ function parseArguments(argv) {
   }
 
   return parsed;
+}
+
+/**
+ * List available audio input devices on Windows (AudioEndpoint via WMI).
+ */
+async function listAudioDevices() {
+  if (process.platform !== "win32") {
+    console.log("Device listing is currently supported on Windows only.");
+    console.log("On macOS/Linux, run: sox -V6 -n -t coreaudio -n trim 0 0  (or similar)");
+    return;
+  }
+
+  const { execSync } = await import("node:child_process");
+  try {
+    const output = execSync(
+      'powershell -NoProfile -Command "Get-CimInstance Win32_PnPEntity | Where-Object { $_.PNPClass -eq \'AudioEndpoint\' } | Select-Object -ExpandProperty Name"',
+      { encoding: "utf-8", timeout: 10000 },
+    ).trim();
+
+    if (!output) {
+      console.log("No audio endpoint devices found.");
+      return;
+    }
+
+    console.log("Available audio endpoint devices:");
+    console.log("");
+    for (const line of output.split(/\r?\n/)) {
+      const name = line.trim();
+      if (name) console.log(`  ${name}`);
+    }
+    console.log("");
+    console.log("Use the device name (or a unique substring) with --audio-input-device.");
+    console.log('Example: node mcp-quickstart.js --audio-input-device "Microphone"');
+  } catch (err) {
+    console.error("Failed to query audio devices:", err.message);
+  }
 }
 
 function resolveVoiceConfig(voiceName) {
@@ -235,7 +295,10 @@ class AudioProcessor {
   async _resetSpeaker() {
     await this._ensureAudioModulesLoaded();
     if (this._speaker && !this._speaker.destroyed) {
-      try { this._speaker.end(); } catch { /* no-op */ }
+      // Use destroy() instead of end() to immediately discard buffered audio.
+      // end() drains the buffer (plays it out), which causes old MCP response
+      // audio to keep playing after barge-in.
+      try { this._speaker.destroy(); } catch { /* no-op */ }
     }
     this._speaker = new this._speakerCtor({
       channels: 1,
@@ -300,6 +363,7 @@ class MCPVoiceAssistant {
     this._staleMcpItems = new Set();
     this._mcpResultsPending = false;
     this._approvedServersThisTurn = new Set();
+    this._bargeInActive = false;
   }
 
   // <configure_session>
@@ -353,11 +417,22 @@ class MCPVoiceAssistant {
           `  Model: ${typeof model === "string" ? model : model?.toString?.() ?? ""}`,
         );
         console.log(`  Voice: ${voice?.name ?? ""}`);
+        writeConversationLog(
+          [
+            `SessionID: ${context.sessionId}`,
+            `Model: ${typeof model === "string" ? model : model?.toString?.() ?? ""}`,
+            `Voice Name: ${voice?.name ?? ""}`,
+            `Voice Type: ${voice?.type ?? ""}`,
+            `Log File: ${conversationLogFile}`,
+            "",
+          ].join("\n"),
+        );
       },
 
       onConversationItemInputAudioTranscriptionCompleted: async (event) => {
         const transcript = event.transcript ?? "";
         console.log(`👤 You said:\t${transcript}`);
+        writeConversationLog(`User Input:\t${transcript}`);
         if (this._pendingApproval !== null) {
           await this._resolveVoiceApproval(transcript, session);
         }
@@ -366,11 +441,13 @@ class MCPVoiceAssistant {
       onResponseTextDone: async (event) => {
         const text = event.text ?? "";
         console.log(`🤖 Assistant text:\t${text}`);
+        writeConversationLog(`Assistant Text Response:\t${text}`);
       },
 
       onResponseAudioTranscriptDone: async (event) => {
         const transcript = event.transcript ?? "";
         console.log(`🤖 Assistant audio transcript:\t${transcript}`);
+        writeConversationLog(`Assistant Audio Response:\t${transcript}`);
       },
 
       onInputAudioBufferSpeechStarted: async () => {
@@ -382,12 +459,20 @@ class MCPVoiceAssistant {
         // pending/queued approvals remain) or on denial (in _resolveVoiceApproval).
         // Resetting on every speech-start would let the model retry denied calls.
 
+        // Clear ALL deferred response flags on barge-in.
+        // This prevents onResponseDone (fired by the cancelled response)
+        // from immediately creating a new response that overlaps the user.
+        this._needsResponseCreate = false;
+        this._mcpResultsPending = false;
+
         // Reset approved-servers-this-turn when user starts a new topic
         if (this._pendingApproval === null && this._mcpCallInProgress <= 0) {
           this._approvedServersThisTurn.clear();
         }
 
         if (this._activeResponse && !this._responseApiDone) {
+          // Mark barge-in so onResponseDone skips deferred actions
+          this._bargeInActive = true;
           try {
             await session.sendEvent({ type: "response.cancel" });
           } catch (err) {
@@ -396,6 +481,9 @@ class MCPVoiceAssistant {
               console.warn("[barge-in] Cancel failed:", msg);
             }
           }
+          try {
+            await session.sendEvent({ type: "input_audio_buffer.clear" });
+          } catch { /* best-effort */ }
         }
 
         if (this._mcpCallInProgress > 0 && this._pendingApproval === null) {
@@ -428,8 +516,16 @@ class MCPVoiceAssistant {
 
       onResponseDone: async () => {
         console.log("✅ Response complete");
+        writeConversationLog("--- Response complete ---");
         this._activeResponse = false;
         this._responseApiDone = true;
+
+        // If this response.done is the result of a barge-in cancel,
+        // skip all deferred actions — the user's new turn will handle things.
+        if (this._bargeInActive) {
+          this._bargeInActive = false;
+          return;
+        }
 
         if (this._approvalPromptNeeded && this._pendingApproval !== null) {
           this._approvalPromptNeeded = false;
@@ -455,19 +551,23 @@ class MCPVoiceAssistant {
         }
         if (msg.toLowerCase().includes("active response")) return;
         console.error(`❌ VoiceLive error: ${msg}`);
+        writeConversationLog(`ERROR: ${msg}`);
       },
 
       // MCP-specific event handlers
       onMcpListToolsCompleted: async (event) => {
         console.log(`🔧 MCP tools discovered successfully`);
+        writeConversationLog("MCP tools discovered successfully");
       },
 
       onMcpListToolsFailed: async (event) => {
         console.error(`❌ MCP tool discovery failed`);
+        writeConversationLog("ERROR: MCP tool discovery failed");
       },
 
       onResponseMcpCallInProgress: async (event) => {
         console.log("⏳ MCP tool call in progress...");
+        writeConversationLog(`MCP call in progress: ${event.item_id ?? ""}`);
         this._mcpCallInProgress++;
         this._activeMcpItems.add(event.item_id);
         this._startMcpStallTimer(session);
@@ -489,6 +589,7 @@ class MCPVoiceAssistant {
         const isStale = this._staleMcpItems.has(itemId);
         this._staleMcpItems.delete(itemId);
         console.log(`✅ MCP tool call completed (stale=${isStale})`);
+        writeConversationLog(`MCP call completed: ${itemId} (stale=${isStale})`);
 
         delete this._mcpItemToServer[itemId];
         if (this._pendingApproval === null && this._approvalQueue.length === 0) {
@@ -520,6 +621,7 @@ class MCPVoiceAssistant {
       onResponseMcpCallFailed: async (event) => {
         const itemId = event.item_id ?? "";
         console.error("❌ MCP tool call failed");
+        writeConversationLog(`ERROR: MCP call failed: ${itemId}`);
         this._mcpCallInProgress = Math.max(0, this._mcpCallInProgress - 1);
         this._activeMcpItems.delete(itemId);
         this._staleMcpItems.delete(itemId);
@@ -534,6 +636,7 @@ class MCPVoiceAssistant {
           const fn = item.name ?? "";
           this._mcpItemToServer[item.id] = `${sl}/${fn}`;
           console.log(`🔧 MCP tool call: ${sl}/${fn}`);
+          writeConversationLog(`MCP tool call: ${sl}/${fn} (id=${item.id})`);
           if (!this._pendingApproval && !this._approvalServers.has(sl)) {
             try {
               await session.addConversationItem({ type: "message", role: "system", content: [{ type: "input_text", text: "Briefly tell the user you're looking something up. One short sentence only." }] });
@@ -542,6 +645,7 @@ class MCPVoiceAssistant {
           }
         }
         if (item?.type === "mcp_approval_request") {
+          writeConversationLog(`MCP approval request: ${item.serverLabel ?? item.server_label ?? ""} / ${item.name ?? ""} (id=${item.id ?? ""})`);
           await this._handleApprovalRequest(item, session);
         }
       },
@@ -569,13 +673,10 @@ class MCPVoiceAssistant {
     if (currentCount >= MAX_APPROVAL_CALLS_PER_TASK) {
       console.log(`   Auto-denied: ${serverLabel}/${functionName} (max ${MAX_APPROVAL_CALLS_PER_TASK} calls reached)`);
       try {
-        await session.sendEvent({
-          type: "conversation.item.create",
-          item: {
-            type: "mcp_approval_response",
-            approval_request_id: approvalId,
-            approve: false,
-          },
+        await session.addConversationItem({
+          type: "mcp_approval_response",
+          approvalRequestId: approvalId,
+          approve: false,
         });
       } catch (err) {
         console.warn("Failed to send auto-deny:", err?.message ?? err);
@@ -587,13 +688,10 @@ class MCPVoiceAssistant {
     if (this._approvedServersThisTurn.has(serverLabel)) {
       console.log(`   Auto-approved: ${serverLabel}/${functionName} (already approved this turn)`);
       try {
-        await session.sendEvent({
-          type: "conversation.item.create",
-          item: {
-            type: "mcp_approval_response",
-            approval_request_id: approvalId,
-            approve: true,
-          },
+        await session.addConversationItem({
+          type: "mcp_approval_response",
+          approvalRequestId: approvalId,
+          approve: true,
         });
       } catch (err) {
         console.warn("Failed to send auto-approve:", err?.message ?? err);
@@ -647,19 +745,23 @@ class MCPVoiceAssistant {
     if (this._pendingApproval === null) return;
 
     const lower = transcript.toLowerCase();
-    const yesMatch = /\byes\b/.test(lower);
-    const noMatch = /\b(no|stop|cancel)\b/.test(lower);
+    let approved = /\byes\b/.test(lower);
+    const denied = /\b(no|stop|cancel)\b/.test(lower);
 
-    if (!yesMatch && !noMatch) {
+    if (!approved && !denied) {
       // Ambiguous — will re-prompt at next response.done
       this._approvalPromptNeeded = true;
       return;
     }
 
-    const approved = yesMatch && !noMatch;
+    if (approved && denied) {
+      approved = false; // Conflicting signals — deny for safety
+    }
+
     const { approvalId, serverLabel } = this._pendingApproval;
 
     console.log(`   Voice response: ${approved ? "Approved ✅" : "Denied ❌"}`);
+    writeConversationLog(`Voice approval: ${approved ? "Approved" : "Denied"} for ${serverLabel}`);
 
     this._pendingApproval = null;
 
@@ -671,13 +773,10 @@ class MCPVoiceAssistant {
     }
 
     try {
-      await session.sendEvent({
-        type: "conversation.item.create",
-        item: {
-          type: "mcp_approval_response",
-          approval_request_id: approvalId,
-          approve: approved,
-        },
+      await session.addConversationItem({
+        type: "mcp_approval_response",
+        approvalRequestId: approvalId,
+        approve: approved,
       });
     } catch (err) {
       console.error("❌ Failed to send approval response:", err?.message ?? err);
@@ -689,7 +788,25 @@ class MCPVoiceAssistant {
   async _processNextApproval(session) {
     if (this._approvalQueue.length === 0) return;
 
-    this._pendingApproval = this._approvalQueue.shift();
+    const next = this._approvalQueue.shift();
+
+    // Auto-approve if user already approved this server earlier in the same turn
+    if (this._approvedServersThisTurn.has(next.serverLabel)) {
+      console.log(`   Auto-approved (queued): ${next.serverLabel}/${next.functionName}`);
+      try {
+        await session.addConversationItem({
+          type: "mcp_approval_response",
+          approvalRequestId: next.approvalId,
+          approve: true,
+        });
+      } catch (err) {
+        console.warn("Failed to send queued auto-approve:", err?.message ?? err);
+      }
+      await this._processNextApproval(session);
+      return;
+    }
+
+    this._pendingApproval = next;
 
     if (!this._activeResponse) {
       await this._sendApprovalVoicePrompt(session);
@@ -828,6 +945,11 @@ async function main() {
     return;
   }
 
+  if (args.listAudioDevices) {
+    await listAudioDevices();
+    return;
+  }
+
   if (!args.endpoint) {
     console.error(
       "❌ Missing endpoint. Set AZURE_VOICELIVE_ENDPOINT or pass --endpoint.",
@@ -856,6 +978,7 @@ async function main() {
   console.log(
     `  Authentication: ${args.useTokenCredential ? "DefaultAzureCredential" : "API Key"}`,
   );
+  console.log(`  Log file: ${conversationLogFile}`);
 
   const assistant = new MCPVoiceAssistant({
     endpoint: args.endpoint,

--- a/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
@@ -256,16 +256,16 @@ function defineMCPServers() {
   return [
     {
       type: "mcp",
-      server_label: "deepwiki",
-      server_url: "https://mcp.deepwiki.com/mcp",
-      allowed_tools: ["read_wiki_structure", "ask_question"],
-      require_approval: "never",
+      serverLabel: "deepwiki",
+      serverUrl: "https://mcp.deepwiki.com/mcp",
+      allowedTools: ["read_wiki_structure", "ask_question"],
+      requireApproval: "never",
     },
     {
       type: "mcp",
-      server_label: "azure_doc",
-      server_url: "https://learn.microsoft.com/api/mcp",
-      require_approval: "always",
+      serverLabel: "azure_doc",
+      serverUrl: "https://learn.microsoft.com/api/mcp",
+      requireApproval: "always",
     },
   ];
 }
@@ -308,7 +308,7 @@ class MCPVoiceAssistant {
     const mcpServers = defineMCPServers();
 
     this._approvalServers = new Set(
-      mcpServers.filter(s => s.require_approval === "always").map(s => s.server_label)
+      mcpServers.filter(s => s.requireApproval === "always").map(s => s.serverLabel)
     );
 
     await this._session.updateSession({
@@ -445,13 +445,11 @@ class MCPVoiceAssistant {
 
       // MCP-specific event handlers
       onMcpListToolsCompleted: async (event) => {
-        const serverLabel = event.server_label ?? "unknown";
-        console.log(`🔧 MCP tools discovered for server "${serverLabel}"`);
+        console.log(`🔧 MCP tools discovered successfully`);
       },
 
       onMcpListToolsFailed: async (event) => {
-        const serverLabel = event.server_label ?? "unknown";
-        console.error(`❌ MCP tool discovery failed for server "${serverLabel}"`);
+        console.error(`❌ MCP tool discovery failed`);
       },
 
       onResponseMcpCallInProgress: async (event) => {
@@ -495,7 +493,7 @@ class MCPVoiceAssistant {
       onConversationItemCreated: async (event) => {
         const item = event.item;
         if (item?.type === "mcp_call") {
-          const sl = item.server_label ?? "";
+          const sl = item.serverLabel ?? item.server_label ?? "";
           const fn = item.name ?? "";
           this._mcpItemToServer[item.id] = `${sl}/${fn}`;
           console.log(`🔧 MCP tool call: ${sl}/${fn}`);
@@ -520,7 +518,7 @@ class MCPVoiceAssistant {
    */
   async _handleApprovalRequest(item, session) {
     const approvalId = item.id ?? "unknown";
-    const serverLabel = item.server_label ?? "unknown";
+    const serverLabel = item.serverLabel ?? item.server_label ?? "unknown";
     const functionName = item.name ?? "unknown";
 
     console.log();

--- a/javascript/voice-live-quickstarts/MCPQuickstart/package.json
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "voice-live-mcp-quickstart",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@azure/ai-voicelive": "1.0.0-beta.3",
+    "@azure/core-auth": "^1.9.0",
+    "@azure/identity": "^4.6.0",
+    "dotenv": "^16.4.7"
+  },
+  "optionalDependencies": {
+    "node-record-lpcm16": "^1.0.1",
+    "speaker": "^0.5.5"
+  }
+}

--- a/javascript/voice-live-quickstarts/ModelQuickstart/model-quickstart.js
+++ b/javascript/voice-live-quickstarts/ModelQuickstart/model-quickstart.js
@@ -343,7 +343,7 @@ class AudioProcessor {
 
     if (this._speaker && !this._speaker.destroyed) {
       try {
-        this._speaker.end();
+        this._speaker.destroy();
       } catch {
         // no-op
       }

--- a/python/README.md
+++ b/python/README.md
@@ -16,6 +16,17 @@ Demonstrates the new Voice Live + Foundry Agent v2 workflow, including creating 
 - Proactive greeting and barge-in handling
 - Conversation logging
 
+### [MCP Quickstart](./voice-live-quickstarts/MCPQuickstart/)
+
+Demonstrates MCP (Model Context Protocol) server integration with Voice Live, enabling the assistant to use remote tools (DeepWiki, Azure Docs) during voice conversations.
+
+**Key Features:**
+- MCP server definitions using `MCPServer` model objects
+- MCP tool discovery, execution, and failure event handling
+- Interactive console-based approval flow for sensitive tools
+- MCP call result processing with automatic response creation
+- Conversation logging to timestamped log files
+
 ### [Agent Quickstart](./voice-live-quickstarts/agents-quickstart.py)
 
 Demonstrates connecting to an Azure AI Foundry agent for voice conversations. The agent handles model selection, instructions, and tools, with support for proactive greetings.

--- a/python/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/python/voice-live-quickstarts/MCPQuickstart/README.md
@@ -18,7 +18,13 @@ Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-r
 
 ## Voice UX Considerations for MCP Integration
 
-Integrating MCP servers into a voice assistant introduces unique UX challenges that don't exist in text-based or console-based MCP clients. This quickstart demonstrates patterns to address them. When building your own voice-enabled MCP application, consider the following:
+Integrating MCP servers into a voice assistant introduces unique UX challenges that don't exist in text-based or console-based MCP clients.
+
+MCP servers can be configured with different approval policies:
+- **`require_approval: "never"`** — tool calls proceed automatically (e.g., DeepWiki in this sample)
+- **`require_approval: "always"`** — every tool call requires explicit user consent before execution (e.g., Azure Docs in this sample)
+
+In a text-based client, approval is typically a simple `y/n` console prompt. In a voice UX, this needs to be handled conversationally — and several additional challenges arise around latency, silence, and repeated calls. This quickstart demonstrates patterns to address them:
 
 ### Tool Approval Must Be Voice-Native
 
@@ -40,10 +46,11 @@ The per-request system messages use `"Say exactly:"` phrasing to prevent the mod
 
 ### Repeated Tool Calls Need Contextual Messaging
 
-MCP servers like Azure Docs may require multiple searches to gather complete information. Each search triggers a separate approval if `require_approval="always"`. Rather than asking the identical question each time, this quickstart tracks the call count per server:
+MCP servers may require multiple searches to gather complete information. Each search triggers a separate approval if `require_approval="always"`. Rather than asking the identical question each time, this quickstart tracks the call count per server:
 
 - **First call**: *"I'd like to search the azure_doc service. Do you approve?"*
 - **Subsequent calls**: *"I need one more search for complete information. Should I continue?"*
+- **After 3 approved calls**: Auto-denied to prevent infinite loops — the model responds with what it has
 
 The counter resets when results are fully delivered or the user denies a request.
 
@@ -52,8 +59,8 @@ The counter resets when results are fully delivered or the user denies a request
 MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses three layers:
 
 1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
-2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers generates natural filler. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline).
-3. **Stall detection** (client-side, 15s timer): If the MCP call takes >15 seconds, the assistant proactively says *"Still waiting for results..."*. This is the **only** verbal feedback for slow calls on `gpt-realtime`.
+2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers generates natural filler. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline). The transcription model is also selected per pipeline: `azure-speech` for non-realtime, `whisper-1` for realtime.
+3. **Stall detection** (client-side, repeating 15s timer): Notifies the user every 15 seconds while an MCP call is running. After 30 seconds, offers the user a choice to keep waiting or move on.
 
 ### Barge-In During MCP Calls
 

--- a/python/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/python/voice-live-quickstarts/MCPQuickstart/README.md
@@ -8,13 +8,11 @@ Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-r
 
 ## What Makes This Sample Unique
 
-This sample showcases:
-
 - **MCP Server Integration**: Configure remote MCP servers as session tools via `MCPServer` model objects
 - **Voice-Based Approval**: Instead of blocking on a console prompt, the assistant verbally asks *"Should I go ahead?"* and interprets the user's spoken *yes* or *no*
-- **MCP Tool Announcements**: For auto-approved tools, the assistant says *"Let me look that up..."* while the call runs
+- **Context-Aware Repeat Approvals**: When the model needs additional searches, the prompt changes to *"I need one more search for complete info. Should I continue?"*
+- **MCP Tool Announcements**: For auto-approved tools, the assistant says a brief acknowledgement while the call runs
 - **Barge-In Handling**: Interrupting during an MCP call triggers a *"Do you want to keep waiting or skip?"* inquiry
-- **Per-Turn Loop Prevention**: Approval-required servers are guarded against repeated tool calls per user turn
 - **Interim Response**: Automatically enabled for non-realtime model pipelines to bridge latency gaps
 
 ## Prerequisites
@@ -50,28 +48,9 @@ This sample showcases:
 4. **Run the sample**:
    ```bash
    python mcp-quickstart.py
+   # or with Azure authentication:
+   python mcp-quickstart.py --use-token-credential
    ```
-
-## Run
-
-### API key authentication
-
-```bash
-python mcp-quickstart.py
-```
-
-### Azure credential authentication
-
-```bash
-az login
-python mcp-quickstart.py --use-token-credential
-```
-
-### With verbose logging
-
-```bash
-python mcp-quickstart.py --use-token-credential --verbose
-```
 
 ## Command Line Options
 
@@ -87,65 +66,61 @@ python mcp-quickstart.py --use-token-credential --verbose
 
 | Say this | MCP Server | Approval | What happens |
 |---|---|---|---|
-| *"Can you summarize the GitHub repo azure-sdk-for-python?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls `read_wiki_structure` → `ask_question`, speaks results |
+| *"Can you summarize the GitHub repo azure-sdk-for-python?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
 | *"Search the Azure documentation for Voice Live API"* | Azure Docs | Voice prompt (`always`) | Assistant asks *"Should I go ahead?"*, waits for your *yes* or *no* |
 
 ## How It Works
 
-The sample extends the Model Quickstart pattern with MCP:
-
-1. **MCP Server Definitions**: Adds `MCPServer` instances to the session tools list alongside standard session configuration
-2. **Session Configuration**: Sends `session.update` with model, voice, VAD, MCP tools, and (for non-realtime models) interim response
+1. **MCP Server Definitions**: `MCPServer` instances added to the session tools list
+2. **Session Configuration**: `session.update` with model, voice, VAD, MCP tools, and (for non-realtime models) interim response
 3. **Tool Discovery**: Voice Live connects to each MCP server and discovers available tools
-4. **Tool Announcements**: When an auto-approved tool call starts, the assistant speaks a brief acknowledgement
-5. **Voice Approval Flow**: For `require_approval="always"` servers, a system message is injected asking the model to verbally request permission. The user's spoken response is parsed for *yes*/*no* (word-boundary matching)
+4. **Tool Announcements**: Auto-approved tool calls trigger a brief spoken acknowledgement
+5. **Voice Approval**: For `require_approval="always"` servers, a system message is injected prompting the model to ask verbally. The user's spoken response is parsed for *yes*/*no* using word-boundary regex
 6. **Result Delivery**: After MCP call completion, `response.create` kicks the model to speak the results
 
 ## Design Decisions: MCP in Voice UX
 
-This quickstart demonstrates several design patterns specific to integrating MCP servers in a voice-first experience:
-
 ### Voice-Based Approval vs Console Prompts
 
-The [SDK sample](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/voicelive/azure-ai-voicelive/samples/async_mcp_sample.py) uses blocking `input()` for approval — fine for a console demo, but it freezes the audio pipeline. This quickstart instead:
+The [SDK sample](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/voicelive/azure-ai-voicelive/samples/async_mcp_sample.py) uses blocking `input()` for approval — fine for a console demo, but it freezes the audio pipeline. This quickstart injects system messages to make the model ask verbally, then parses the next transcription for `\byes\b` or `\b(no|stop|cancel)\b` using word-boundary regex. Users can barge in with "yes" without waiting for the full prompt to finish.
 
-- Injects a system message prompting the model to ask verbally
-- Waits for the next `CONVERSATION_ITEM_INPUT_AUDIO_TRANSCRIPTION_COMPLETED` event
-- Parses for `\byes\b` or `\bno\b` using word-boundary regex
-- On ambiguous input, re-prompts via voice
+### Context-Aware Repeat Approvals
 
-### Per-Turn Loop Prevention (Approval Servers Only)
+MCP servers may require multiple tool calls to gather complete information. Rather than blocking repeated calls, this quickstart tracks the call count per server per user turn:
+- **First call**: *"I need your permission to use X from Y. Should I go ahead?"*
+- **Subsequent calls**: *"I need one more search for more complete information. Should I continue?"*
 
-MCP tool calls that require approval can cause loops: approve → call completes → `response.create` → model calls the same tool again → new approval needed. This quickstart guards **only approval-required servers** against repeated calls in the same user turn. Auto-approved servers (like DeepWiki) are allowed to make multiple calls freely, since their multi-step patterns (e.g. `read_wiki_structure` → `ask_question`) are useful and don't interrupt the user.
+The counter resets when the user starts a new topic (speech without pending approval) or when the user denies a request.
 
-### Deferred Response Creation
+### Tool Announcements (Auto-Approved Servers Only)
 
-The approval voice prompt requires `response.create` to make the model speak. If a response is already active (common during MCP flows), the prompt is deferred to the next `RESPONSE_DONE` event via an `_approval_prompt_needed` flag. The same pattern applies to `response.create` after MCP completion — if it collides with an active response, it's retried at `RESPONSE_DONE`.
-
-### Approval Queuing
-
-If the model fires multiple tool calls requiring approval before the user can respond, subsequent requests are queued and asked one-by-one after each resolution. This avoids auto-approving without consent.
+For servers with `require_approval="never"`, the assistant speaks a brief one-sentence acknowledgement when a tool call starts. This is skipped for approval-required servers since the approval prompt already communicates with the user.
 
 ### Barge-In During MCP Calls
 
-If the user speaks while an MCP call is running, the assistant asks whether to keep waiting or skip. If the user barges in during an unanswered approval prompt, the approval is re-queued and re-asked after the user's turn completes.
+If the user speaks while an MCP call is running, a system message asks the model to briefly check: *"Do you want to keep waiting or skip?"* The model handles the conversation naturally.
+
+### Deferred Response Creation
+
+`response.create` calls that collide with an active response are deferred to the next `RESPONSE_DONE` event via a `_needs_response_create` flag, avoiding "active response in progress" errors.
 
 ### Interim Response
 
-`LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers is configured to bridge silence during tool calls. This is automatically skipped for `gpt-realtime` (not supported on the realtime pipeline) and enabled for other models.
+`LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers is configured for non-realtime models. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline).
 
 ## Troubleshooting
 
 | Symptom | Resolution |
 |---|---|
 | `❌ No audio input devices found` | Connect a microphone and restart. |
-| `❌ No audio output devices found` | Connect speakers or headphones and restart. |
 | Authentication errors | Run `az login` or verify `AZURE_VOICELIVE_API_KEY` in `.env`. |
 | MCP tool discovery failed | Check that MCP server URLs are reachable from your network. |
-| Assistant doesn't ask for approval | Only servers with `require_approval="always"` trigger the voice prompt. |
-| Repeated approval prompts for same tool | Expected if the model decides to search again. The per-turn guard limits this to once per approval-required tool per user turn. |
-| Session hit maximum duration | VoiceLive sessions have a 30-minute server-side limit. Restart the sample. |
-| Interim response not supported | Expected with `gpt-realtime`. Use a non-realtime model (e.g. `gpt-4o-mini`) for interim response support. |
+| Repeated approval prompts | Expected — the model may need multiple searches. Say *"no"* or *"stop"* to deny. |
+| Session hit maximum duration | VoiceLive sessions have a 30-minute limit. Restart the sample. |
+| Interim response not supported | Expected with `gpt-realtime`. Use a non-realtime model for interim response. |
+| Results take long or don't arrive | MCP server latency varies. Interrupt and ask the assistant what it found. |
+
+See [Python Samples README](../../README.md) for available voices and additional troubleshooting.
 
 ## Additional Resources
 

--- a/python/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/python/voice-live-quickstarts/MCPQuickstart/README.md
@@ -4,16 +4,18 @@
 
 This sample demonstrates **MCP (Model Context Protocol) server integration** with Voice Live using the Azure AI Voice Live SDK for Python.
 
-Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-realtime`) — but additionally configures remote MCP servers as tools, enabling the assistant to call external services (DeepWiki, Azure Docs) during the conversation and prompting the user for approval when required.
+Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-realtime`) — but additionally configures remote MCP servers as tools, enabling the assistant to call external services (DeepWiki, Azure Docs) during the conversation. It implements a **voice-based approval flow** where the assistant verbally asks the user for permission before using tools that require consent.
 
 ## What Makes This Sample Unique
 
 This sample showcases:
 
 - **MCP Server Integration**: Configure remote MCP servers as session tools via `MCPServer` model objects
-- **Approval Flow**: Interactive console-based approval for `require_approval="always"` MCP tools
-- **MCP Event Handling**: Process MCP tool discovery, execution, and result events
-- **Flexible Authentication**: Supports both API key and Azure CLI credential authentication
+- **Voice-Based Approval**: Instead of blocking on a console prompt, the assistant verbally asks *"Should I go ahead?"* and interprets the user's spoken *yes* or *no*
+- **MCP Tool Announcements**: For auto-approved tools, the assistant says *"Let me look that up..."* while the call runs
+- **Barge-In Handling**: Interrupting during an MCP call triggers a *"Do you want to keep waiting or skip?"* inquiry
+- **Per-Turn Loop Prevention**: Approval-required servers are guarded against repeated tool calls per user turn
+- **Interim Response**: Automatically enabled for non-realtime model pipelines to bridge latency gaps
 
 ## Prerequisites
 
@@ -50,41 +52,100 @@ This sample showcases:
    python mcp-quickstart.py
    ```
 
-## Command Line Options
+## Run
+
+### API key authentication
 
 ```bash
-# Run with API key (from .env)
 python mcp-quickstart.py
-
-# Run with Azure authentication
-python mcp-quickstart.py --use-token-credential
-
-# Run with custom model and verbose logging
-python mcp-quickstart.py --model gpt-realtime --verbose
 ```
 
-### Available Options
+### Azure credential authentication
 
-- `--api-key`: Azure VoiceLive API key
-- `--endpoint`: Azure VoiceLive endpoint URL
+```bash
+az login
+python mcp-quickstart.py --use-token-credential
+```
+
+### With verbose logging
+
+```bash
+python mcp-quickstart.py --use-token-credential --verbose
+```
+
+## Command Line Options
+
+- `--api-key`: Azure VoiceLive API key (or set `AZURE_VOICELIVE_API_KEY` env var)
+- `--endpoint`: Azure VoiceLive endpoint (default: from `AZURE_VOICELIVE_ENDPOINT` env var)
 - `--model`: VoiceLive model to use (default: `gpt-realtime`)
 - `--voice`: Voice for the assistant (default: `en-US-Ava:DragonHDLatestNeural`)
 - `--instructions`: Custom system instructions for the AI
 - `--use-token-credential`: Use Azure authentication instead of API key
 - `--verbose`: Enable detailed logging
 
+## Sample Trigger Phrases
+
+| Say this | MCP Server | Approval | What happens |
+|---|---|---|---|
+| *"Can you summarize the GitHub repo azure-sdk-for-python?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls `read_wiki_structure` → `ask_question`, speaks results |
+| *"Search the Azure documentation for Voice Live API"* | Azure Docs | Voice prompt (`always`) | Assistant asks *"Should I go ahead?"*, waits for your *yes* or *no* |
+
 ## How It Works
 
 The sample extends the Model Quickstart pattern with MCP:
 
 1. **MCP Server Definitions**: Adds `MCPServer` instances to the session tools list alongside standard session configuration
-2. **Session Configuration**: Sends `session.update` with model, voice, VAD, and MCP tools
+2. **Session Configuration**: Sends `session.update` with model, voice, VAD, MCP tools, and (for non-realtime models) interim response
 3. **Tool Discovery**: Voice Live connects to each MCP server and discovers available tools
-4. **Tool Execution**: When the model decides to call an MCP tool, the service executes the call
-5. **Approval Flow**: For servers with `require_approval="always"`, the user is prompted in the console
-6. **Result Processing**: MCP call output is captured and a new response is created for the model to incorporate
+4. **Tool Announcements**: When an auto-approved tool call starts, the assistant speaks a brief acknowledgement
+5. **Voice Approval Flow**: For `require_approval="always"` servers, a system message is injected asking the model to verbally request permission. The user's spoken response is parsed for *yes*/*no* (word-boundary matching)
+6. **Result Delivery**: After MCP call completion, `response.create` kicks the model to speak the results
 
-See [Python Samples README](../../README.md) for available voices, troubleshooting, and additional resources.
+## Design Decisions: MCP in Voice UX
+
+This quickstart demonstrates several design patterns specific to integrating MCP servers in a voice-first experience:
+
+### Voice-Based Approval vs Console Prompts
+
+The [SDK sample](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/voicelive/azure-ai-voicelive/samples/async_mcp_sample.py) uses blocking `input()` for approval — fine for a console demo, but it freezes the audio pipeline. This quickstart instead:
+
+- Injects a system message prompting the model to ask verbally
+- Waits for the next `CONVERSATION_ITEM_INPUT_AUDIO_TRANSCRIPTION_COMPLETED` event
+- Parses for `\byes\b` or `\bno\b` using word-boundary regex
+- On ambiguous input, re-prompts via voice
+
+### Per-Turn Loop Prevention (Approval Servers Only)
+
+MCP tool calls that require approval can cause loops: approve → call completes → `response.create` → model calls the same tool again → new approval needed. This quickstart guards **only approval-required servers** against repeated calls in the same user turn. Auto-approved servers (like DeepWiki) are allowed to make multiple calls freely, since their multi-step patterns (e.g. `read_wiki_structure` → `ask_question`) are useful and don't interrupt the user.
+
+### Deferred Response Creation
+
+The approval voice prompt requires `response.create` to make the model speak. If a response is already active (common during MCP flows), the prompt is deferred to the next `RESPONSE_DONE` event via an `_approval_prompt_needed` flag. The same pattern applies to `response.create` after MCP completion — if it collides with an active response, it's retried at `RESPONSE_DONE`.
+
+### Approval Queuing
+
+If the model fires multiple tool calls requiring approval before the user can respond, subsequent requests are queued and asked one-by-one after each resolution. This avoids auto-approving without consent.
+
+### Barge-In During MCP Calls
+
+If the user speaks while an MCP call is running, the assistant asks whether to keep waiting or skip. If the user barges in during an unanswered approval prompt, the approval is re-queued and re-asked after the user's turn completes.
+
+### Interim Response
+
+`LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers is configured to bridge silence during tool calls. This is automatically skipped for `gpt-realtime` (not supported on the realtime pipeline) and enabled for other models.
+
+## Troubleshooting
+
+| Symptom | Resolution |
+|---|---|
+| `❌ No audio input devices found` | Connect a microphone and restart. |
+| `❌ No audio output devices found` | Connect speakers or headphones and restart. |
+| Authentication errors | Run `az login` or verify `AZURE_VOICELIVE_API_KEY` in `.env`. |
+| MCP tool discovery failed | Check that MCP server URLs are reachable from your network. |
+| Assistant doesn't ask for approval | Only servers with `require_approval="always"` trigger the voice prompt. |
+| Repeated approval prompts for same tool | Expected if the model decides to search again. The per-turn guard limits this to once per approval-required tool per user turn. |
+| Session hit maximum duration | VoiceLive sessions have a 30-minute server-side limit. Restart the sample. |
+| Interim response not supported | Expected with `gpt-realtime`. Use a non-realtime model (e.g. `gpt-4o-mini`) for interim response support. |
 
 ## Additional Resources
 

--- a/python/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/python/voice-live-quickstarts/MCPQuickstart/README.md
@@ -115,7 +115,7 @@ MCP flows generate rapid event sequences where `response.create` calls can colli
 | Say this | MCP Server | Approval | What happens |
 |---|---|---|---|
 | *"Can you summarize the GitHub repo azure-sdk-for-python?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
-| *"Search the Azure documentation for Voice Live API"* | Azure Docs | Voice prompt (`always`) | Assistant asks *"Should I go ahead?"*, waits for your *yes* or *no* |
+| *"Search the Azure documentation for Voice Live API"* | Azure Docs | Voice prompt (`always`) | Assistant asks *"Do you approve?"*, waits for your *yes* or *no* |
 
 ## How It Works
 

--- a/python/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/python/voice-live-quickstarts/MCPQuickstart/README.md
@@ -56,15 +56,28 @@ The counter resets when results are fully delivered or the user denies a request
 
 ### Silence During Tool Calls Must Be Filled
 
-MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses three layers:
+MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses three complementary layers to keep the user informed throughout:
 
-1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
-2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers generates natural filler. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline). The transcription model is also selected per pipeline: `azure-speech` for non-realtime, `whisper-1` for realtime.
-3. **Stall detection** (client-side, repeating 15s timer): Notifies the user up to 3 times that results are still pending. Note: MCP calls **cannot be cancelled** via the API — the call runs until the MCP server responds or the server-side timeout fires.
+1. **Tool announcements** (immediate, client-side): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates. This covers the first few seconds.
+
+2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers lets the service generate natural filler speech while tools run. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline). This fills the gap between the initial announcement and the stall timer.
+
+3. **Stall detection** (client-side, repeating timer): If a tool call runs longer than expected, the assistant proactively tells the user it's still waiting. This quickstart uses a **10-second interval with a maximum of 3 notifications** — tune these values based on your expected MCP server latency:
+   - **Fast servers (< 5s)**: Stall timer rarely fires. Consider increasing the interval or reducing max notifications.
+   - **Medium servers (5–15s)**: The default 10s/3-max works well. The first notification arrives before most users lose patience.
+   - **Slow servers (15–60s+)**: Consider shorter intervals (e.g. 8s) or more notifications (e.g. 5) to keep the user engaged. However, note that MCP calls **cannot be cancelled** — the notifications are status updates, not actionable options.
+
+Together, these three layers ensure continuous feedback: the announcement handles seconds 0–5, interim response (when available) fills 2–10s, and the stall timer covers 10s+ with periodic reassurance.
+
+### Batched Response After Tool Completion
+
+When the model makes multiple MCP calls in a single turn (common with search-heavy servers), this quickstart waits for **all calls to complete** before generating a response. This prevents partial results from being spoken prematurely and avoids the model making additional tool calls based on incomplete data.
+
+For approval-required servers, once the user approves the first call, subsequent calls to the **same server within the same turn are auto-approved** — avoiding repeated voice prompts for what is logically a single task.
 
 ### Barge-In During MCP Calls
 
-Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message so the model can acknowledge the user and reassure them that results are on the way. Note: since MCP calls cannot be cancelled, the assistant cannot actually skip or abort a running tool call.
+Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message so the model can acknowledge the user and respond to what they said. If the original MCP call completes later, its result is introduced as a **late result** (e.g. *"By the way, those results from earlier just came in..."*). Note: since MCP calls cannot be cancelled, the call continues running in the background regardless of what the user says.
 
 ### Response Collision Handling
 

--- a/python/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/python/voice-live-quickstarts/MCPQuickstart/README.md
@@ -22,7 +22,7 @@ Integrating MCP servers into a voice assistant introduces unique UX challenges t
 
 ### Tool Approval Must Be Voice-Native
 
-The [SDK sample](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/voicelive/azure-ai-voicelive/samples/async_mcp_sample.py) uses blocking `input()` for approval — fine for a console demo, but it freezes the audio pipeline and breaks the voice experience. In a voice UX, approvals should be handled conversationally:
+Console-based MCP samples typically use blocking `input()` for approval — fine for a terminal demo, but it freezes the audio pipeline and breaks the voice experience. In a voice UX, approvals should be handled conversationally:
 
 - Inject a system message instructing the model to **verbally ask for permission**
 - Parse the user's spoken response for clear intent (`yes`, `no`, `stop`, `cancel`)

--- a/python/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/python/voice-live-quickstarts/MCPQuickstart/README.md
@@ -1,0 +1,94 @@
+# Python – MCP Quickstart
+
+> **For common setup instructions, troubleshooting, and detailed information, see the [Python Samples README](../../README.md)**
+
+This sample demonstrates **MCP (Model Context Protocol) server integration** with Voice Live using the Azure AI Voice Live SDK for Python.
+
+Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-realtime`) — but additionally configures remote MCP servers as tools, enabling the assistant to call external services (DeepWiki, Azure Docs) during the conversation and prompting the user for approval when required.
+
+## What Makes This Sample Unique
+
+This sample showcases:
+
+- **MCP Server Integration**: Configure remote MCP servers as session tools via `MCPServer` model objects
+- **Approval Flow**: Interactive console-based approval for `require_approval="always"` MCP tools
+- **MCP Event Handling**: Process MCP tool discovery, execution, and result events
+- **Flexible Authentication**: Supports both API key and Azure CLI credential authentication
+
+## Prerequisites
+
+- [AI Foundry resource](https://learn.microsoft.com/en-us/azure/ai-services/multi-service-resource)
+- API key or [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) for authentication
+- See [Python Samples README](../../README.md) for common prerequisites
+
+## Quick Start
+
+1. **Create and activate virtual environment**:
+   ```bash
+   python -m venv .venv
+
+   # On Windows
+   .venv\Scripts\activate
+
+   # On Linux/macOS
+   source .venv/bin/activate
+   ```
+
+2. **Install dependencies**:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. **Update `.env` file** (in the parent `voice-live-quickstarts/` folder):
+   ```plaintext
+   AZURE_VOICELIVE_ENDPOINT=https://your-endpoint.services.ai.azure.com/
+   AZURE_VOICELIVE_API_KEY=your-api-key
+   ```
+
+4. **Run the sample**:
+   ```bash
+   python mcp-quickstart.py
+   ```
+
+## Command Line Options
+
+```bash
+# Run with API key (from .env)
+python mcp-quickstart.py
+
+# Run with Azure authentication
+python mcp-quickstart.py --use-token-credential
+
+# Run with custom model and verbose logging
+python mcp-quickstart.py --model gpt-realtime --verbose
+```
+
+### Available Options
+
+- `--api-key`: Azure VoiceLive API key
+- `--endpoint`: Azure VoiceLive endpoint URL
+- `--model`: VoiceLive model to use (default: `gpt-realtime`)
+- `--voice`: Voice for the assistant (default: `en-US-Ava:DragonHDLatestNeural`)
+- `--instructions`: Custom system instructions for the AI
+- `--use-token-credential`: Use Azure authentication instead of API key
+- `--verbose`: Enable detailed logging
+
+## How It Works
+
+The sample extends the Model Quickstart pattern with MCP:
+
+1. **MCP Server Definitions**: Adds `MCPServer` instances to the session tools list alongside standard session configuration
+2. **Session Configuration**: Sends `session.update` with model, voice, VAD, and MCP tools
+3. **Tool Discovery**: Voice Live connects to each MCP server and discovers available tools
+4. **Tool Execution**: When the model decides to call an MCP tool, the service executes the call
+5. **Approval Flow**: For servers with `require_approval="always"`, the user is prompted in the console
+6. **Result Processing**: MCP call output is captured and a new response is created for the model to incorporate
+
+See [Python Samples README](../../README.md) for available voices, troubleshooting, and additional resources.
+
+## Additional Resources
+
+- [Voice Live Documentation](https://learn.microsoft.com/azure/ai-services/speech-service/voice-live)
+- [Python SDK Documentation](https://learn.microsoft.com/python/api/overview/azure/ai-voicelive-readme)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [Support Guide](../../../SUPPORT.md)

--- a/python/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/python/voice-live-quickstarts/MCPQuickstart/README.md
@@ -12,7 +12,7 @@ Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-r
 - **Voice-Based Approval**: Instead of blocking on a console prompt, the assistant verbally asks *"Do you approve?"* and interprets the user's spoken *yes* or *no*
 - **Context-Aware Repeat Approvals**: When the model needs additional searches, the prompt changes to *"I need one more search. Should I continue?"*
 - **MCP Tool Announcements**: For auto-approved tools, the assistant says a brief acknowledgement while the call runs
-- **Barge-In Handling**: Interrupting during an MCP call triggers a *"Do you want to keep waiting or skip?"* inquiry
+- **Barge-In Handling**: Interrupting during an MCP call prompts the assistant to acknowledge and reassure the user
 - **MCP Stall Detection**: If a tool call takes >15 seconds, the assistant proactively tells the user it's still waiting
 - **Interim Response**: Automatically enabled for non-realtime model pipelines to bridge latency gaps
 
@@ -60,11 +60,11 @@ MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the a
 
 1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
 2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers generates natural filler. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline). The transcription model is also selected per pipeline: `azure-speech` for non-realtime, `whisper-1` for realtime.
-3. **Stall detection** (client-side, repeating 15s timer): Notifies the user every 15 seconds while an MCP call is running. After 30 seconds, offers the user a choice to keep waiting or move on.
+3. **Stall detection** (client-side, repeating 15s timer): Notifies the user up to 3 times that results are still pending. Note: MCP calls **cannot be cancelled** via the API — the call runs until the MCP server responds or the server-side timeout fires.
 
 ### Barge-In During MCP Calls
 
-Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message asking the model to check: *"Do you want to keep waiting or skip?"* The model handles the conversation naturally from there.
+Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message so the model can acknowledge the user and reassure them that results are on the way. Note: since MCP calls cannot be cancelled, the assistant cannot actually skip or abort a running tool call.
 
 ### Response Collision Handling
 

--- a/python/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/python/voice-live-quickstarts/MCPQuickstart/README.md
@@ -132,13 +132,15 @@ Not all MCP servers are well-suited for voice UX. Servers that respond quickly (
 
 ## Command Line Options
 
-- `--api-key`: Azure VoiceLive API key (or set `AZURE_VOICELIVE_API_KEY` env var)
-- `--endpoint`: Azure VoiceLive endpoint (default: from `AZURE_VOICELIVE_ENDPOINT` env var)
-- `--model`: VoiceLive model to use (default: `gpt-realtime`)
-- `--voice`: Voice for the assistant (default: `en-US-Ava:DragonHDLatestNeural`)
-- `--instructions`: Custom system instructions for the AI
-- `--use-token-credential`: Use Azure authentication instead of API key
-- `--verbose`: Enable detailed logging
+| Flag | Description |
+|---|---|
+| `--api-key` | Azure VoiceLive API key (or set `AZURE_VOICELIVE_API_KEY` env var) |
+| `--endpoint` | Azure VoiceLive endpoint (default: from `AZURE_VOICELIVE_ENDPOINT` env var) |
+| `--model` | VoiceLive model to use (default: `gpt-realtime`) |
+| `--voice` | Voice for the assistant (default: `en-US-Ava:DragonHDLatestNeural`) |
+| `--instructions` | Custom system instructions for the AI |
+| `--use-token-credential` | Use Azure authentication instead of API key |
+| `--verbose` | Enable detailed logging |
 
 ## Sample Trigger Phrases
 

--- a/python/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/python/voice-live-quickstarts/MCPQuickstart/README.md
@@ -9,11 +9,59 @@ Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-r
 ## What Makes This Sample Unique
 
 - **MCP Server Integration**: Configure remote MCP servers as session tools via `MCPServer` model objects
-- **Voice-Based Approval**: Instead of blocking on a console prompt, the assistant verbally asks *"Should I go ahead?"* and interprets the user's spoken *yes* or *no*
-- **Context-Aware Repeat Approvals**: When the model needs additional searches, the prompt changes to *"I need one more search for complete info. Should I continue?"*
+- **Voice-Based Approval**: Instead of blocking on a console prompt, the assistant verbally asks *"Do you approve?"* and interprets the user's spoken *yes* or *no*
+- **Context-Aware Repeat Approvals**: When the model needs additional searches, the prompt changes to *"I need one more search. Should I continue?"*
 - **MCP Tool Announcements**: For auto-approved tools, the assistant says a brief acknowledgement while the call runs
 - **Barge-In Handling**: Interrupting during an MCP call triggers a *"Do you want to keep waiting or skip?"* inquiry
+- **MCP Stall Detection**: If a tool call takes >15 seconds, the assistant proactively tells the user it's still waiting
 - **Interim Response**: Automatically enabled for non-realtime model pipelines to bridge latency gaps
+
+## Voice UX Considerations for MCP Integration
+
+Integrating MCP servers into a voice assistant introduces unique UX challenges that don't exist in text-based or console-based MCP clients. This quickstart demonstrates patterns to address them. When building your own voice-enabled MCP application, consider the following:
+
+### Tool Approval Must Be Voice-Native
+
+The [SDK sample](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/voicelive/azure-ai-voicelive/samples/async_mcp_sample.py) uses blocking `input()` for approval — fine for a console demo, but it freezes the audio pipeline and breaks the voice experience. In a voice UX, approvals should be handled conversationally:
+
+- Inject a system message instructing the model to **verbally ask for permission**
+- Parse the user's spoken response for clear intent (`yes`, `no`, `stop`, `cancel`)
+- Allow **barge-in** — the user should be able to say "yes" without waiting for the full approval prompt to finish
+
+This quickstart uses word-boundary regex (`\byes\b`, `\b(no|stop|cancel)\b`) to avoid false positives from words like "yesterday" or "nobody".
+
+### System Instructions Must Teach the Model About Approval
+
+The model needs explicit instructions about the approval flow. Without them, it may paraphrase the permission request into a generic *"Let me look that up"* — skipping the actual question. This quickstart includes in the system prompt:
+
+> *"Some tools require user approval. When you receive a system message asking you to request permission, you MUST clearly ask the user for their explicit approval. Never skip the approval question or assume permission is granted."*
+
+The per-request system messages use `"Say exactly:"` phrasing to prevent the model from rewording the question.
+
+### Repeated Tool Calls Need Contextual Messaging
+
+MCP servers like Azure Docs may require multiple searches to gather complete information. Each search triggers a separate approval if `require_approval="always"`. Rather than asking the identical question each time, this quickstart tracks the call count per server:
+
+- **First call**: *"I'd like to search the azure_doc service. Do you approve?"*
+- **Subsequent calls**: *"I need one more search for complete information. Should I continue?"*
+
+The counter resets when results are fully delivered or the user denies a request.
+
+### Silence During Tool Calls Must Be Filled
+
+MCP tool calls can take 3–60+ seconds. Without feedback, the user thinks the assistant is broken. This quickstart uses three layers:
+
+1. **Tool announcements** (immediate): For auto-approved servers, the assistant says *"Let me look that up"* when the call starts. Skipped for approval-required servers since the approval prompt already communicates.
+2. **Interim response** (server-side, non-realtime models only): `LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers generates natural filler. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline).
+3. **Stall detection** (client-side, 15s timer): If the MCP call takes >15 seconds, the assistant proactively says *"Still waiting for results..."*. This is the **only** verbal feedback for slow calls on `gpt-realtime`.
+
+### Barge-In During MCP Calls
+
+Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message asking the model to check: *"Do you want to keep waiting or skip?"* The model handles the conversation naturally from there.
+
+### Response Collision Handling
+
+MCP flows generate rapid event sequences where `response.create` calls can collide with active responses. This quickstart defers collisions to the next `RESPONSE_DONE` event via a flag, ensuring tool results and approval prompts are never silently dropped.
 
 ## Prerequisites
 
@@ -77,36 +125,6 @@ Like the Model Quickstart, this sample connects directly to a model (e.g. `gpt-r
 4. **Tool Announcements**: Auto-approved tool calls trigger a brief spoken acknowledgement
 5. **Voice Approval**: For `require_approval="always"` servers, a system message is injected prompting the model to ask verbally. The user's spoken response is parsed for *yes*/*no* using word-boundary regex
 6. **Result Delivery**: After MCP call completion, `response.create` kicks the model to speak the results
-
-## Design Decisions: MCP in Voice UX
-
-### Voice-Based Approval vs Console Prompts
-
-The [SDK sample](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/voicelive/azure-ai-voicelive/samples/async_mcp_sample.py) uses blocking `input()` for approval — fine for a console demo, but it freezes the audio pipeline. This quickstart injects system messages to make the model ask verbally, then parses the next transcription for `\byes\b` or `\b(no|stop|cancel)\b` using word-boundary regex. Users can barge in with "yes" without waiting for the full prompt to finish.
-
-### Context-Aware Repeat Approvals
-
-MCP servers may require multiple tool calls to gather complete information. Rather than blocking repeated calls, this quickstart tracks the call count per server per user turn:
-- **First call**: *"I need your permission to use X from Y. Should I go ahead?"*
-- **Subsequent calls**: *"I need one more search for more complete information. Should I continue?"*
-
-The counter resets when the user starts a new topic (speech without pending approval) or when the user denies a request.
-
-### Tool Announcements (Auto-Approved Servers Only)
-
-For servers with `require_approval="never"`, the assistant speaks a brief one-sentence acknowledgement when a tool call starts. This is skipped for approval-required servers since the approval prompt already communicates with the user.
-
-### Barge-In During MCP Calls
-
-If the user speaks while an MCP call is running, a system message asks the model to briefly check: *"Do you want to keep waiting or skip?"* The model handles the conversation naturally.
-
-### Deferred Response Creation
-
-`response.create` calls that collide with an active response are deferred to the next `RESPONSE_DONE` event via a `_needs_response_create` flag, avoiding "active response in progress" errors.
-
-### Interim Response
-
-`LlmInterimResponseConfig` with `TOOL` and `LATENCY` triggers is configured for non-realtime models. Automatically skipped for `gpt-realtime` (not supported on the realtime pipeline).
 
 ## Troubleshooting
 

--- a/python/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/python/voice-live-quickstarts/MCPQuickstart/README.md
@@ -121,7 +121,7 @@ MCP flows generate rapid event sequences where `response.create` calls can colli
 
 | Say this | MCP Server | Approval | What happens |
 |---|---|---|---|
-| *"Can you summarize the GitHub repo azure-sdk-for-python?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
+| *"What is the GitHub repo fastapi about?"* | DeepWiki | Auto (`never`) | Assistant announces lookup, calls tools, speaks results |
 | *"Search the Azure documentation for Voice Live API"* | Azure Docs | Voice prompt (`always`) | Assistant asks *"Do you approve?"*, waits for your *yes* or *no* |
 
 ## How It Works

--- a/python/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/python/voice-live-quickstarts/MCPQuickstart/README.md
@@ -70,6 +70,16 @@ Users will naturally try to interrupt or ask *"Are you still there?"* during lon
 
 MCP flows generate rapid event sequences where `response.create` calls can collide with active responses. This quickstart defers collisions to the next `RESPONSE_DONE` event via a flag, ensuring tool results and approval prompts are never silently dropped.
 
+### MCP Server Selection: Latency Matters
+
+Not all MCP servers are well-suited for voice UX. Servers that respond quickly (< 5 seconds) provide a seamless experience, while slow servers (10–60+ seconds) create awkward silence even with stall notifications. When choosing MCP servers for a voice assistant:
+
+- **Prefer low-latency servers** — search APIs, simple lookups, and cached data sources work best
+- **Avoid servers that perform heavy computation** — large repo analysis, complex document retrieval, or multi-step workflows can take 30–60+ seconds, degrading the voice experience
+- **MCP calls cannot be cancelled** — once a call starts, it runs until the server responds or times out. There is no client-side or API-level cancellation mechanism
+- **Late results arrive out of context** — if the user moves on during a slow MCP call, the result arrives asynchronously and must be introduced as a late result, which can feel disjointed
+- **Consider whether async results are acceptable** for your use case. If users expect real-time answers, long-running MCP servers will frustrate them. If they expect a research-assistant style interaction where results trickle in, it may be acceptable
+
 ## Prerequisites
 
 - [AI Foundry resource](https://learn.microsoft.com/en-us/azure/ai-services/multi-service-resource)

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -383,7 +383,9 @@ class MCPVoiceAssistant:
             input_audio_noise_reduction=AudioNoiseReduction(type="azure_deep_noise_suppression"),
             tools=mcp_tools,
             tool_choice=ToolChoiceLiteral.AUTO,
-            input_audio_transcription=AudioInputTranscriptionOptions(model="whisper-1"),
+            input_audio_transcription=AudioInputTranscriptionOptions(
+                model="azure-speech" if "realtime" not in self.model.lower() else "whisper-1"
+            ),
         )
 
         # Interim response bridges latency during MCP tool calls, but is only

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -341,7 +341,7 @@ class MCPVoiceAssistant:
                 print("\n" + "=" * 70)
                 print("🎤 VOICE ASSISTANT WITH MCP READY")
                 print("Try saying:")
-                print("  • 'Can you summarize the GitHub repo azure-sdk-for-python?'")
+                print("  • 'What is the GitHub repo fastapi about?'")
                 print("  • 'Search the Azure documentation for Voice Live API.'")
                 print("You may need to approve some MCP tool calls in the console.")
                 print("Press Ctrl+C to exit")

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -1,0 +1,710 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# -------------------------------------------------------------------------
+
+"""
+FILE: mcp-quickstart.py
+
+DESCRIPTION:
+    This sample demonstrates how to use the Azure AI Voice Live SDK with MCP
+    (Model Context Protocol) server integration. It shows how to define MCP
+    servers, handle MCP tool call events, and implement an approval flow for
+    tool calls that require user consent.
+
+USAGE:
+    python mcp-quickstart.py --use-token-credential
+
+    Set the environment variables with your own values before running the sample:
+    1) AZURE_VOICELIVE_ENDPOINT - The Azure VoiceLive endpoint
+    2) AZURE_VOICELIVE_API_KEY  - The Azure VoiceLive API key (if not using token credential)
+
+REQUIREMENTS:
+    - azure-ai-voicelive
+    - python-dotenv
+    - pyaudio (for audio capture and playback)
+    - azure-identity (for token credential authentication)
+"""
+
+from __future__ import annotations
+import os
+import sys
+import argparse
+import asyncio
+import base64
+from datetime import datetime
+import logging
+import queue
+import signal
+from typing import Union, Optional, TYPE_CHECKING, cast
+
+from azure.core.credentials import AzureKeyCredential
+from azure.core.credentials_async import AsyncTokenCredential
+from azure.identity.aio import AzureCliCredential
+
+from azure.ai.voicelive.aio import connect
+from azure.ai.voicelive.models import (
+    AudioEchoCancellation,
+    AudioNoiseReduction,
+    AzureStandardVoice,
+    InputAudioFormat,
+    ItemType,
+    MCPApprovalResponseRequestItem,
+    MCPServer,
+    Modality,
+    OutputAudioFormat,
+    RequestSession,
+    ResponseMCPApprovalRequestItem,
+    ResponseMCPCallItem,
+    ServerEventConversationItemCreated,
+    ServerEventResponseMcpCallArgumentsDone,
+    ServerEventResponseMcpCallCompleted,
+    ServerEventResponseOutputItemDone,
+    ServerEventType,
+    ServerVad,
+    Tool,
+    ToolChoiceLiteral,
+)
+from dotenv import load_dotenv
+import pyaudio
+
+if TYPE_CHECKING:
+    from azure.ai.voicelive.aio import VoiceLiveConnection
+
+# Change to the directory where this script is located
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+# Environment variable loading
+load_dotenv('../.env', override=True)
+
+# Set up logging
+if not os.path.exists('logs'):
+    os.makedirs('logs')
+
+timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+
+logging.basicConfig(
+    filename=f'logs/{timestamp}_voicelive.log',
+    filemode="w",
+    format='%(asctime)s:%(name)s:%(levelname)s:%(message)s',
+    level=logging.INFO
+)
+logger = logging.getLogger(__name__)
+
+
+async def _wait_for_event(conn, wanted_types: set, timeout_s: float = 30.0):
+    """Wait until we receive any event whose type is in wanted_types."""
+    async def _next():
+        while True:
+            evt = await conn.recv()
+            if evt.type in wanted_types:
+                return evt
+    return await asyncio.wait_for(_next(), timeout=timeout_s)
+
+
+class AudioProcessor:
+    """
+    Handles real-time audio capture and playback for the voice assistant.
+
+    Threading Architecture:
+    - Main thread: Event loop and UI
+    - Capture thread: PyAudio input stream reading
+    - Send thread: Async audio data transmission to VoiceLive
+    - Playback thread: PyAudio output stream writing
+    """
+
+    loop: asyncio.AbstractEventLoop
+
+    class AudioPlaybackPacket:
+        """Represents a packet that can be sent to the audio playback queue."""
+        def __init__(self, seq_num: int, data: Optional[bytes]):
+            self.seq_num = seq_num
+            self.data = data
+
+    def __init__(self, connection):
+        self.connection = connection
+        self.audio = pyaudio.PyAudio()
+
+        # Audio configuration - PCM16, 24kHz, mono
+        self.format = pyaudio.paInt16
+        self.channels = 1
+        self.rate = 24000
+        self.chunk_size = 1200  # 50ms
+
+        # Capture and playback state
+        self.input_stream = None
+
+        self.playback_queue: queue.Queue[AudioProcessor.AudioPlaybackPacket] = queue.Queue()
+        self.playback_base = 0
+        self.next_seq_num = 0
+        self.output_stream: Optional[pyaudio.Stream] = None
+
+        logger.info("AudioProcessor initialized with 24kHz PCM16 mono audio")
+
+    def start_capture(self):
+        """Start capturing audio from microphone."""
+        def _capture_callback(in_data, _frame_count, _time_info, _status_flags):
+            audio_base64 = base64.b64encode(in_data).decode("utf-8")
+            asyncio.run_coroutine_threadsafe(
+                self.connection.input_audio_buffer.append(audio=audio_base64), self.loop
+            )
+            return (None, pyaudio.paContinue)
+
+        if self.input_stream:
+            return
+
+        self.loop = asyncio.get_event_loop()
+
+        try:
+            self.input_stream = self.audio.open(
+                format=self.format,
+                channels=self.channels,
+                rate=self.rate,
+                input=True,
+                frames_per_buffer=self.chunk_size,
+                stream_callback=_capture_callback,
+            )
+            logger.info("Started audio capture")
+        except Exception:
+            logger.exception("Failed to start audio capture")
+            raise
+
+    def start_playback(self):
+        """Initialize audio playback system."""
+        if self.output_stream:
+            return
+
+        remaining = bytes()
+
+        def _playback_callback(_in_data, frame_count, _time_info, _status_flags):
+            nonlocal remaining
+            frame_count *= pyaudio.get_sample_size(pyaudio.paInt16)
+
+            out = remaining[:frame_count]
+            remaining_local = remaining[frame_count:]
+
+            while len(out) < frame_count:
+                try:
+                    packet = self.playback_queue.get_nowait()
+                except queue.Empty:
+                    out = out + bytes(frame_count - len(out))
+                    continue
+
+                if not packet or not packet.data:
+                    break
+
+                if packet.seq_num < self.playback_base:
+                    continue
+
+                num_to_take = frame_count - len(out)
+                out = out + packet.data[:num_to_take]
+                remaining_local = packet.data[num_to_take:]
+
+            remaining = remaining_local
+
+            if len(out) >= frame_count:
+                return (out, pyaudio.paContinue)
+            else:
+                return (out, pyaudio.paComplete)
+
+        try:
+            self.output_stream = self.audio.open(
+                format=self.format,
+                channels=self.channels,
+                rate=self.rate,
+                output=True,
+                frames_per_buffer=self.chunk_size,
+                stream_callback=_playback_callback
+            )
+            logger.info("Audio playback system ready")
+        except Exception:
+            logger.exception("Failed to initialize audio playback")
+            raise
+
+    def _get_and_increase_seq_num(self):
+        seq = self.next_seq_num
+        self.next_seq_num += 1
+        return seq
+
+    def queue_audio(self, audio_data: Optional[bytes]) -> None:
+        """Queue audio data for playback."""
+        self.playback_queue.put(
+            AudioProcessor.AudioPlaybackPacket(
+                seq_num=self._get_and_increase_seq_num(),
+                data=audio_data))
+
+    def skip_pending_audio(self):
+        """Skip current audio in playback queue."""
+        self.playback_base = self._get_and_increase_seq_num()
+
+    def shutdown(self):
+        """Clean up audio resources."""
+        if self.input_stream:
+            self.input_stream.stop_stream()
+            self.input_stream.close()
+            self.input_stream = None
+        logger.info("Stopped audio capture")
+
+        if self.output_stream:
+            self.skip_pending_audio()
+            self.queue_audio(None)
+            self.output_stream.stop_stream()
+            self.output_stream.close()
+            self.output_stream = None
+        logger.info("Stopped audio playback")
+
+        if self.audio:
+            self.audio.terminate()
+        logger.info("Audio processor cleaned up")
+
+
+class MCPVoiceAssistant:
+    """Voice assistant with MCP server integration."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        credential: Union[AzureKeyCredential, AsyncTokenCredential],
+        model: str,
+        voice: str,
+        instructions: str,
+    ):
+        self.endpoint = endpoint
+        self.credential = credential
+        self.model = model
+        self.voice = voice
+        self.instructions = instructions
+        self.connection: Optional["VoiceLiveConnection"] = None
+        self.audio_processor: Optional[AudioProcessor] = None
+        self.session_ready = False
+        self._active_response = False
+        self._response_api_done = False
+
+    async def start(self):
+        """Start the voice assistant session with MCP support."""
+        try:
+            logger.info("Connecting to VoiceLive API with model %s", self.model)
+
+            # <define_mcp_servers>
+            # Define MCP servers that Voice Live can use during the session.
+            # Each server is an MCPServer instance added to the tools list.
+            mcp_tools: list[Tool] = [
+                MCPServer(
+                    server_label="deepwiki",
+                    server_url="https://mcp.deepwiki.com/mcp",
+                    allowed_tools=["read_wiki_structure", "ask_question"],
+                    require_approval="never",
+                ),
+                MCPServer(
+                    server_label="azure_doc",
+                    server_url="https://learn.microsoft.com/api/mcp",
+                    require_approval="always",
+                ),
+            ]
+            # </define_mcp_servers>
+
+            # Connect with api_version="2026-01-01-preview" for MCP support
+            async with connect(
+                endpoint=self.endpoint,
+                credential=self.credential,
+                model=self.model,
+                api_version="2026-01-01-preview",
+            ) as connection:
+                self.connection = connection
+
+                # Initialize audio processor
+                ap = AudioProcessor(connection)
+                self.audio_processor = ap
+
+                # Configure session with MCP tools
+                await self._setup_session(mcp_tools)
+
+                # Start audio systems
+                ap.start_playback()
+
+                logger.info("Voice assistant with MCP ready! Start speaking...")
+                print("\n" + "=" * 70)
+                print("🎤 VOICE ASSISTANT WITH MCP READY")
+                print("Try saying:")
+                print("  • 'Can you summarize the GitHub repo azure-sdk-for-python?'")
+                print("  • 'Search the Azure documentation for Voice Live API.'")
+                print("You may need to approve some MCP tool calls in the console.")
+                print("Press Ctrl+C to exit")
+                print("=" * 70 + "\n")
+
+                # Process events
+                await self._process_events()
+        finally:
+            if self.audio_processor:
+                self.audio_processor.shutdown()
+
+    # <configure_session>
+    async def _setup_session(self, mcp_tools: list[Tool]):
+        """Configure the VoiceLive session with MCP tools."""
+        logger.info("Setting up voice conversation session with MCP tools...")
+
+        # Create voice configuration
+        voice_config: Union[AzureStandardVoice, str]
+        if "-" in self.voice or ":" in self.voice:
+            voice_config = AzureStandardVoice(name=self.voice)
+        else:
+            voice_config = self.voice
+
+        # Create turn detection configuration
+        turn_detection_config = ServerVad(
+            threshold=0.5,
+            prefix_padding_ms=300,
+            silence_duration_ms=500)
+
+        # Create session configuration with MCP tools in the tools list
+        session_config = RequestSession(
+            modalities=[Modality.TEXT, Modality.AUDIO],
+            instructions=self.instructions,
+            voice=voice_config,
+            input_audio_format=InputAudioFormat.PCM16,
+            output_audio_format=OutputAudioFormat.PCM16,
+            turn_detection=turn_detection_config,
+            input_audio_echo_cancellation=AudioEchoCancellation(),
+            input_audio_noise_reduction=AudioNoiseReduction(type="azure_deep_noise_suppression"),
+            tools=mcp_tools,
+            tool_choice=ToolChoiceLiteral.AUTO,
+        )
+
+        conn = self.connection
+        assert conn is not None
+        await conn.session.update(session=session_config)
+        logger.info("Session configuration with MCP tools sent")
+    # </configure_session>
+
+    async def _process_events(self):
+        """Process events from the VoiceLive connection."""
+        try:
+            conn = self.connection
+            assert conn is not None
+            async for event in conn:
+                await self._handle_event(event)
+        except Exception:
+            logger.exception("Error processing events")
+            raise
+
+    # <handle_mcp_events>
+    async def _handle_event(self, event):
+        """Handle different types of events from VoiceLive, including MCP events."""
+        ap = self.audio_processor
+        conn = self.connection
+        assert ap is not None
+        assert conn is not None
+
+        if event.type == ServerEventType.SESSION_UPDATED:
+            logger.info("Session ready: %s", event.session.id)
+            self.session_ready = True
+            ap.start_capture()
+
+        elif event.type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STARTED:
+            logger.info("User started speaking - stopping playback")
+            print("🎤 Listening...")
+            ap.skip_pending_audio()
+            if self._active_response and not self._response_api_done:
+                try:
+                    await conn.response.cancel()
+                except Exception as e:
+                    if "no active response" not in str(e).lower():
+                        logger.warning("Cancel failed: %s", e)
+
+        elif event.type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED:
+            logger.info("User stopped speaking")
+            print("🤔 Processing...")
+
+        elif event.type == ServerEventType.RESPONSE_CREATED:
+            logger.info("Assistant response created")
+            self._active_response = True
+            self._response_api_done = False
+
+        elif event.type == ServerEventType.RESPONSE_AUDIO_DELTA:
+            ap.queue_audio(event.delta)
+
+        elif event.type == ServerEventType.RESPONSE_AUDIO_DONE:
+            logger.info("Assistant finished speaking")
+            print("🎤 Ready for next input...")
+
+        elif event.type == ServerEventType.RESPONSE_DONE:
+            logger.info("Response complete")
+            self._active_response = False
+            self._response_api_done = True
+
+        elif event.type == ServerEventType.ERROR:
+            msg = event.error.message
+            if "Cancellation failed: no active response" not in msg:
+                logger.error("VoiceLive error: %s", msg)
+                print(f"Error: {msg}")
+
+        # MCP-specific events
+        elif event.type == ServerEventType.MCP_LIST_TOOLS_IN_PROGRESS:
+            logger.info("MCP list tools in progress for %s", event.item_id)
+
+        elif event.type == ServerEventType.MCP_LIST_TOOLS_COMPLETED:
+            logger.info("MCP list tools completed for %s", event.item_id)
+            print("🔧 MCP tools discovered successfully")
+
+        elif event.type == ServerEventType.MCP_LIST_TOOLS_FAILED:
+            logger.error("MCP list tools failed for %s", event.item_id)
+            print("❌ MCP tool discovery failed")
+
+        elif event.type == ServerEventType.RESPONSE_MCP_CALL_IN_PROGRESS:
+            logger.info("MCP call in progress for %s", event.item_id)
+            print("⏳ MCP tool call in progress...")
+
+        elif event.type == ServerEventType.RESPONSE_MCP_CALL_COMPLETED:
+            logger.info("MCP call completed for %s", event.item_id)
+            await self._handle_mcp_call_completed(event, conn)
+
+        elif event.type == ServerEventType.RESPONSE_MCP_CALL_FAILED:
+            logger.error("MCP call failed for %s", event.item_id)
+            print("❌ MCP tool call failed")
+
+        elif event.type == ServerEventType.CONVERSATION_ITEM_CREATED:
+            logger.info("Conversation item created: id=%s, type=%s", event.item.id, event.item.type)
+            if event.item.type == ItemType.MCP_LIST_TOOLS:
+                logger.info("MCP list tools item: server_label=%s", event.item.server_label)
+            elif event.item.type == ItemType.MCP_CALL:
+                await self._handle_mcp_call_arguments(event, conn)
+            elif event.item.type == ItemType.MCP_APPROVAL_REQUEST:
+                await self._handle_mcp_approval_request(event, conn)
+        else:
+            logger.debug("Unhandled event type: %s", event.type)
+    # </handle_mcp_events>
+
+    # <handle_approval>
+    async def _handle_mcp_approval_request(self, conversation_created_event, connection):
+        """Handle MCP approval request events by prompting the user."""
+        if not isinstance(conversation_created_event, ServerEventConversationItemCreated):
+            logger.error("Expected ServerEventConversationItemCreated")
+            return
+        if not isinstance(conversation_created_event.item, ResponseMCPApprovalRequestItem):
+            logger.error("Expected ResponseMCPApprovalRequestItem")
+            return
+
+        mcp_approval_item = conversation_created_event.item
+        approval_id = mcp_approval_item.id
+        server_label = mcp_approval_item.server_label
+        function_name = mcp_approval_item.name
+        arguments = mcp_approval_item.arguments
+
+        if not approval_id:
+            logger.error("MCP approval item missing ID")
+            return
+
+        print(f"\n🔐 MCP Approval Request:")
+        print(f"   Server:    {server_label}")
+        print(f"   Tool:      {function_name}")
+        print(f"   Arguments: {arguments}")
+
+        # Prompt the user for approval
+        approval_response = False
+        while True:
+            user_input = input("   Approve? (y/n): ").strip().lower()
+            if user_input == "y":
+                approval_response = True
+                break
+            elif user_input == "n":
+                approval_response = False
+                break
+            else:
+                print("   Invalid input. Please type 'y' to approve or 'n' to deny.")
+
+        # Send the approval or denial response
+        approval_response_item = MCPApprovalResponseRequestItem(
+            approval_request_id=approval_id, approve=approval_response
+        )
+        await connection.conversation.item.create(item=approval_response_item)
+        logger.info("Sent approval response: %s for %s", approval_response, function_name)
+    # </handle_approval>
+
+    async def _handle_mcp_call_completed(self, mcp_call_completed_event, connection):
+        """Handle MCP call completed events."""
+        if not isinstance(mcp_call_completed_event, ServerEventResponseMcpCallCompleted):
+            logger.error("Expected ServerEventResponseMcpCallCompleted")
+            return
+
+        mcp_call_item_id = mcp_call_completed_event.item_id
+        mcp_call_done = await _wait_for_event(connection, {ServerEventType.RESPONSE_OUTPUT_ITEM_DONE})
+        if not isinstance(mcp_call_done, ServerEventResponseOutputItemDone):
+            logger.error("Expected ServerEventResponseOutputItemDone")
+            return
+        if not isinstance(mcp_call_done.item, ResponseMCPCallItem):
+            logger.error("Expected ResponseMCPCallItem")
+            return
+        if mcp_call_done.item.id != mcp_call_item_id:
+            logger.error("Item ID mismatch: expected %s, got %s", mcp_call_item_id, mcp_call_done.item.id)
+            return
+
+        mcp_output = mcp_call_done.item.output
+        logger.info("MCP Call output received: %s", mcp_output)
+        print("✅ MCP tool call completed successfully")
+
+        # Create a new response to process the MCP output
+        await connection.response.create()
+
+    async def _handle_mcp_call_arguments(self, conversation_created_event, connection):
+        """Handle MCP call events and wait for arguments to stream in."""
+        if not isinstance(conversation_created_event, ServerEventConversationItemCreated):
+            logger.error("Expected ServerEventConversationItemCreated")
+            return
+        if not isinstance(conversation_created_event.item, ResponseMCPCallItem):
+            logger.error("Expected ResponseMCPCallItem")
+            return
+
+        mcp_call_item = conversation_created_event.item
+        server_label = mcp_call_item.server_label
+        function_name = mcp_call_item.name
+
+        logger.info("MCP Call triggered: server_label=%s, function_name=%s", server_label, function_name)
+        print(f"🔧 MCP tool call: {server_label}/{function_name}")
+
+        try:
+            # Wait for the MCP call arguments to be complete
+            mcp_arguments_done = await _wait_for_event(
+                connection, {ServerEventType.RESPONSE_MCP_CALL_ARGUMENTS_DONE}
+            )
+            if not isinstance(mcp_arguments_done, ServerEventResponseMcpCallArgumentsDone):
+                logger.error("Expected ServerEventResponseMcpCallArgumentsDone")
+                return
+            if mcp_arguments_done.item_id != mcp_call_item.id:
+                logger.warning("Item ID mismatch: expected %s, got %s",
+                               mcp_call_item.id, mcp_arguments_done.item_id)
+                return
+
+            arguments = mcp_arguments_done.arguments or "{}"
+            logger.info("MCP Call arguments received: %s", arguments)
+
+            # Wait for response to be done before proceeding
+            await _wait_for_event(connection, {ServerEventType.RESPONSE_DONE})
+
+        except asyncio.TimeoutError:
+            logger.error("Timeout waiting for MCP call arguments done for %s", function_name)
+        except Exception as e:
+            logger.error("Error waiting for MCP call arguments done: %s", e)
+
+
+def parse_arguments():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Voice Assistant with MCP using Azure VoiceLive SDK",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--api-key",
+        help="Azure VoiceLive API key.",
+        type=str,
+        default=os.environ.get("AZURE_VOICELIVE_API_KEY"),
+    )
+    parser.add_argument(
+        "--endpoint",
+        help="Azure VoiceLive endpoint",
+        type=str,
+        default=os.environ.get("AZURE_VOICELIVE_ENDPOINT", "https://your-resource-name.services.ai.azure.com/"),
+    )
+    parser.add_argument(
+        "--model",
+        help="VoiceLive model to use",
+        type=str,
+        default=os.environ.get("AZURE_VOICELIVE_MODEL", "gpt-realtime"),
+    )
+    parser.add_argument(
+        "--voice",
+        help="Voice to use for the assistant",
+        type=str,
+        default=os.environ.get("AZURE_VOICELIVE_VOICE", "en-US-Ava:DragonHDLatestNeural"),
+    )
+    parser.add_argument(
+        "--instructions",
+        help="System instructions for the AI assistant",
+        type=str,
+        default=os.environ.get(
+            "AZURE_VOICELIVE_INSTRUCTIONS",
+            "You are a helpful AI assistant with access to MCP tools. "
+            "Use the tools to help answer user questions. "
+            "Respond naturally and conversationally.",
+        ),
+    )
+    parser.add_argument(
+        "--use-token-credential", help="Use Azure token credential instead of API key", action="store_true", default=False
+    )
+    parser.add_argument("--verbose", help="Enable verbose logging", action="store_true")
+
+    return parser.parse_args()
+
+
+def main():
+    """Main function."""
+    args = parse_arguments()
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    if not args.api_key and not args.use_token_credential:
+        print("❌ Error: No authentication provided")
+        print("Please provide an API key using --api-key or set AZURE_VOICELIVE_API_KEY environment variable,")
+        print("or use --use-token-credential for Azure authentication.")
+        sys.exit(1)
+
+    credential: Union[AzureKeyCredential, AsyncTokenCredential]
+    if args.use_token_credential:
+        credential = AzureCliCredential()
+        logger.info("Using Azure token credential")
+    else:
+        credential = AzureKeyCredential(args.api_key)
+        logger.info("Using API key credential")
+
+    assistant = MCPVoiceAssistant(
+        endpoint=args.endpoint,
+        credential=credential,
+        model=args.model,
+        voice=args.voice,
+        instructions=args.instructions,
+    )
+
+    def signal_handler(_sig, _frame):
+        logger.info("Received shutdown signal")
+        raise KeyboardInterrupt()
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    try:
+        asyncio.run(assistant.start())
+    except KeyboardInterrupt:
+        print("\n👋 Voice assistant with MCP shut down. Goodbye!")
+    except Exception as e:
+        print("Fatal Error: ", e)
+
+
+if __name__ == "__main__":
+    # Check audio system
+    try:
+        p = pyaudio.PyAudio()
+        input_devices = [
+            i for i in range(p.get_device_count())
+            if cast(Union[int, float], p.get_device_info_by_index(i).get("maxInputChannels", 0) or 0) > 0
+        ]
+        output_devices = [
+            i for i in range(p.get_device_count())
+            if cast(Union[int, float], p.get_device_info_by_index(i).get("maxOutputChannels", 0) or 0) > 0
+        ]
+        p.terminate()
+
+        if not input_devices:
+            print("❌ No audio input devices found. Please check your microphone.")
+            sys.exit(1)
+        if not output_devices:
+            print("❌ No audio output devices found. Please check your speakers.")
+            sys.exit(1)
+    except Exception as e:
+        print(f"❌ Audio system check failed: {e}")
+        sys.exit(1)
+
+    print("🎙️  Voice Assistant with MCP - Azure VoiceLive SDK")
+    print("=" * 65)
+
+    main()

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -35,6 +35,7 @@ import base64
 from datetime import datetime
 import logging
 import queue
+import re
 import signal
 from typing import Union, Optional, TYPE_CHECKING, cast
 
@@ -45,21 +46,24 @@ from azure.identity.aio import AzureCliCredential
 from azure.ai.voicelive.aio import connect
 from azure.ai.voicelive.models import (
     AudioEchoCancellation,
+    AudioInputTranscriptionOptions,
     AudioNoiseReduction,
     AzureStandardVoice,
     InputAudioFormat,
+    InputTextContentPart,
+    InterimResponseTrigger,
     ItemType,
+    LlmInterimResponseConfig,
     MCPApprovalResponseRequestItem,
     MCPServer,
+    MessageItem,
     Modality,
     OutputAudioFormat,
     RequestSession,
     ResponseMCPApprovalRequestItem,
     ResponseMCPCallItem,
     ServerEventConversationItemCreated,
-    ServerEventResponseMcpCallArgumentsDone,
     ServerEventResponseMcpCallCompleted,
-    ServerEventResponseOutputItemDone,
     ServerEventType,
     ServerVad,
     Tool,
@@ -90,16 +94,6 @@ logging.basicConfig(
     level=logging.INFO
 )
 logger = logging.getLogger(__name__)
-
-
-async def _wait_for_event(conn, wanted_types: set, timeout_s: float = 30.0):
-    """Wait until we receive any event whose type is in wanted_types."""
-    async def _next():
-        while True:
-            evt = await conn.recv()
-            if evt.type in wanted_types:
-                return evt
-    return await asyncio.wait_for(_next(), timeout=timeout_s)
 
 
 class AudioProcessor:
@@ -279,6 +273,16 @@ class MCPVoiceAssistant:
         self.session_ready = False
         self._active_response = False
         self._response_api_done = False
+        self._pending_approval: Optional[dict] = None  # Currently active approval request
+        self._approval_queue: list[dict] = []  # Queued approvals waiting to be asked
+        self._awaiting_approval_voice = False  # True only after the model has spoken the approval prompt
+        self._approval_prompt_needed = False  # True when we need to inject the prompt at next RESPONSE_DONE
+        self._mcp_call_in_progress = 0  # Count of active MCP tool calls
+        self._handled_mcp_completions: set = set()  # Deduplicate MCP completion events
+        self._needs_response_create = False  # Retry response.create at next RESPONSE_DONE
+        self._approval_tools_completed_this_turn: set = set()  # Approval-required tools completed this turn
+        self._mcp_item_to_server: dict = {}  # Map MCP item IDs to server_label/function_name
+        self._approval_servers: set = set()  # Server labels that require approval
 
     async def start(self):
         """Start the voice assistant session with MCP support."""
@@ -302,6 +306,17 @@ class MCPVoiceAssistant:
                 ),
             ]
             # </define_mcp_servers>
+
+            # Track which servers require approval for per-turn loop prevention.
+            # Servers with require_approval="always" are guarded to avoid
+            # repeated approval prompts in voice UX — a design decision to keep
+            # the voice conversation flow smooth. Servers with "never" are allowed
+            # to make multiple calls (e.g. DeepWiki's read_wiki_structure →
+            # ask_question pattern) since they don't interrupt the user.
+            self._approval_servers = {
+                s.server_label for s in mcp_tools
+                if isinstance(s, MCPServer) and s.require_approval == "always"
+            }
 
             # Connect with api_version="2026-01-01-preview" for MCP support
             async with connect(
@@ -368,7 +383,23 @@ class MCPVoiceAssistant:
             input_audio_noise_reduction=AudioNoiseReduction(type="azure_deep_noise_suppression"),
             tools=mcp_tools,
             tool_choice=ToolChoiceLiteral.AUTO,
+            input_audio_transcription=AudioInputTranscriptionOptions(model="whisper-1"),
         )
+
+        # Interim response bridges latency during MCP tool calls, but is only
+        # supported on non-realtime model pipelines (e.g. gpt-4o-mini).
+        if "realtime" not in self.model.lower():
+            session_config.interim_response = LlmInterimResponseConfig(
+                triggers=[InterimResponseTrigger.TOOL, InterimResponseTrigger.LATENCY],
+                latency_threshold_ms=100,
+                instructions="Create friendly interim responses indicating wait time due to "
+                             "ongoing processing, if any. Do not include in all responses! "
+                             "Do not say you don't have real-time access to information when "
+                             "calling tools!",
+            )
+            logger.info("Interim response enabled for model %s", self.model)
+        else:
+            logger.info("Interim response skipped — not supported on realtime pipeline (%s)", self.model)
 
         conn = self.connection
         assert conn is not None
@@ -378,14 +409,13 @@ class MCPVoiceAssistant:
 
     async def _process_events(self):
         """Process events from the VoiceLive connection."""
-        try:
-            conn = self.connection
-            assert conn is not None
-            async for event in conn:
+        conn = self.connection
+        assert conn is not None
+        async for event in conn:
+            try:
                 await self._handle_event(event)
-        except Exception:
-            logger.exception("Error processing events")
-            raise
+            except Exception:
+                logger.exception("Error handling event %s (non-fatal)", getattr(event, 'type', '?'))
 
     # <handle_mcp_events>
     async def _handle_event(self, event):
@@ -404,12 +434,40 @@ class MCPVoiceAssistant:
             logger.info("User started speaking - stopping playback")
             print("🎤 Listening...")
             ap.skip_pending_audio()
+            self._approval_tools_completed_this_turn.clear()
+
+            # If the model was still speaking the approval prompt (not yet
+            # awaiting voice), the user barged in before hearing the question.
+            # Re-queue the approval so it gets asked again after this turn.
+            if self._pending_approval is not None and not self._awaiting_approval_voice:
+                logger.info("Barge-in during approval prompt — re-queuing")
+                self._approval_queue.insert(0, self._pending_approval)
+                self._pending_approval = None
+                self._approval_prompt_needed = False
+
             if self._active_response and not self._response_api_done:
                 try:
                     await conn.response.cancel()
                 except Exception as e:
                     if "no active response" not in str(e).lower():
                         logger.warning("Cancel failed: %s", e)
+
+            # If an MCP call is running, ask the user if they want to wait or skip
+            if self._mcp_call_in_progress > 0 and self._pending_approval is None:
+                logger.info("User spoke during MCP call — will ask if they want to skip")
+                try:
+                    await conn.conversation.item.create(
+                        item=MessageItem(
+                            role="system",
+                            content=[InputTextContentPart(
+                                text="A tool call is still running. The user just interrupted. "
+                                     "Briefly ask them: do you want to keep waiting for the result, "
+                                     "or skip it and move on? Keep it short."
+                            )],
+                        )
+                    )
+                except Exception as e:
+                    logger.warning("Failed to inject MCP skip inquiry: %s", e)
 
         elif event.type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED:
             logger.info("User stopped speaking")
@@ -432,11 +490,44 @@ class MCPVoiceAssistant:
             self._active_response = False
             self._response_api_done = True
 
+            # If an approval prompt needs to be injected, do it now that no response is active
+            if self._approval_prompt_needed and self._pending_approval is not None:
+                self._approval_prompt_needed = False
+                await self._send_approval_voice_prompt(self._pending_approval, conn)
+            # If an approval prompt was just spoken, the next user utterance is the answer
+            elif self._pending_approval is not None:
+                self._awaiting_approval_voice = True
+            # If a response.create was deferred due to collision, retry now
+            elif self._needs_response_create:
+                self._needs_response_create = False
+                try:
+                    await conn.response.create()
+                except Exception:
+                    pass  # Best-effort retry
+
+        # <voice_approval_transcription>
+        elif event.type == ServerEventType.CONVERSATION_ITEM_INPUT_AUDIO_TRANSCRIPTION_COMPLETED:
+            transcript = event.transcript if hasattr(event, 'transcript') else event.get("transcript", "")
+            logger.info("User said: %s", transcript)
+            print(f"👤 You said:\t{transcript}")
+
+            # Only interpret as an approval answer if the model has finished
+            # speaking the approval prompt and we are actively waiting
+            if self._pending_approval is not None and self._awaiting_approval_voice:
+                await self._resolve_voice_approval(transcript, conn)
+        # </voice_approval_transcription>
+
         elif event.type == ServerEventType.ERROR:
             msg = event.error.message
             if "Cancellation failed: no active response" not in msg:
-                logger.error("VoiceLive error: %s", msg)
-                print(f"Error: {msg}")
+                # Interim response errors are non-fatal — log but don't alarm the user
+                if "interim response" in msg.lower():
+                    logger.warning("Interim response not supported with this model pipeline (non-fatal)")
+                elif "active response in progress" in msg.lower():
+                    logger.debug("Response collision (expected during MCP flow): %s", msg)
+                else:
+                    logger.error("VoiceLive error: %s", msg)
+                    print(f"Error: {msg}")
 
         # MCP-specific events
         elif event.type == ServerEventType.MCP_LIST_TOOLS_IN_PROGRESS:
@@ -453,14 +544,28 @@ class MCPVoiceAssistant:
         elif event.type == ServerEventType.RESPONSE_MCP_CALL_IN_PROGRESS:
             logger.info("MCP call in progress for %s", event.item_id)
             print("⏳ MCP tool call in progress...")
+            self._mcp_call_in_progress += 1
 
         elif event.type == ServerEventType.RESPONSE_MCP_CALL_COMPLETED:
-            logger.info("MCP call completed for %s", event.item_id)
-            await self._handle_mcp_call_completed(event, conn)
+            item_id = event.item_id
+            if item_id in self._handled_mcp_completions:
+                logger.debug("Ignoring duplicate MCP completion for %s", item_id)
+            else:
+                self._handled_mcp_completions.add(item_id)
+                logger.info("MCP call completed for %s", item_id)
+                self._mcp_call_in_progress = max(0, self._mcp_call_in_progress - 1)
+                await self._handle_mcp_call_completed(event, conn)
 
         elif event.type == ServerEventType.RESPONSE_MCP_CALL_FAILED:
             logger.error("MCP call failed for %s", event.item_id)
             print("❌ MCP tool call failed")
+            self._mcp_call_in_progress = max(0, self._mcp_call_in_progress - 1)
+            # Kick the model to respond — it should inform the user the tool call failed
+            try:
+                await conn.response.create()
+            except Exception as e:
+                if "active response" not in str(e).lower():
+                    logger.warning("Failed to create response after MCP failure: %s", e)
 
         elif event.type == ServerEventType.CONVERSATION_ITEM_CREATED:
             logger.info("Conversation item created: id=%s, type=%s", event.item.id, event.item.type)
@@ -476,7 +581,7 @@ class MCPVoiceAssistant:
 
     # <handle_approval>
     async def _handle_mcp_approval_request(self, conversation_created_event, connection):
-        """Handle MCP approval request events by prompting the user."""
+        """Handle MCP approval request by asking the user via voice."""
         if not isinstance(conversation_created_event, ServerEventConversationItemCreated):
             logger.error("Expected ServerEventConversationItemCreated")
             return
@@ -488,36 +593,113 @@ class MCPVoiceAssistant:
         approval_id = mcp_approval_item.id
         server_label = mcp_approval_item.server_label
         function_name = mcp_approval_item.name
-        arguments = mcp_approval_item.arguments
 
         if not approval_id:
             logger.error("MCP approval item missing ID")
             return
 
-        print(f"\n🔐 MCP Approval Request:")
-        print(f"   Server:    {server_label}")
-        print(f"   Tool:      {function_name}")
-        print(f"   Arguments: {arguments}")
+        # If another approval is already pending, queue this one
+        if self._pending_approval is not None:
+            logger.info("Queuing approval for %s — another is already pending", function_name)
+            self._approval_queue.append({
+                "approval_id": approval_id,
+                "server_label": server_label,
+                "function_name": function_name,
+            })
+            return
 
-        # Prompt the user for approval
-        approval_response = False
-        while True:
-            user_input = input("   Approve? (y/n): ").strip().lower()
-            if user_input == "y":
-                approval_response = True
-                break
-            elif user_input == "n":
-                approval_response = False
-                break
-            else:
-                print("   Invalid input. Please type 'y' to approve or 'n' to deny.")
+        logger.info("MCP approval request: server=%s tool=%s", server_label, function_name)
+        print(f"\n🔐 MCP Approval Request (voice-based):")
+        print(f"   Server: {server_label}  Tool: {function_name}")
 
-        # Send the approval or denial response
-        approval_response_item = MCPApprovalResponseRequestItem(
-            approval_request_id=approval_id, approve=approval_response
+        # Store the pending approval. If no response is currently active,
+        # send the voice prompt immediately. Otherwise, defer it to
+        # RESPONSE_DONE to avoid colliding with an active response.
+        self._pending_approval = {
+            "approval_id": approval_id,
+            "server_label": server_label,
+            "function_name": function_name,
+        }
+        self._awaiting_approval_voice = False
+
+        if not self._active_response:
+            await self._send_approval_voice_prompt(self._pending_approval, connection)
+        else:
+            self._approval_prompt_needed = True
+
+    async def _send_approval_voice_prompt(self, pending: dict, connection):
+        """Inject a system message asking the model to verbally request permission."""
+        prompt = (
+            f'I need your permission to use the "{pending["function_name"]}" tool '
+            f'from the "{pending["server_label"]}" service. '
+            f"Should I go ahead? Just say yes or no."
         )
-        await connection.conversation.item.create(item=approval_response_item)
-        logger.info("Sent approval response: %s for %s", approval_response, function_name)
+        try:
+            await connection.conversation.item.create(
+                item=MessageItem(
+                    role="system",
+                    content=[InputTextContentPart(text=prompt)],
+                )
+            )
+            await connection.response.create()
+        except Exception as e:
+            logger.warning("Failed to send approval voice prompt: %s", e)
+
+    async def _resolve_voice_approval(self, transcript: str, connection):
+        """Interpret the user's spoken response as approval or denial."""
+        pending = self._pending_approval
+        if pending is None:
+            return
+
+        text = transcript.strip().lower()
+
+        # Match "yes" or "no" as whole words (word boundaries prevent false
+        # positives from words like "yesterday" or "nobody")
+        approved = bool(re.search(r'\byes\b', text))
+        denied = bool(re.search(r'\bno\b', text))
+
+        if not approved and not denied:
+            # Ambiguous — ask again via the deferred prompt mechanism
+            logger.info("Ambiguous approval response: %s", transcript)
+            self._awaiting_approval_voice = False
+            self._approval_prompt_needed = True
+            return
+
+        if approved and denied:
+            # Conflicting signals — treat as denial for safety
+            approved = False
+
+        # Clear the pending state before sending the response
+        self._pending_approval = None
+        self._awaiting_approval_voice = False
+
+        approval_response_item = MCPApprovalResponseRequestItem(
+            approval_request_id=pending["approval_id"], approve=approved
+        )
+        try:
+            await connection.conversation.item.create(item=approval_response_item)
+        except Exception as e:
+            logger.error("Failed to send approval response: %s", e)
+            return
+        logger.info("Voice approval resolved: %s for %s", approved, pending["function_name"])
+        print(f"   Voice approval: {'Approved ✅' if approved else 'Denied ❌'}")
+
+        # Process next queued approval, if any
+        await self._process_next_approval(connection)
+
+    async def _process_next_approval(self, connection):
+        """Pop the next queued approval and ask via voice."""
+        if not self._approval_queue:
+            return
+        next_approval = self._approval_queue.pop(0)
+        self._pending_approval = next_approval
+        self._awaiting_approval_voice = False
+
+        # Send immediately if no response is active, otherwise defer
+        if not self._active_response:
+            await self._send_approval_voice_prompt(next_approval, connection)
+        else:
+            self._approval_prompt_needed = True
     # </handle_approval>
 
     async def _handle_mcp_call_completed(self, mcp_call_completed_event, connection):
@@ -526,27 +708,35 @@ class MCPVoiceAssistant:
             logger.error("Expected ServerEventResponseMcpCallCompleted")
             return
 
-        mcp_call_item_id = mcp_call_completed_event.item_id
-        mcp_call_done = await _wait_for_event(connection, {ServerEventType.RESPONSE_OUTPUT_ITEM_DONE})
-        if not isinstance(mcp_call_done, ServerEventResponseOutputItemDone):
-            logger.error("Expected ServerEventResponseOutputItemDone")
-            return
-        if not isinstance(mcp_call_done.item, ResponseMCPCallItem):
-            logger.error("Expected ResponseMCPCallItem")
-            return
-        if mcp_call_done.item.id != mcp_call_item_id:
-            logger.error("Item ID mismatch: expected %s, got %s", mcp_call_item_id, mcp_call_done.item.id)
-            return
-
-        mcp_output = mcp_call_done.item.output
-        logger.info("MCP Call output received: %s", mcp_output)
+        logger.info("MCP call completed for %s", mcp_call_completed_event.item_id)
         print("✅ MCP tool call completed successfully")
 
-        # Create a new response to process the MCP output
-        await connection.response.create()
+        item_id = mcp_call_completed_event.item_id
+
+        # Track which tool completed to avoid repeated approval prompts
+        # for the same tool in voice UX. Only guard approval-required servers —
+        # servers with require_approval="never" are free to make multiple calls.
+        tool_key = self._mcp_item_to_server.pop(item_id, "")
+        server_label = tool_key.split("/")[0] if "/" in tool_key else ""
+
+        if server_label in self._approval_servers:
+            if tool_key in self._approval_tools_completed_this_turn:
+                logger.info("Skipping response.create — %s already completed this turn", tool_key)
+                return
+            self._approval_tools_completed_this_turn.add(tool_key)
+
+        # Kick the model to incorporate and speak the MCP output.
+        # If a response is already active, defer to RESPONSE_DONE.
+        try:
+            await connection.response.create()
+        except Exception as e:
+            if "active response" in str(e).lower():
+                self._needs_response_create = True
+            else:
+                logger.warning("Failed to create response after MCP call: %s", e)
 
     async def _handle_mcp_call_arguments(self, conversation_created_event, connection):
-        """Handle MCP call events and wait for arguments to stream in."""
+        """Log MCP call details and announce the tool call to the user via voice."""
         if not isinstance(conversation_created_event, ServerEventConversationItemCreated):
             logger.error("Expected ServerEventConversationItemCreated")
             return
@@ -560,60 +750,55 @@ class MCPVoiceAssistant:
 
         logger.info("MCP Call triggered: server_label=%s, function_name=%s", server_label, function_name)
         print(f"🔧 MCP tool call: {server_label}/{function_name}")
+        self._mcp_item_to_server[mcp_call_item.id] = f"{server_label}/{function_name}"
 
-        try:
-            # Wait for the MCP call arguments to be complete
-            mcp_arguments_done = await _wait_for_event(
-                connection, {ServerEventType.RESPONSE_MCP_CALL_ARGUMENTS_DONE}
-            )
-            if not isinstance(mcp_arguments_done, ServerEventResponseMcpCallArgumentsDone):
-                logger.error("Expected ServerEventResponseMcpCallArgumentsDone")
-                return
-            if mcp_arguments_done.item_id != mcp_call_item.id:
-                logger.warning("Item ID mismatch: expected %s, got %s",
-                               mcp_call_item.id, mcp_arguments_done.item_id)
-                return
-
-            arguments = mcp_arguments_done.arguments or "{}"
-            logger.info("MCP Call arguments received: %s", arguments)
-
-            # Wait for response to be done before proceeding
-            await _wait_for_event(connection, {ServerEventType.RESPONSE_DONE})
-
-        except asyncio.TimeoutError:
-            logger.error("Timeout waiting for MCP call arguments done for %s", function_name)
-        except Exception as e:
-            logger.error("Error waiting for MCP call arguments done: %s", e)
+        # Announce the tool call to the user so they know something is
+        # happening while the MCP call runs. Skip if an approval prompt
+        # is pending (that flow handles its own voice messaging).
+        if self._pending_approval is None:
+            try:
+                await connection.conversation.item.create(
+                    item=MessageItem(
+                        role="system",
+                        content=[InputTextContentPart(
+                            text=f'I\'m now looking up information using the "{server_label}" service. '
+                                 f"Let the user know briefly that you're working on it."
+                        )],
+                    )
+                )
+                await connection.response.create()
+            except Exception as e:
+                if "active response" not in str(e).lower():
+                    logger.warning("Failed to create tool announcement: %s", e)
 
 
 def parse_arguments():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
         description="Voice Assistant with MCP using Azure VoiceLive SDK",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     parser.add_argument(
         "--api-key",
-        help="Azure VoiceLive API key.",
+        help="Azure VoiceLive API key (or set AZURE_VOICELIVE_API_KEY env var)",
         type=str,
         default=os.environ.get("AZURE_VOICELIVE_API_KEY"),
     )
     parser.add_argument(
         "--endpoint",
-        help="Azure VoiceLive endpoint",
+        help="Azure VoiceLive endpoint (default: from AZURE_VOICELIVE_ENDPOINT env var)",
         type=str,
         default=os.environ.get("AZURE_VOICELIVE_ENDPOINT", "https://your-resource-name.services.ai.azure.com/"),
     )
     parser.add_argument(
         "--model",
-        help="VoiceLive model to use",
+        help="VoiceLive model to use (default: gpt-realtime)",
         type=str,
         default=os.environ.get("AZURE_VOICELIVE_MODEL", "gpt-realtime"),
     )
     parser.add_argument(
         "--voice",
-        help="Voice to use for the assistant",
+        help="Voice to use for the assistant (default: en-US-Ava:DragonHDLatestNeural)",
         type=str,
         default=os.environ.get("AZURE_VOICELIVE_VOICE", "en-US-Ava:DragonHDLatestNeural"),
     )
@@ -624,8 +809,11 @@ def parse_arguments():
         default=os.environ.get(
             "AZURE_VOICELIVE_INSTRUCTIONS",
             "You are a helpful AI assistant with access to MCP tools. "
-            "Use the tools to help answer user questions. "
-            "Respond naturally and conversationally.",
+            "Always respond in English. "
+            "When a user asks a question, use the appropriate tool once to find information, "
+            "then summarize the results conversationally. IMPORTANT: Never call the same tool "
+            "more than once per user question. After receiving a tool result, always respond "
+            "to the user with what you found — do not search again.",
         ),
     )
     parser.add_argument(

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -283,6 +283,8 @@ class MCPVoiceAssistant:
         self._mcp_item_to_server: dict = {}  # Map MCP item IDs to server_label/function_name
         self._approval_servers: set = set()  # Server labels that require approval
         self._mcp_stall_task: Optional[asyncio.Task] = None  # Timer for MCP stall detection
+        self._active_mcp_items: set = set()  # Item IDs of currently in-progress MCP calls
+        self._stale_mcp_items: set = set()  # MCP calls the user has moved on from
 
     async def start(self):
         """Start the voice assistant session with MCP support."""
@@ -446,17 +448,19 @@ class MCPVoiceAssistant:
                     if "no active response" not in str(e).lower():
                         logger.warning("Cancel failed: %s", e)
 
-            # If an MCP call is running, let the user know it's still in progress
+            # If an MCP call is running, mark current calls as stale (user is moving on)
+            # and let the user know it's still in progress
             if self._mcp_call_in_progress > 0 and self._pending_approval is None:
-                logger.info("User spoke during MCP call — acknowledging")
+                self._stale_mcp_items.update(self._active_mcp_items)
+                logger.info("User spoke during MCP call — marking %d calls as stale", len(self._active_mcp_items))
                 try:
                     await conn.conversation.item.create(
                         item=MessageItem(
                             role="system",
                             content=[InputTextContentPart(
-                                text="A tool call is still running. The user just spoke. "
-                                     "Briefly acknowledge them and let them know you're "
-                                     "still waiting for results. One short sentence."
+                                text="A tool call is still running in the background. The user just spoke. "
+                                     "Respond to what the user said. If a tool result arrives later, "
+                                     "briefly introduce it as a late result from an earlier request."
                             )],
                         )
                     )
@@ -539,23 +543,30 @@ class MCPVoiceAssistant:
             logger.info("MCP call in progress for %s", event.item_id)
             print("⏳ MCP tool call in progress...")
             self._mcp_call_in_progress += 1
+            self._active_mcp_items.add(event.item_id)
             self._start_mcp_stall_timer(conn)
 
         elif event.type == ServerEventType.RESPONSE_MCP_CALL_COMPLETED:
             item_id = event.item_id
             self._mcp_call_in_progress = max(0, self._mcp_call_in_progress - 1)
+            self._active_mcp_items.discard(item_id)
             self._cancel_mcp_stall_timer()
             if item_id in self._handled_mcp_completions:
                 logger.debug("Ignoring duplicate MCP completion for %s", item_id)
             else:
                 self._handled_mcp_completions.add(item_id)
-                logger.info("MCP call completed for %s", item_id)
-                await self._handle_mcp_call_completed(event, conn)
+                is_stale = item_id in self._stale_mcp_items
+                self._stale_mcp_items.discard(item_id)
+                logger.info("MCP call completed for %s (stale=%s)", item_id, is_stale)
+                await self._handle_mcp_call_completed(event, conn, is_stale=is_stale)
 
         elif event.type == ServerEventType.RESPONSE_MCP_CALL_FAILED:
-            logger.error("MCP call failed for %s", event.item_id)
+            item_id = event.item_id
+            logger.error("MCP call failed for %s", item_id)
             print("❌ MCP tool call failed")
             self._mcp_call_in_progress = max(0, self._mcp_call_in_progress - 1)
+            self._active_mcp_items.discard(item_id)
+            self._stale_mcp_items.discard(item_id)
             self._cancel_mcp_stall_timer()
             # Kick the model to inform the user the tool call failed
             try:
@@ -735,7 +746,7 @@ class MCPVoiceAssistant:
         async def _stall_loop():
             stall_count = 0
             while self._mcp_call_in_progress > 0 and stall_count < self.MCP_STALL_MAX_NOTIFICATIONS:
-                await asyncio.sleep(15)
+                await asyncio.sleep(10)
                 if self._mcp_call_in_progress <= 0:
                     break
                 stall_count += 1
@@ -768,13 +779,13 @@ class MCPVoiceAssistant:
         self._mcp_stall_task = None
     # </mcp_stall_detection>
 
-    async def _handle_mcp_call_completed(self, mcp_call_completed_event, connection):
+    async def _handle_mcp_call_completed(self, mcp_call_completed_event, connection, *, is_stale=False):
         """Handle MCP call completed events."""
         if not isinstance(mcp_call_completed_event, ServerEventResponseMcpCallCompleted):
             logger.error("Expected ServerEventResponseMcpCallCompleted")
             return
 
-        logger.info("MCP call completed for %s", mcp_call_completed_event.item_id)
+        logger.info("MCP call completed for %s (stale=%s)", mcp_call_completed_event.item_id, is_stale)
         print("✅ MCP tool call completed successfully")
 
         # Clean up item mapping
@@ -783,6 +794,23 @@ class MCPVoiceAssistant:
         # Reset approval counter if no more approvals are pending (task complete)
         if self._pending_approval is None and not self._approval_queue:
             self._approval_call_count.clear()
+
+        # If the user moved on during this call, tell the model it's a late result
+        if is_stale:
+            try:
+                await connection.conversation.item.create(
+                    item=MessageItem(
+                        role="system",
+                        content=[InputTextContentPart(
+                            text="This tool result is from an earlier request. The user has "
+                                 "since moved on. Briefly introduce it as a late result, e.g. "
+                                 "'By the way, those results from earlier just came in...' "
+                                 "then share the key findings concisely."
+                        )],
+                    )
+                )
+            except Exception as e:
+                logger.warning("Failed to inject late-result context: %s", e)
 
         # Kick the model to incorporate and speak the MCP output.
         # If a response is already active, defer to RESPONSE_DONE.
@@ -876,7 +904,9 @@ def parse_arguments():
             "Some tools require user approval before they can be used. When you receive a "
             "system message asking you to request permission, you MUST clearly ask the user "
             "for their explicit approval before proceeding. Always wait for the user to say "
-            "yes or no. Never skip the approval question or assume permission is granted.",
+            "yes or no. Never skip the approval question or assume permission is granted. "
+            "If a tool result arrives after the conversation has moved to a different topic, "
+            "briefly introduce it as a late result before sharing the findings.",
         ),
     )
     parser.add_argument(

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -591,6 +591,21 @@ class MCPVoiceAssistant:
             logger.error("MCP approval item missing ID")
             return
 
+        # Auto-deny after too many calls to the same server in one task.
+        # This prevents infinite tool-call loops in voice UX.
+        MAX_APPROVAL_CALLS_PER_TASK = 3
+        current_count = self._approval_call_count.get(server_label, 0)
+        if current_count >= MAX_APPROVAL_CALLS_PER_TASK:
+            logger.info("Auto-denying %s — reached %d calls this task", function_name, current_count)
+            print(f"   Auto-denied: {server_label}/{function_name} (max {MAX_APPROVAL_CALLS_PER_TASK} calls reached)")
+            try:
+                await connection.conversation.item.create(
+                    item=MCPApprovalResponseRequestItem(approval_request_id=approval_id, approve=False)
+                )
+            except Exception as e:
+                logger.warning("Failed to send auto-deny: %s", e)
+            return
+
         # If another approval is already pending, queue this one
         if self._pending_approval is not None:
             logger.info("Queuing approval for %s — another is already pending", function_name)

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -627,14 +627,15 @@ class MCPVoiceAssistant:
 
         if call_count == 0:
             prompt = (
-                f'I need your permission to use the "{pending["function_name"]}" tool '
-                f'from the "{server}" service. '
-                f"Should I go ahead? Just say yes or no."
+                "You MUST ask the user for explicit permission before proceeding. "
+                f'Say exactly: "I\'d like to search the {server} service for information. '
+                f'Do you approve? Please say yes or no."'
             )
         else:
             prompt = (
-                f"I need to do one more search to get more complete information. "
-                f"Should I continue? Just say yes or no."
+                "You MUST ask the user for permission again. "
+                'Say exactly: "I need to do one more search to get complete information. '
+                'Should I continue? Please say yes or no."'
             )
 
         try:
@@ -841,7 +842,11 @@ def parse_arguments():
             "When a user asks a question, use the appropriate tool once to find information, "
             "then summarize the results conversationally. IMPORTANT: Never call the same tool "
             "more than once per user question. After receiving a tool result, always respond "
-            "to the user with what you found — do not search again.",
+            "to the user with what you found — do not search again. "
+            "Some tools require user approval before they can be used. When you receive a "
+            "system message asking you to request permission, you MUST clearly ask the user "
+            "for their explicit approval before proceeding. Always wait for the user to say "
+            "yes or no. Never skip the approval question or assume permission is granted.",
         ),
     )
     parser.add_argument(

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -446,22 +446,22 @@ class MCPVoiceAssistant:
                     if "no active response" not in str(e).lower():
                         logger.warning("Cancel failed: %s", e)
 
-            # If an MCP call is running, ask the user if they want to wait or skip
+            # If an MCP call is running, let the user know it's still in progress
             if self._mcp_call_in_progress > 0 and self._pending_approval is None:
-                logger.info("User spoke during MCP call — will ask if they want to skip")
+                logger.info("User spoke during MCP call — acknowledging")
                 try:
                     await conn.conversation.item.create(
                         item=MessageItem(
                             role="system",
                             content=[InputTextContentPart(
-                                text="A tool call is still running. The user just interrupted. "
-                                     "Briefly ask them: do you want to keep waiting for the result, "
-                                     "or skip it and move on? Keep it short."
+                                text="A tool call is still running. The user just spoke. "
+                                     "Briefly acknowledge them and let them know you're "
+                                     "still waiting for results. One short sentence."
                             )],
                         )
                     )
                 except Exception as e:
-                    logger.warning("Failed to inject MCP skip inquiry: %s", e)
+                    logger.warning("Failed to inject MCP status update: %s", e)
 
         elif event.type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED:
             logger.info("User stopped speaking")
@@ -726,24 +726,24 @@ class MCPVoiceAssistant:
     # </handle_approval>
 
     # <mcp_stall_detection>
+    MCP_STALL_MAX_NOTIFICATIONS = 3
+
     def _start_mcp_stall_timer(self, connection):
         """Start a repeating timer that verbally updates the user if an MCP call takes too long."""
         self._cancel_mcp_stall_timer()
 
         async def _stall_loop():
             stall_count = 0
-            while self._mcp_call_in_progress > 0:
+            while self._mcp_call_in_progress > 0 and stall_count < self.MCP_STALL_MAX_NOTIFICATIONS:
                 await asyncio.sleep(15)
                 if self._mcp_call_in_progress <= 0:
                     break
                 stall_count += 1
-                if stall_count == 1:
-                    msg = ("The tool call is taking longer than expected. "
-                           "Briefly let the user know you're still waiting for results.")
-                else:
-                    msg = ("The tool call is taking very long. Ask the user: "
-                           "would you like to keep waiting, or should I move on "
-                           "and answer with what I know? Keep it short.")
+                # Note: MCP calls cannot be cancelled via the API — only honest
+                # status updates are possible until the server responds or times out.
+                msg = ("The tool call is still running. "
+                       "Briefly reassure the user that you're still waiting for results. "
+                       "One short sentence only.")
                 logger.info("MCP stall notification #%d", stall_count)
                 try:
                     await connection.conversation.item.create(

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -548,12 +548,12 @@ class MCPVoiceAssistant:
 
         elif event.type == ServerEventType.RESPONSE_MCP_CALL_COMPLETED:
             item_id = event.item_id
+            self._mcp_call_in_progress = max(0, self._mcp_call_in_progress - 1)
             if item_id in self._handled_mcp_completions:
                 logger.debug("Ignoring duplicate MCP completion for %s", item_id)
             else:
                 self._handled_mcp_completions.add(item_id)
                 logger.info("MCP call completed for %s", item_id)
-                self._mcp_call_in_progress = max(0, self._mcp_call_in_progress - 1)
                 await self._handle_mcp_call_completed(event, conn)
 
         elif event.type == ServerEventType.RESPONSE_MCP_CALL_FAILED:

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -89,7 +89,7 @@ timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
 # Conversation log filename (separate from debug log)
 _script_dir = os.path.dirname(os.path.abspath(__file__))
-conversation_logfilename = f"{timestamp}_conversation.log"
+conversation_logfilename = f"conversation_{timestamp}.log"
 
 logging.basicConfig(
     filename=f'logs/{timestamp}_voicelive.log',
@@ -987,9 +987,10 @@ def parse_arguments():
 async def write_conversation_log(message: str) -> None:
     """Write a message to the conversation log."""
     log_path = os.path.join(_script_dir, 'logs', conversation_logfilename)
-    await asyncio.to_thread(
-        lambda: open(log_path, 'a', encoding='utf-8').write(message + "\n")
-    )
+    def _write():
+        with open(log_path, 'a', encoding='utf-8') as f:
+            f.write(message + "\n")
+    await asyncio.to_thread(_write)
 
 
 def main():

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -723,21 +723,29 @@ class MCPVoiceAssistant:
 
     # <mcp_stall_detection>
     def _start_mcp_stall_timer(self, connection):
-        """Start a timer that verbally updates the user if an MCP call takes too long."""
+        """Start a repeating timer that verbally updates the user if an MCP call takes too long."""
         self._cancel_mcp_stall_timer()
 
-        async def _stall_check():
-            await asyncio.sleep(15)
-            if self._mcp_call_in_progress > 0:
-                logger.info("MCP call taking >15s — notifying user")
+        async def _stall_loop():
+            stall_count = 0
+            while self._mcp_call_in_progress > 0:
+                await asyncio.sleep(15)
+                if self._mcp_call_in_progress <= 0:
+                    break
+                stall_count += 1
+                if stall_count == 1:
+                    msg = ("The tool call is taking longer than expected. "
+                           "Briefly let the user know you're still waiting for results.")
+                else:
+                    msg = ("The tool call is taking very long. Ask the user: "
+                           "would you like to keep waiting, or should I move on "
+                           "and answer with what I know? Keep it short.")
+                logger.info("MCP stall notification #%d", stall_count)
                 try:
                     await connection.conversation.item.create(
                         item=MessageItem(
                             role="system",
-                            content=[InputTextContentPart(
-                                text="The tool call is taking longer than expected. "
-                                     "Briefly let the user know you're still waiting for results."
-                            )],
+                            content=[InputTextContentPart(text=msg)],
                         )
                     )
                     await connection.response.create()
@@ -747,7 +755,7 @@ class MCPVoiceAssistant:
                     else:
                         logger.debug("Stall notification failed: %s", e)
 
-        self._mcp_stall_task = asyncio.create_task(_stall_check())
+        self._mcp_stall_task = asyncio.create_task(_stall_loop())
 
     def _cancel_mcp_stall_timer(self):
         """Cancel the MCP stall timer if running."""

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -654,9 +654,10 @@ class MCPVoiceAssistant:
         text = transcript.strip().lower()
 
         # Match "yes" or "no" as whole words (word boundaries prevent false
-        # positives from words like "yesterday" or "nobody")
+        # positives from words like "yesterday" or "nobody").
+        # Also accept "stop" and "cancel" as denial.
         approved = bool(re.search(r'\byes\b', text))
-        denied = bool(re.search(r'\bno\b', text))
+        denied = bool(re.search(r'\b(no|stop|cancel)\b', text))
 
         if not approved and not denied:
             # Ambiguous — ask again via the deferred prompt mechanism
@@ -753,9 +754,10 @@ class MCPVoiceAssistant:
         self._mcp_item_to_server[mcp_call_item.id] = f"{server_label}/{function_name}"
 
         # Announce the tool call to the user so they know something is
-        # happening while the MCP call runs. Skip if an approval prompt
-        # is pending (that flow handles its own voice messaging).
-        if self._pending_approval is None:
+        # happening while the MCP call runs. Skip for approval-required
+        # servers (the approval prompt handles communication) and skip
+        # if an approval is already pending.
+        if self._pending_approval is None and server_label not in self._approval_servers:
             try:
                 await connection.conversation.item.create(
                     item=MessageItem(

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -511,11 +511,13 @@ class MCPVoiceAssistant:
 
         elif event.type == ServerEventType.ERROR:
             msg = event.error.message
+            # Reset response state — errors can terminate a response without RESPONSE_DONE
+            self._active_response = False
+            self._response_api_done = True
             if "Cancellation failed: no active response" not in msg:
-                # Interim response errors are non-fatal — log but don't alarm the user
                 if "interim response" in msg.lower():
                     logger.warning("Interim response not supported with this model pipeline (non-fatal)")
-                elif "active response in progress" in msg.lower():
+                elif "active response" in msg.lower():
                     logger.debug("Response collision (expected during MCP flow): %s", msg)
                 else:
                     logger.error("VoiceLive error: %s", msg)

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -275,7 +275,6 @@ class MCPVoiceAssistant:
         self._response_api_done = False
         self._pending_approval: Optional[dict] = None  # Currently active approval request
         self._approval_queue: list[dict] = []  # Queued approvals waiting to be asked
-        self._awaiting_approval_voice = False  # True only after the model has spoken the approval prompt
         self._approval_prompt_needed = False  # True when we need to inject the prompt at next RESPONSE_DONE
         self._mcp_call_in_progress = 0  # Count of active MCP tool calls
         self._handled_mcp_completions: set = set()  # Deduplicate MCP completion events
@@ -436,15 +435,6 @@ class MCPVoiceAssistant:
             ap.skip_pending_audio()
             self._approval_tools_completed_this_turn.clear()
 
-            # If the model was still speaking the approval prompt (not yet
-            # awaiting voice), the user barged in before hearing the question.
-            # Re-queue the approval so it gets asked again after this turn.
-            if self._pending_approval is not None and not self._awaiting_approval_voice:
-                logger.info("Barge-in during approval prompt — re-queuing")
-                self._approval_queue.insert(0, self._pending_approval)
-                self._pending_approval = None
-                self._approval_prompt_needed = False
-
             if self._active_response and not self._response_api_done:
                 try:
                     await conn.response.cancel()
@@ -494,9 +484,6 @@ class MCPVoiceAssistant:
             if self._approval_prompt_needed and self._pending_approval is not None:
                 self._approval_prompt_needed = False
                 await self._send_approval_voice_prompt(self._pending_approval, conn)
-            # If an approval prompt was just spoken, the next user utterance is the answer
-            elif self._pending_approval is not None:
-                self._awaiting_approval_voice = True
             # If a response.create was deferred due to collision, retry now
             elif self._needs_response_create:
                 self._needs_response_create = False
@@ -511,9 +498,10 @@ class MCPVoiceAssistant:
             logger.info("User said: %s", transcript)
             print(f"👤 You said:\t{transcript}")
 
-            # Only interpret as an approval answer if the model has finished
-            # speaking the approval prompt and we are actively waiting
-            if self._pending_approval is not None and self._awaiting_approval_voice:
+            # Interpret as an approval answer if we have a pending approval —
+            # whether or not the prompt has finished speaking. This allows the
+            # user to barge in with "yes" without waiting for the full prompt.
+            if self._pending_approval is not None:
                 await self._resolve_voice_approval(transcript, conn)
         # </voice_approval_transcription>
 
@@ -620,7 +608,6 @@ class MCPVoiceAssistant:
             "server_label": server_label,
             "function_name": function_name,
         }
-        self._awaiting_approval_voice = False
 
         if not self._active_response:
             await self._send_approval_voice_prompt(self._pending_approval, connection)
@@ -662,7 +649,6 @@ class MCPVoiceAssistant:
         if not approved and not denied:
             # Ambiguous — ask again via the deferred prompt mechanism
             logger.info("Ambiguous approval response: %s", transcript)
-            self._awaiting_approval_voice = False
             self._approval_prompt_needed = True
             return
 
@@ -672,7 +658,6 @@ class MCPVoiceAssistant:
 
         # Clear the pending state before sending the response
         self._pending_approval = None
-        self._awaiting_approval_voice = False
 
         approval_response_item = MCPApprovalResponseRequestItem(
             approval_request_id=pending["approval_id"], approve=approved
@@ -694,7 +679,6 @@ class MCPVoiceAssistant:
             return
         next_approval = self._approval_queue.pop(0)
         self._pending_approval = next_approval
-        self._awaiting_approval_voice = False
 
         # Send immediately if no response is active, otherwise defer
         if not self._active_response:
@@ -763,8 +747,7 @@ class MCPVoiceAssistant:
                     item=MessageItem(
                         role="system",
                         content=[InputTextContentPart(
-                            text=f'I\'m now looking up information using the "{server_label}" service. '
-                                 f"Let the user know briefly that you're working on it."
+                            text="Briefly tell the user you're looking something up. One short sentence only."
                         )],
                     )
                 )

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -282,6 +282,7 @@ class MCPVoiceAssistant:
         self._approval_call_count: dict[str, int] = {}  # Per-server call count this turn
         self._mcp_item_to_server: dict = {}  # Map MCP item IDs to server_label/function_name
         self._approval_servers: set = set()  # Server labels that require approval
+        self._mcp_stall_task: Optional[asyncio.Task] = None  # Timer for MCP stall detection
 
     async def start(self):
         """Start the voice assistant session with MCP support."""
@@ -534,10 +535,12 @@ class MCPVoiceAssistant:
             logger.info("MCP call in progress for %s", event.item_id)
             print("⏳ MCP tool call in progress...")
             self._mcp_call_in_progress += 1
+            self._start_mcp_stall_timer(conn)
 
         elif event.type == ServerEventType.RESPONSE_MCP_CALL_COMPLETED:
             item_id = event.item_id
             self._mcp_call_in_progress = max(0, self._mcp_call_in_progress - 1)
+            self._cancel_mcp_stall_timer()
             if item_id in self._handled_mcp_completions:
                 logger.debug("Ignoring duplicate MCP completion for %s", item_id)
             else:
@@ -549,7 +552,8 @@ class MCPVoiceAssistant:
             logger.error("MCP call failed for %s", event.item_id)
             print("❌ MCP tool call failed")
             self._mcp_call_in_progress = max(0, self._mcp_call_in_progress - 1)
-            # Kick the model to respond — it should inform the user the tool call failed
+            self._cancel_mcp_stall_timer()
+            # Kick the model to inform the user the tool call failed
             try:
                 await conn.response.create()
             except Exception as e:
@@ -700,6 +704,38 @@ class MCPVoiceAssistant:
         else:
             self._approval_prompt_needed = True
     # </handle_approval>
+
+    # <mcp_stall_detection>
+    def _start_mcp_stall_timer(self, connection):
+        """Start a timer that verbally updates the user if an MCP call takes too long."""
+        self._cancel_mcp_stall_timer()
+
+        async def _stall_check():
+            await asyncio.sleep(15)
+            if self._mcp_call_in_progress > 0:
+                logger.info("MCP call taking >15s — notifying user")
+                try:
+                    await connection.conversation.item.create(
+                        item=MessageItem(
+                            role="system",
+                            content=[InputTextContentPart(
+                                text="The tool call is taking longer than expected. "
+                                     "Briefly let the user know you're still waiting for results."
+                            )],
+                        )
+                    )
+                    await connection.response.create()
+                except Exception as e:
+                    logger.debug("Stall notification failed: %s", e)
+
+        self._mcp_stall_task = asyncio.create_task(_stall_check())
+
+    def _cancel_mcp_stall_timer(self):
+        """Cancel the MCP stall timer if running."""
+        if self._mcp_stall_task and not self._mcp_stall_task.done():
+            self._mcp_stall_task.cancel()
+        self._mcp_stall_task = None
+    # </mcp_stall_detection>
 
     async def _handle_mcp_call_completed(self, mcp_call_completed_event, connection):
         """Handle MCP call completed events."""

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -433,7 +433,10 @@ class MCPVoiceAssistant:
             logger.info("User started speaking - stopping playback")
             print("🎤 Listening...")
             ap.skip_pending_audio()
-            self._approval_call_count.clear()
+            # Only reset approval call counter if no approval is pending
+            # (preserves counter for multi-search flows within one topic)
+            if self._pending_approval is None:
+                self._approval_call_count.clear()
 
             if self._active_response and not self._response_api_done:
                 try:
@@ -669,6 +672,8 @@ class MCPVoiceAssistant:
 
         # Clear the pending state before sending the response
         self._pending_approval = None
+        if not approved:
+            self._approval_call_count.clear()  # Topic is over
 
         approval_response_item = MCPApprovalResponseRequestItem(
             approval_request_id=pending["approval_id"], approve=approved

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -279,7 +279,7 @@ class MCPVoiceAssistant:
         self._mcp_call_in_progress = 0  # Count of active MCP tool calls
         self._handled_mcp_completions: set = set()  # Deduplicate MCP completion events
         self._needs_response_create = False  # Retry response.create at next RESPONSE_DONE
-        self._approval_tools_completed_this_turn: set = set()  # Approval-required tools completed this turn
+        self._approval_call_count: dict[str, int] = {}  # Per-server call count this turn
         self._mcp_item_to_server: dict = {}  # Map MCP item IDs to server_label/function_name
         self._approval_servers: set = set()  # Server labels that require approval
 
@@ -433,7 +433,7 @@ class MCPVoiceAssistant:
             logger.info("User started speaking - stopping playback")
             print("🎤 Listening...")
             ap.skip_pending_audio()
-            self._approval_tools_completed_this_turn.clear()
+            self._approval_call_count.clear()
 
             if self._active_response and not self._response_api_done:
                 try:
@@ -616,11 +616,22 @@ class MCPVoiceAssistant:
 
     async def _send_approval_voice_prompt(self, pending: dict, connection):
         """Inject a system message asking the model to verbally request permission."""
-        prompt = (
-            f'I need your permission to use the "{pending["function_name"]}" tool '
-            f'from the "{pending["server_label"]}" service. '
-            f"Should I go ahead? Just say yes or no."
-        )
+        server = pending["server_label"]
+        call_count = self._approval_call_count.get(server, 0)
+        self._approval_call_count[server] = call_count + 1
+
+        if call_count == 0:
+            prompt = (
+                f'I need your permission to use the "{pending["function_name"]}" tool '
+                f'from the "{server}" service. '
+                f"Should I go ahead? Just say yes or no."
+            )
+        else:
+            prompt = (
+                f"I need to do one more search to get more complete information. "
+                f"Should I continue? Just say yes or no."
+            )
+
         try:
             await connection.conversation.item.create(
                 item=MessageItem(
@@ -696,19 +707,8 @@ class MCPVoiceAssistant:
         logger.info("MCP call completed for %s", mcp_call_completed_event.item_id)
         print("✅ MCP tool call completed successfully")
 
-        item_id = mcp_call_completed_event.item_id
-
-        # Track which tool completed to avoid repeated approval prompts
-        # for the same tool in voice UX. Only guard approval-required servers —
-        # servers with require_approval="never" are free to make multiple calls.
-        tool_key = self._mcp_item_to_server.pop(item_id, "")
-        server_label = tool_key.split("/")[0] if "/" in tool_key else ""
-
-        if server_label in self._approval_servers:
-            if tool_key in self._approval_tools_completed_this_turn:
-                logger.info("Skipping response.create — %s already completed this turn", tool_key)
-                return
-            self._approval_tools_completed_this_turn.add(tool_key)
+        # Clean up item mapping
+        self._mcp_item_to_server.pop(mcp_call_completed_event.item_id, None)
 
         # Kick the model to incorporate and speak the MCP output.
         # If a response is already active, defer to RESPONSE_DONE.

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -87,6 +87,10 @@ if not os.path.exists('logs'):
 
 timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
+# Conversation log filename (separate from debug log)
+_script_dir = os.path.dirname(os.path.abspath(__file__))
+conversation_logfilename = f"{timestamp}_conversation.log"
+
 logging.basicConfig(
     filename=f'logs/{timestamp}_voicelive.log',
     filemode="w",
@@ -433,6 +437,10 @@ class MCPVoiceAssistant:
 
         if event.type == ServerEventType.SESSION_UPDATED:
             logger.info("Session ready: %s", event.session.id)
+            await write_conversation_log(f"SessionID: {event.session.id}")
+            await write_conversation_log(f"Model: {event.session.model}")
+            await write_conversation_log(f"Voice: {event.session.voice}")
+            await write_conversation_log("")
             self.session_ready = True
             ap.start_capture()
 
@@ -445,6 +453,13 @@ class MCPVoiceAssistant:
             # But approved-servers-this-turn resets when user starts a new topic
             if self._pending_approval is None and self._mcp_call_in_progress <= 0:
                 self._approved_servers_this_turn.clear()
+
+            # Clear deferred response flags if no MCP calls are in progress.
+            # Prevents stale _needs_response_create from re-triggering result
+            # playback after the user interrupts.
+            if self._mcp_call_in_progress <= 0:
+                self._needs_response_create = False
+                self._mcp_results_pending = False
 
             if self._active_response and not self._response_api_done:
                 try:
@@ -488,8 +503,19 @@ class MCPVoiceAssistant:
             logger.info("Assistant finished speaking")
             print("🎤 Ready for next input...")
 
+        elif event.type == ServerEventType.RESPONSE_TEXT_DONE:
+            text = event.text if hasattr(event, 'text') else event.get("text", "")
+            print(f"🤖 Assistant text:\t{text}")
+            await write_conversation_log(f"Assistant Text Response:\t{text}")
+
+        elif event.type == ServerEventType.RESPONSE_AUDIO_TRANSCRIPT_DONE:
+            transcript = event.transcript if hasattr(event, 'transcript') else event.get("transcript", "")
+            print(f"🤖 Assistant audio transcript:\t{transcript}")
+            await write_conversation_log(f"Assistant Audio Response:\t{transcript}")
+
         elif event.type == ServerEventType.RESPONSE_DONE:
             logger.info("Response complete")
+            await write_conversation_log("--- Response complete ---")
             self._active_response = False
             self._response_api_done = True
 
@@ -517,6 +543,7 @@ class MCPVoiceAssistant:
             transcript = event.transcript if hasattr(event, 'transcript') else event.get("transcript", "")
             logger.info("User said: %s", transcript)
             print(f"👤 You said:\t{transcript}")
+            await write_conversation_log(f"User Input:\t{transcript}")
 
             # Interpret as an approval answer if we have a pending approval —
             # whether or not the prompt has finished speaking. This allows the
@@ -538,6 +565,7 @@ class MCPVoiceAssistant:
                 else:
                     logger.error("VoiceLive error: %s", msg)
                     print(f"Error: {msg}")
+                    await write_conversation_log(f"ERROR: {msg}")
 
         # MCP-specific events
         elif event.type == ServerEventType.MCP_LIST_TOOLS_IN_PROGRESS:
@@ -546,14 +574,17 @@ class MCPVoiceAssistant:
         elif event.type == ServerEventType.MCP_LIST_TOOLS_COMPLETED:
             logger.info("MCP list tools completed for %s", event.item_id)
             print("🔧 MCP tools discovered successfully")
+            await write_conversation_log("MCP tools discovered successfully")
 
         elif event.type == ServerEventType.MCP_LIST_TOOLS_FAILED:
             logger.error("MCP list tools failed for %s", event.item_id)
             print("❌ MCP tool discovery failed")
+            await write_conversation_log("ERROR: MCP tool discovery failed")
 
         elif event.type == ServerEventType.RESPONSE_MCP_CALL_IN_PROGRESS:
             logger.info("MCP call in progress for %s", event.item_id)
             print("⏳ MCP tool call in progress...")
+            await write_conversation_log(f"MCP call in progress: {event.item_id}")
             self._mcp_call_in_progress += 1
             self._active_mcp_items.add(event.item_id)
             self._start_mcp_stall_timer(conn)
@@ -570,12 +601,14 @@ class MCPVoiceAssistant:
                 is_stale = item_id in self._stale_mcp_items
                 self._stale_mcp_items.discard(item_id)
                 logger.info("MCP call completed for %s (stale=%s)", item_id, is_stale)
+                await write_conversation_log(f"MCP call completed: {item_id} (stale={is_stale})")
                 await self._handle_mcp_call_completed(event, conn, is_stale=is_stale)
 
         elif event.type == ServerEventType.RESPONSE_MCP_CALL_FAILED:
             item_id = event.item_id
             logger.error("MCP call failed for %s", item_id)
             print("❌ MCP tool call failed")
+            await write_conversation_log(f"ERROR: MCP call failed: {item_id}")
             self._mcp_call_in_progress = max(0, self._mcp_call_in_progress - 1)
             self._active_mcp_items.discard(item_id)
             self._stale_mcp_items.discard(item_id)
@@ -746,6 +779,7 @@ class MCPVoiceAssistant:
             return
         logger.info("Voice approval resolved: %s for %s", approved, pending["function_name"])
         print(f"   Voice approval: {'Approved ✅' if approved else 'Denied ❌'}")
+        await write_conversation_log(f"Voice approval: {'Approved' if approved else 'Denied'} for {pending['server_label']}")
 
         # Process next queued approval, if any
         await self._process_next_approval(connection)
@@ -948,6 +982,14 @@ def parse_arguments():
     parser.add_argument("--verbose", help="Enable verbose logging", action="store_true")
 
     return parser.parse_args()
+
+
+async def write_conversation_log(message: str) -> None:
+    """Write a message to the conversation log."""
+    log_path = os.path.join(_script_dir, 'logs', conversation_logfilename)
+    await asyncio.to_thread(
+        lambda: open(log_path, 'a', encoding='utf-8').write(message + "\n")
+    )
 
 
 def main():

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -742,7 +742,10 @@ class MCPVoiceAssistant:
                     )
                     await connection.response.create()
                 except Exception as e:
-                    logger.debug("Stall notification failed: %s", e)
+                    if "active response" in str(e).lower():
+                        self._needs_response_create = True
+                    else:
+                        logger.debug("Stall notification failed: %s", e)
 
         self._mcp_stall_task = asyncio.create_task(_stall_check())
 

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -433,10 +433,8 @@ class MCPVoiceAssistant:
             logger.info("User started speaking - stopping playback")
             print("🎤 Listening...")
             ap.skip_pending_audio()
-            # Only reset approval call counter if no approval is pending
-            # (preserves counter for multi-search flows within one topic)
-            if self._pending_approval is None:
-                self._approval_call_count.clear()
+            # Approval call counter is NOT reset on speech — it tracks the
+            # lifecycle of a task (reset on denial or after results are spoken)
 
             if self._active_response and not self._response_api_done:
                 try:
@@ -714,6 +712,10 @@ class MCPVoiceAssistant:
 
         # Clean up item mapping
         self._mcp_item_to_server.pop(mcp_call_completed_event.item_id, None)
+
+        # Reset approval counter if no more approvals are pending (task complete)
+        if self._pending_approval is None and not self._approval_queue:
+            self._approval_call_count.clear()
 
         # Kick the model to incorporate and speak the MCP output.
         # If a response is already active, defer to RESPONSE_DONE.

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -285,6 +285,8 @@ class MCPVoiceAssistant:
         self._mcp_stall_task: Optional[asyncio.Task] = None  # Timer for MCP stall detection
         self._active_mcp_items: set = set()  # Item IDs of currently in-progress MCP calls
         self._stale_mcp_items: set = set()  # MCP calls the user has moved on from
+        self._approved_servers_this_turn: set = set()  # Servers user already approved this turn
+        self._mcp_results_pending = False  # True when MCP calls completed but response.create deferred
 
     async def start(self):
         """Start the voice assistant session with MCP support."""
@@ -440,6 +442,9 @@ class MCPVoiceAssistant:
             ap.skip_pending_audio()
             # Approval call counter is NOT reset on speech — it tracks the
             # lifecycle of a task (reset on denial or after results are spoken)
+            # But approved-servers-this-turn resets when user starts a new topic
+            if self._pending_approval is None and self._mcp_call_in_progress <= 0:
+                self._approved_servers_this_turn.clear()
 
             if self._active_response and not self._response_api_done:
                 try:
@@ -492,6 +497,13 @@ class MCPVoiceAssistant:
             if self._approval_prompt_needed and self._pending_approval is not None:
                 self._approval_prompt_needed = False
                 await self._send_approval_voice_prompt(self._pending_approval, conn)
+            # If MCP results are pending and all calls are now done, create response
+            elif self._mcp_results_pending and self._mcp_call_in_progress <= 0 and self._pending_approval is None:
+                self._mcp_results_pending = False
+                try:
+                    await conn.response.create()
+                except Exception:
+                    pass
             # If a response.create was deferred due to collision, retry now
             elif self._needs_response_create:
                 self._needs_response_create = False
@@ -621,6 +633,19 @@ class MCPVoiceAssistant:
                 logger.warning("Failed to send auto-deny: %s", e)
             return
 
+        # Auto-approve if user already approved this server earlier in the same turn.
+        # This avoids repeated approval prompts for consecutive calls to the same service.
+        if server_label in self._approved_servers_this_turn:
+            logger.info("Auto-approving %s — server already approved this turn", function_name)
+            print(f"   Auto-approved: {server_label}/{function_name} (already approved this turn)")
+            try:
+                await connection.conversation.item.create(
+                    item=MCPApprovalResponseRequestItem(approval_request_id=approval_id, approve=True)
+                )
+            except Exception as e:
+                logger.warning("Failed to send auto-approve: %s", e)
+            return
+
         # If another approval is already pending, queue this one
         if self._pending_approval is not None:
             logger.info("Queuing approval for %s — another is already pending", function_name)
@@ -705,8 +730,11 @@ class MCPVoiceAssistant:
 
         # Clear the pending state before sending the response
         self._pending_approval = None
-        if not approved:
+        if approved:
+            self._approved_servers_this_turn.add(pending["server_label"])
+        else:
             self._approval_call_count.clear()  # Topic is over
+            self._approved_servers_this_turn.discard(pending["server_label"])
 
         approval_response_item = MCPApprovalResponseRequestItem(
             approval_request_id=pending["approval_id"], approve=approved
@@ -812,15 +840,20 @@ class MCPVoiceAssistant:
             except Exception as e:
                 logger.warning("Failed to inject late-result context: %s", e)
 
-        # Kick the model to incorporate and speak the MCP output.
-        # If a response is already active, defer to RESPONSE_DONE.
-        try:
-            await connection.response.create()
-        except Exception as e:
-            if "active response" in str(e).lower():
-                self._needs_response_create = True
-            else:
-                logger.warning("Failed to create response after MCP call: %s", e)
+        # Batch response: only call response.create when ALL MCP calls for this
+        # turn have completed. This prevents partial results and repeated tool calls.
+        if self._mcp_call_in_progress <= 0 and self._pending_approval is None and not self._approval_queue:
+            logger.info("All MCP calls complete — creating response")
+            try:
+                await connection.response.create()
+            except Exception as e:
+                if "active response" in str(e).lower():
+                    self._needs_response_create = True
+                else:
+                    logger.warning("Failed to create response after MCP calls: %s", e)
+        else:
+            self._mcp_results_pending = True
+            logger.info("MCP calls still in progress (%d) — deferring response", self._mcp_call_in_progress)
 
     async def _handle_mcp_call_arguments(self, conversation_created_event, connection):
         """Log MCP call details and announce the tool call to the user via voice."""

--- a/python/voice-live-quickstarts/MCPQuickstart/requirements.txt
+++ b/python/voice-live-quickstarts/MCPQuickstart/requirements.txt
@@ -1,0 +1,4 @@
+azure-ai-voicelive[aiohttp]
+pyaudio
+python-dotenv
+azure-identity

--- a/python/voice-live-quickstarts/MCPQuickstart/requirements.txt
+++ b/python/voice-live-quickstarts/MCPQuickstart/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-voicelive[aiohttp]
+azure-ai-voicelive[aiohttp]>=1.2.0b4
 pyaudio
 python-dotenv
 azure-identity

--- a/python/voice-live-quickstarts/README.md
+++ b/python/voice-live-quickstarts/README.md
@@ -3,6 +3,7 @@
 This folder contains Python quickstart samples demonstrating different ways to use Azure AI Speech Service VoiceLive:
 
 - [Agents New Quickstart](./AgentsNewQuickstart/) - New Voice Live + Foundry Agent v2 flow with agent creation helper scripts
+- [MCP Quickstart](./MCPQuickstart/) - MCP server integration with remote tool calling and approval flow
 - [Model Quickstart](#model-quickstart) - Direct VoiceLive model integration with custom instructions
 - [Bring-Your-Own-Model Quickstart (BYOM)](#byom-quickstart) - Demonstrates direct integration with VoiceLive using bring-your-own-models from Foundry.
 - [Agent Quickstart](#agent-quickstart) - Integration with Azure AI Foundry agents


### PR DESCRIPTION
## Summary

Add MCP (Model Context Protocol) quickstart samples for **Python**, **C#**, **Java**, and **JavaScript** that demonstrate MCP server integration with the Voice Live SDK.

## What's included

Each language sample (`{lang}/voice-live-quickstarts/MCPQuickstart/`) includes:

- **MCP server definition** — Two MCP servers configured: `deepwiki` (no approval) and `azure_doc` (always requires approval)
- **Session configuration** — Voice Live session setup with MCP tools in the tools list
- **MCP event handling** — Handlers for tool discovery, call progress, call completion, and failure events
- **User approval flow** — Console-based approval prompt for MCP tool calls that require user consent
- **Named snippet regions** — `define_mcp_servers`, `configure_session`, `handle_mcp_events`, `handle_approval` for `:::code` references in the documentation

## Files added

| Language | Files |
| --- | --- |
| Python | `mcp-quickstart.py`, `requirements.txt` |
| C# | `MCPQuickstart.cs`, `MCPQuickstart.csproj` |
| Java | `MCPQuickstart.java`, `pom.xml` |
| JavaScript | `mcp-quickstart.js`, `package.json` |

## Notes

- Requires `api_version` `2026-01-01-preview` for MCP support
- SDK minimum versions: Python `1.0.0b5`, C# `1.1.0-beta.2`, Java `1.0.0-beta.5`, JS `1.0.0-beta.3`
- These samples are referenced by the "Add an MCP server" how-to article in `azure-ai-docs-pr` via `:::code` snippets