### PR TITLE
Add region markers for docs :::code id= references

### DIFF
--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -740,6 +740,7 @@ namespace Azure.AI.VoiceLive.Samples
             }
         }
 
+        // <voice_approval_transcription>
         /// <summary>
         /// Interpret the user's spoken response as approval or denial.
         /// </summary>
@@ -822,6 +823,7 @@ namespace Azure.AI.VoiceLive.Samples
                 _approvalPromptNeeded = true;
             }
         }
+        // </voice_approval_transcription>
         // </handle_approval>
 
         // <mcp_stall_detection>

--- a/javascript/voice-live-quickstarts/AgentsNewQuickstart/voice-live-with-agent-v2.js
+++ b/javascript/voice-live-quickstarts/AgentsNewQuickstart/voice-live-with-agent-v2.js
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// <all>
 // Voice Live with Foundry Agent Service v2 - Node.js Console Voice Assistant
 // Uses @azure/ai-voicelive SDK with handler-based event subscription pattern.
 
@@ -34,7 +35,7 @@ function writeConversationLog(message) {
 // ---------------------------------------------------------------------------
 // Audio helpers
 // ---------------------------------------------------------------------------
-
+// <audio_processor>
 /**
  * AudioProcessor manages microphone capture via node-record-lpcm16
  * and playback via the speaker npm package. Audio format: 24 kHz, 16-bit, mono.
@@ -236,10 +237,12 @@ class AudioProcessor {
     this._speaker.on("error", () => {});
   }
 }
+// </audio_processor>
 
 // ---------------------------------------------------------------------------
 // BasicVoiceAssistant
 // ---------------------------------------------------------------------------
+// <voice_assistant>
 class BasicVoiceAssistant {
   /**
    * @param {object} opts
@@ -255,6 +258,7 @@ class BasicVoiceAssistant {
    * @param {string} [opts.greetingText]
    * @param {boolean} [opts.noAudio]
    */
+  // <agent_config>
   constructor(opts) {
     this.endpoint = opts.endpoint;
     this.credential = opts.credential;
@@ -280,7 +284,9 @@ class BasicVoiceAssistant {
     this._activeResponse = false;
     this._responseApiDone = false;
   }
+  // </agent_config>
 
+  // <start_session>
   /** Connect, subscribe to events, and run until interrupted. */
   async start() {
     const client = new VoiceLiveClient(this.endpoint, this.credential);
@@ -294,7 +300,9 @@ class BasicVoiceAssistant {
 
     // Subscribe to VoiceLive events BEFORE connecting, so the
     // SESSION_UPDATED event is not missed.
+    // <handle_events>
     const subscription = session.subscribe({
+      // <session_updated_metadata>
       onSessionUpdated: async (event, context) => {
         const s = event.session;
         const agent = s?.agent;
@@ -312,6 +320,7 @@ class BasicVoiceAssistant {
           ].join("\n"),
         );
       },
+      // </session_updated_metadata>
 
       onConversationItemInputAudioTranscriptionCompleted: async (event) => {
         const transcript = event.transcript ?? "";
@@ -386,6 +395,7 @@ class BasicVoiceAssistant {
         console.log(`[event] Conversation item created: ${event.item?.id ?? ""}`);
       },
     });
+    // </handle_events>
 
     // Connect after subscribing so SESSION_UPDATED is not missed
     await session.connect();
@@ -447,7 +457,9 @@ class BasicVoiceAssistant {
       // ignore dispose errors during shutdown
     }
   }
+  // </start_session>
 
+  // <proactive_greeting>
   /**
    * Send a proactive greeting when the session starts.
    * Supports pre-defined (--greeting-text) or LLM-generated (default).
@@ -490,7 +502,9 @@ class BasicVoiceAssistant {
       }
     }
   }
+  // </proactive_greeting>
 
+  // <setup_session>
   /** Configure session modalities, audio format, and interim response. */
   async _setupSession() {
     console.log("[session] Configuring session ...");
@@ -509,7 +523,9 @@ class BasicVoiceAssistant {
     });
     console.log("[session] Session configuration sent");
   }
+  // </setup_session>
 }
+// </voice_assistant>
 
 // ---------------------------------------------------------------------------
 // CLI helpers
@@ -640,6 +656,7 @@ async function listAudioDevices() {
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
+// <main>
 async function main() {
   let args;
   try {
@@ -713,6 +730,8 @@ async function main() {
   }
 }
 
+// </main>
+
 console.log("🎙️  Basic Foundry Voice Agent with Azure VoiceLive SDK (Agent Mode)");
 console.log("=".repeat(65));
 main().then(
@@ -722,3 +741,4 @@ main().then(
     process.exit(1);
   },
 );
+// </all>

--- a/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
@@ -741,6 +741,7 @@ class MCPVoiceAssistant {
     }
   }
 
+  // <voice_approval_transcription>
   async _resolveVoiceApproval(transcript, session) {
     if (this._pendingApproval === null) return;
 
@@ -814,8 +815,11 @@ class MCPVoiceAssistant {
       this._approvalPromptNeeded = true;
     }
   }
+  // </voice_approval_transcription>
+
   // </handle_approval>
 
+  // <mcp_stall_detection>
   _startMcpStallTimer(session) {
     this._cancelMcpStallTimer();
     let stallCount = 0;
@@ -849,6 +853,7 @@ class MCPVoiceAssistant {
       this._mcpStallTimer = null;
     }
   }
+  // </mcp_stall_detection>
 
   async start() {
     const client = new VoiceLiveClient(this.endpoint, this.credential, {

--- a/python/voice-live-quickstarts/AgentsNewQuickstart/voice-live-with-agent-v2.py
+++ b/python/voice-live-quickstarts/AgentsNewQuickstart/voice-live-with-agent-v2.py
@@ -1,3 +1,4 @@
+# <all>
 from __future__ import annotations
 import os
 import sys
@@ -59,6 +60,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# <audio_processor>
 class AudioProcessor:
     """
     Handles real-time audio capture and playback for the voice assistant.
@@ -235,7 +237,9 @@ class AudioProcessor:
             self.audio.terminate()
 
         logger.info("Audio processor cleaned up")
+# </audio_processor>
 
+# <voice_assistant>
 class BasicVoiceAssistant:
     """
     Basic voice assistant implementing the VoiceLive SDK patterns with Foundry Agent.
@@ -244,6 +248,7 @@ class BasicVoiceAssistant:
     This sample also demonstrates how to collect a conversation log of user and agent interactions.
     """
 
+    # <agent_config>
     def __init__(
         self,
         endpoint: str,
@@ -275,7 +280,9 @@ class BasicVoiceAssistant:
         self.greeting_sent = False
         self._active_response = False
         self._response_api_done = False
+    # </agent_config>
 
+    # <start_session>
     async def start(self) -> None:
         """Start the voice assistant session."""
         try:
@@ -321,7 +328,9 @@ class BasicVoiceAssistant:
         finally:
             if self.audio_processor:
                 self.audio_processor.shutdown()
+    # </start_session>
 
+    # <setup_session>
     async def _setup_session(self) -> None:
         """Configure the VoiceLive session for audio conversation."""
         logger.info("Setting up voice conversation session...")
@@ -353,7 +362,9 @@ class BasicVoiceAssistant:
         await conn.session.update(session=session_config)
 
         logger.info("Session configuration sent")
+    # </setup_session>
 
+    # <process_events>
     async def _process_events(self) -> None:
         """Process events from the VoiceLive connection."""
         try:
@@ -365,7 +376,9 @@ class BasicVoiceAssistant:
         except Exception:
             logger.exception("Error processing events")
             raise
+    # </process_events>
 
+    # <handle_events>
     async def _handle_event(self, event: Any) -> None:
         """Handle different types of events from VoiceLive."""
         logger.debug("Received event: %s", event.type)
@@ -375,6 +388,7 @@ class BasicVoiceAssistant:
             raise RuntimeError("AudioProcessor and Connection must be initialized")
 
         if event.type == ServerEventType.SESSION_UPDATED:
+            # <session_updated_metadata>
             logger.info("Session ready: %s", event.session.id)
             s, a, v = event.session, event.session.agent, event.session.voice
             await write_conversation_log("\n".join([
@@ -383,8 +397,10 @@ class BasicVoiceAssistant:
                 f"Voice Name: {v['name']}", f"Voice Type: {v['type']}",
                 f"Voice Temperature: {v['temperature']}", ""
             ]))
+            # </session_updated_metadata>
             self.session_ready = True
 
+            # <proactive_greeting>
             # Invoke Proactive greeting
             if not self.greeting_sent:
                 self.greeting_sent = True
@@ -403,6 +419,7 @@ class BasicVoiceAssistant:
                     await conn.response.create()
                 except Exception:
                     logger.exception("Failed to send proactive greeting request")
+            # </proactive_greeting>
 
             # Start audio capture once session is ready
             ap.start_capture()
@@ -471,6 +488,8 @@ class BasicVoiceAssistant:
 
         else:
             logger.debug("Unhandled event type: %s", event.type)
+    # </handle_events>
+# </voice_assistant>
 
 async def write_conversation_log(message: str) -> None:
     """Write a message to the conversation log."""
@@ -479,6 +498,7 @@ async def write_conversation_log(message: str) -> None:
         lambda: open(log_path, 'a', encoding='utf-8').write(message + "\n")
     )
 
+# <main>
 def main() -> None:
     """Main function."""
     endpoint = os.environ.get("VOICELIVE_ENDPOINT", "")
@@ -530,7 +550,9 @@ def main() -> None:
         print("\n👋 Voice assistant shut down. Goodbye!")
     except Exception as e:
         print("Fatal Error: ", e)
+# </main>
 
+# <check_audio>
 def _check_audio_devices() -> None:
     """Verify audio input/output devices are available."""
     p = pyaudio.PyAudio()
@@ -546,6 +568,7 @@ def _check_audio_devices() -> None:
             sys.exit("❌ No audio output devices found. Please check your speakers.")
     finally:
         p.terminate()
+# </check_audio>
 
 if __name__ == "__main__":
     try:
@@ -558,3 +581,4 @@ if __name__ == "__main__":
     print("🎙️ Basic Foundry Voice Agent with Azure VoiceLive SDK (Agent Mode)")
     print("=" * 65)
     main()
+# </all>


### PR DESCRIPTION
## Summary

Adds `// <region_name>` / `// </region_name>` (and `# <region_name>` / `# </region_name>` for Python) comment markers to code samples so the documentation can reference specific sections using `:::code id="region_name":::` instead of fragile `range=` line-number references.

## Changes

### MCP Quickstarts
| File | Markers added |
|------|---------------|
| **C#** `MCPQuickstart.cs` | `voice_approval_transcription` |
| **JS** `mcp-quickstart.js` | `voice_approval_transcription`, `mcp_stall_detection` |

### Agent Quickstarts (JS and Python — C#/Java already had markers)
| File | Markers added |
|------|---------------|
| **JS** `voice-live-with-agent-v2.js` | `all`, `audio_processor`, `voice_assistant`, `agent_config`, `start_session`, `handle_events`, `session_updated_metadata`, `proactive_greeting`, `setup_session`, `main` |
| **Python** `voice-live-with-agent-v2.py` | `all`, `audio_processor`, `voice_assistant`, `agent_config`, `start_session`, `setup_session`, `process_events`, `handle_events`, `session_updated_metadata`, `proactive_greeting`, `main`, `check_audio` |

## Validation
- All files pass syntax checks (`node --check` for JS, `py_compile` for Python, `dotnet build` for C#)
- Comment-only changes — no functional code modifications
- Marker names are consistent with existing C#/Java Agent quickstart markers

## Related
- Docs PR will switch from `range=` to `id=` references after this merges