### PR TITLE
chore(deps): Consolidated manual-test dependabot updates (wave 3)

### DIFF
--- a/java/voice-live-quickstarts/ModelQuickstart/pom.xml
+++ b/java/voice-live-quickstarts/ModelQuickstart/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core</artifactId>
-            <version>1.53.0</version>
+            <version>1.57.1</version>
         </dependency>
 
         <!-- Azure Identity for authentication -->
@@ -44,19 +44,19 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.5.11</version>
+            <version>3.8.4</version>
         </dependency>
 
         <!-- SLF4J for logging -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.9</version>
+            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.9</version>
+            <version>2.0.17</version>
         </dependency>
     </dependencies>
 
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.15.0</version>
                 <configuration>
                     <source>11</source>
                     <target>11</target>

--- a/javascript/voice-live-trader-demo/package.json
+++ b/javascript/voice-live-trader-demo/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@azure/ai-voicelive": "^1.0.0-beta.1",
     "@azure/core-auth": "^1.9.0",
-    "next": "16.1.0",
+    "next": "16.2.2",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/python/voice-live-voicerag-assistant/app/backend/requirements.txt
+++ b/python/voice-live-voicerag-assistant/app/backend/requirements.txt
@@ -1,7 +1,7 @@
 # Azure SDK and AI Services - USED MODULES ONLY
 azure-identity                                # Azure authentication and credentials management
 azure-search-documents==11.7.0b2             # Azure AI Search integration
-azure-ai-voicelive==1.0.0                    # Azure VoiceLive API for real-time voice conversations
+azure-ai-voicelive==1.1.0                    # Azure VoiceLive API for real-time voice conversations
 
 # HTTP Client (required by Azure VoiceLive)
 aiohttp                                       # Async HTTP client library

--- a/voice-live-universal-assistant/java/pom.xml
+++ b/voice-live-universal-assistant/java/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.6</version>
+        <version>3.5.13</version>
         <relativePath/>
     </parent>
 
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core</artifactId>
-            <version>1.55.3</version>
+            <version>1.57.1</version>
         </dependency>
 
         <!-- Jackson for JSON -->

--- a/voice-live-universal-assistant/python/requirements.txt
+++ b/voice-live-universal-assistant/python/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-voicelive==1.2.0b4
+azure-ai-voicelive==1.2.0b5
 azure-identity
 aiohttp
 fastapi>=0.104.0


### PR DESCRIPTION
## Consolidated manual-test dependency updates (wave 3)

These updates touch voice SDKs, frameworks, and core libraries that need manual audio/voice testing before merge.

| PR | Directory | Updates |
|---|---|---|
| #172 | python/voice-live-voicerag-assistant/app/backend | azure-ai-voicelive 1.0.0→1.1.0 |
| #173 | voice-live-universal-assistant/python | azure-ai-voicelive 1.2.0b4→1.2.0b5 |
| #174 | javascript/voice-live-trader-demo | next 16.1.0→16.2.2 |
| #177 | java/voice-live-quickstarts/ModelQuickstart | azure-core 1.53→1.57.1, reactor-core 3.5.11→3.8.4, slf4j 2.0.9→2.0.17, maven-compiler 3.11→3.15 |
| #178 | voice-live-universal-assistant/java | spring-boot 3.3.6→3.5.13, azure-core 1.55.3→1.57.1 |

### Build verification
- ✅ Java 4/4 projects compile successfully (ModelQuickstart, MCPQuickstart, AgentsNewQuickstart, universal-assistant)
- ⏳ Manual audio/voice testing still required for voice SDK and framework changes

### Testing checklist
- [ ] Python voicerag assistant — voice conversations work with azure-ai-voicelive 1.1.0
- [ ] Python universal-assistant — voice conversations work with azure-ai-voicelive 1.2.0b5
- [ ] JS trader-demo — UI and voice features work with Next.js 16.2.2
- [ ] Java quickstart — voice session works with updated azure-core + reactor-core
- [ ] Java universal-assistant — Spring Boot 3.5.13 starts and voice features work

### Supersedes
Previous wave 1/2 content (old PRs #33, #111, #114, #115, #116, #138, #155) replaced with newer grouped versions from wave 3.