### PR TITLE
chore: improve dependabot config — ignore major bumps, group minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,10 @@
 version: 2
+
+# Config policy:
+# - Ignore ALL major version bumps (handled as coordinated manual upgrades)
+# - Group minor/patch updates per directory into a single PR
+# - Limit open PRs to 5 per directory to reduce noise
+
 updates:
   # === Python ===
 
@@ -6,23 +12,35 @@ updates:
     directory: "/python/voice-live-avatar"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "microsoft-foundry/voicelive-repo-maintainers"
     labels:
       - "dependencies"
       - "python"
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/python/voice-live-quickstarts"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "microsoft-foundry/voicelive-repo-maintainers"
     labels:
       - "dependencies"
       - "python"
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/python/voice-live-quickstarts/AgentsNewQuickstart"
@@ -34,28 +52,46 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/python/voice-live-voicerag-assistant/app/backend"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "microsoft-foundry/voicelive-repo-maintainers"
     labels:
       - "dependencies"
       - "python"
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/voice-live-universal-assistant/python"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "microsoft-foundry/voicelive-repo-maintainers"
     labels:
       - "dependencies"
       - "python"
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # === JavaScript / npm ===
 
@@ -63,56 +99,86 @@ updates:
     directory: "/javascript/basic-web-voice-assistant"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "microsoft-foundry/voicelive-repo-maintainers"
     labels:
       - "dependencies"
       - "javascript"
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/javascript/voice-live-car-demo"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "microsoft-foundry/voicelive-repo-maintainers"
     labels:
       - "dependencies"
       - "javascript"
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/javascript/voice-live-interpreter-demo"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "microsoft-foundry/voicelive-repo-maintainers"
     labels:
       - "dependencies"
       - "javascript"
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/javascript/voice-live-trader-demo"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "microsoft-foundry/voicelive-repo-maintainers"
     labels:
       - "dependencies"
       - "javascript"
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/javascript/voice-live-avatar"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "microsoft-foundry/voicelive-repo-maintainers"
     labels:
       - "dependencies"
       - "javascript"
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/javascript/voice-live-quickstarts/ModelQuickstart"
@@ -124,6 +190,12 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/javascript/voice-live-quickstarts/AgentsNewQuickstart"
@@ -135,39 +207,63 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/voice-live-universal-assistant/javascript"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "microsoft-foundry/voicelive-repo-maintainers"
     labels:
       - "dependencies"
       - "javascript"
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/voice-live-universal-assistant/frontend"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "microsoft-foundry/voicelive-repo-maintainers"
     labels:
       - "dependencies"
       - "javascript"
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/python/voice-live-voicerag-assistant/app/frontend"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "microsoft-foundry/voicelive-repo-maintainers"
     labels:
       - "dependencies"
       - "javascript"
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # === C# / NuGet ===
 
@@ -181,6 +277,12 @@ updates:
     labels:
       - "dependencies"
       - "csharp"
+    groups:
+      nuget-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "nuget"
     directory: "/csharp/voice-live-quickstarts/AgentQuickstart"
@@ -192,6 +294,12 @@ updates:
     labels:
       - "dependencies"
       - "csharp"
+    groups:
+      nuget-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "nuget"
     directory: "/csharp/voice-live-quickstarts/BringYourOwnModelQuickstart"
@@ -203,6 +311,12 @@ updates:
     labels:
       - "dependencies"
       - "csharp"
+    groups:
+      nuget-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "nuget"
     directory: "/csharp/voice-live-quickstarts/AgentsNewQuickstart"
@@ -214,6 +328,12 @@ updates:
     labels:
       - "dependencies"
       - "csharp"
+    groups:
+      nuget-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "nuget"
     directory: "/csharp/CustomerServiceBot"
@@ -225,6 +345,12 @@ updates:
     labels:
       - "dependencies"
       - "csharp"
+    groups:
+      nuget-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "nuget"
     directory: "/voice-live-universal-assistant/csharp"
@@ -236,6 +362,12 @@ updates:
     labels:
       - "dependencies"
       - "csharp"
+    groups:
+      nuget-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # === Java / Maven ===
 
@@ -249,6 +381,12 @@ updates:
     labels:
       - "dependencies"
       - "java"
+    groups:
+      maven-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "maven"
     directory: "/voice-live-universal-assistant/java"
@@ -260,3 +398,9 @@ updates:
     labels:
       - "dependencies"
       - "java"
+    groups:
+      maven-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
# Improve Dependabot Configuration

Prevents the PR pileup problem where 40+ major-bump PRs accumulate that always get closed manually.

## Changes

### 1. Ignore major version bumps (`ignore` rules)
Every entry now has:
```yaml
ignore:
  - dependency-name: "*"
    update-types: ["version-update:semver-major"]
```

This prevents PRs for: React 18→19, vite→8, ESLint→10, Tailwind→4, .NET 9→10, Spring Boot 3→4, Express 4→5, TypeScript 5→6, etc.

Major upgrades should be planned and executed as coordinated efforts, not individual dependabot PRs.

### 2. Group minor/patch updates (`groups`)
Every entry now has:
```yaml
groups:
  npm-minor-patch:  # (or python-/nuget-/maven-minor-patch)
    update-types: ["minor", "patch"]
```

This consolidates all minor+patch bumps per directory into a **single PR** instead of one per dependency. Expected reduction: ~5-10x fewer PRs for the same coverage.

### 3. Standardized limits
All entries use `open-pull-requests-limit: 5` (down from 10 on many entries).

## Impact

- **Before**: 40+ open dependabot PRs, most of which are major bumps that get closed manually
- **After**: Only minor/patch PRs, grouped per directory — expect ~1 PR per directory per week at most
- Dependabot's built-in superseding behavior handles the rest (newer patch replaces older patch automatically)