### PR TITLE
chore(deps): Consolidate 2 safe dependabot updates (wave 3)

### DIFF
--- a/javascript/voice-live-avatar/package.json
+++ b/javascript/voice-live-avatar/package.json
@@ -24,7 +24,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@tailwindcss/postcss": "^4.2.1",
     "class-variance-authority": "^0.7.1",
-    "lucide-react": "^0.575.0",
+    "lucide-react": "^0.577.0",
     "microsoft-cognitiveservices-speech-sdk": "^1.48.0",
     "next": "^16.0.10",
     "react": "19.2.4",

--- a/python/voice-live-voicerag-assistant/app/frontend/package.json
+++ b/python/voice-live-voicerag-assistant/app/frontend/package.json
@@ -20,7 +20,7 @@
     "i18next": "^23.12.2",
     "i18next-browser-languagedetector": "^8.0.0",
     "i18next-http-backend": "^2.5.2",
-    "lucide-react": "^0.445.0",
+    "lucide-react": "^0.577.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^15.0.0",
@@ -36,7 +36,7 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.47",
     "prettier": "^3.3.3",
-    "prettier-plugin-tailwindcss": "^0.6.8",
+    "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^3.4.12",
     "typescript": "^5.5.3",
     "vite": "^7.1.2"


### PR DESCRIPTION
## Consolidated safe dependency updates (wave 3)

Cherry-picks 2 safe dependabot PRs into a single merge:

| PR | Directory | Update |
|---|---|---|
| #175 | python/voice-live-voicerag-assistant/app/frontend | lucide-react ^0.445→^0.577, prettier-plugin-tailwindcss ^0.6.8→^0.7.2 |
| #176 | javascript/voice-live-avatar | lucide-react 0.575.0→0.577.0 |

### Build verification
- ✅ javascript/voice-live-avatar — `npm run build` passes (Next.js 16.2.2)
- ✅ python/voice-live-voicerag-assistant/app/frontend — `npm run build` passes (Vite)

### Excluded
- PR #171 (voice-live-car-demo) — `eslint-plugin-react-refresh@0.5.2` requires `eslint ^9 || ^10` but car-demo has `eslint@^8.57.0`. Reclassified as requiring coordinated eslint upgrade.