### PR TITLE
chore: add *.tsbuildinfo to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -449,6 +449,7 @@ target/
 dependency-reduced-pom.xml
 application.properties
 
-# JavaScript files
+# JavaScript/TypeScript files
 package-lock.json
 node_modules/
+*.tsbuildinfo


### PR DESCRIPTION
Adds `*.tsbuildinfo` (TypeScript incremental build cache) to `.gitignore`. These files are generated during `tsc -b` / `vite build` and have no value in source control.