### PR TITLE
Add Voice Live telemetry quickstart samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Python samples showcasing:
 - **Model Quickstart**: Direct model access with flexible authentication
 - **Bring-Your-Own-Model (BYOM) Quickstart**: Use your own models hosted in Foundry with proactive greetings
 - **Function Calling**: Advanced tool integration with custom functions and proactive greetings
+- **Telemetry Quickstart**: OpenTelemetry tracing — console export, Azure Monitor, custom attributes, and content recording
 - **RAG-enabled Voice Assistant**: Full-stack voice assistant with Azure AI Search integration and `azd` deployment
 - **Voice Live Avatar**: Avatar-enabled voice conversations with server-side SDK and Docker deployment
 - Built with Python 3.8+ and async/await patterns

--- a/csharp/voice-live-quickstarts/TelemetryQuickstart/README.md
+++ b/csharp/voice-live-quickstarts/TelemetryQuickstart/README.md
@@ -1,0 +1,5 @@
+# Telemetry Quickstart - C#
+
+Telemetry samples for the C# Voice Live SDK are coming soon.
+
+For Python telemetry samples, see the [Python TelemetryQuickstart](../../python/voice-live-quickstarts/TelemetryQuickstart/).

--- a/csharp/voice-live-quickstarts/TelemetryQuickstart/README.md
+++ b/csharp/voice-live-quickstarts/TelemetryQuickstart/README.md
@@ -2,4 +2,4 @@
 
 Telemetry samples for the C# Voice Live SDK are coming soon.
 
-For Python telemetry samples, see the [Python TelemetryQuickstart](../../python/voice-live-quickstarts/TelemetryQuickstart/).
+For Python telemetry samples, see the [Python TelemetryQuickstart](../../../python/voice-live-quickstarts/TelemetryQuickstart/).

--- a/java/voice-live-quickstarts/TelemetryQuickstart/README.md
+++ b/java/voice-live-quickstarts/TelemetryQuickstart/README.md
@@ -2,4 +2,4 @@
 
 Telemetry samples for the Java Voice Live SDK are coming soon.
 
-For Python telemetry samples, see the [Python TelemetryQuickstart](../../python/voice-live-quickstarts/TelemetryQuickstart/).
+For Python telemetry samples, see the [Python TelemetryQuickstart](../../../python/voice-live-quickstarts/TelemetryQuickstart/).

--- a/java/voice-live-quickstarts/TelemetryQuickstart/README.md
+++ b/java/voice-live-quickstarts/TelemetryQuickstart/README.md
@@ -1,0 +1,5 @@
+# Telemetry Quickstart - Java
+
+Telemetry samples for the Java Voice Live SDK are coming soon.
+
+For Python telemetry samples, see the [Python TelemetryQuickstart](../../python/voice-live-quickstarts/TelemetryQuickstart/).

--- a/javascript/voice-live-quickstarts/TelemetryQuickstart/README.md
+++ b/javascript/voice-live-quickstarts/TelemetryQuickstart/README.md
@@ -2,4 +2,4 @@
 
 Telemetry samples for the JavaScript Voice Live SDK are coming soon.
 
-For Python telemetry samples, see the [Python TelemetryQuickstart](../../python/voice-live-quickstarts/TelemetryQuickstart/).
+For Python telemetry samples, see the [Python TelemetryQuickstart](../../../python/voice-live-quickstarts/TelemetryQuickstart/).

--- a/javascript/voice-live-quickstarts/TelemetryQuickstart/README.md
+++ b/javascript/voice-live-quickstarts/TelemetryQuickstart/README.md
@@ -1,0 +1,5 @@
+# Telemetry Quickstart - JavaScript
+
+Telemetry samples for the JavaScript Voice Live SDK are coming soon.
+
+For Python telemetry samples, see the [Python TelemetryQuickstart](../../python/voice-live-quickstarts/TelemetryQuickstart/).

--- a/python/README.md
+++ b/python/README.md
@@ -68,6 +68,18 @@ Demonstrates how to implement function calling with VoiceLive models, enabling t
 - Advanced tool integration
 - Proactive greeting support
 
+### [Telemetry Quickstart](./voice-live-quickstarts/TelemetryQuickstart/)
+
+Demonstrates how to enable and customize OpenTelemetry tracing for Voice Live SDK sessions. These are text-mode samples — copy the region-tagged snippets into any existing Voice Live application.
+
+**Key Features:**
+- Console span export for local debugging
+- Azure Monitor / Application Insights export
+- Custom span attributes for session and user correlation
+- Content recording with PII warnings
+
+> **Docs**: [Enable telemetry and tracing for Voice Live](https://learn.microsoft.com/azure/ai-services/speech-service/how-to-voice-live-telemetry)
+
 ### [RAG-enabled Voice Assistant](./voice-live-voicerag-assistant/README.md)
 
 Demonstrates how to build a real-time voice assistant with Retrieval-Augmented Generation (RAG) capabilities using Azure AI Voice Live API and Azure AI Search.

--- a/python/voice-live-quickstarts/TelemetryQuickstart/README.md
+++ b/python/voice-live-quickstarts/TelemetryQuickstart/README.md
@@ -1,0 +1,57 @@
+# Telemetry Quickstart - Python
+
+These samples demonstrate how to enable and customize OpenTelemetry tracing for the Azure AI Voice Live SDK.
+
+> **Text-mode samples**: These samples use text mode (`Modality.TEXT`) so they run without a microphone. The telemetry setup code is isolated inside region tags (e.g., `# <enable_console_tracing>` / `# </enable_console_tracing>`) and can be copied into any existing Voice Live application — including audio-mode quickstarts and demos in this repo.
+
+## Documentation
+
+- [Enable telemetry and tracing for Voice Live](https://learn.microsoft.com/azure/ai-services/speech-service/how-to-voice-live-telemetry) — full how-to guide on Microsoft Learn
+
+## Samples
+
+| File | Region tag(s) | Description |
+|---|---|---|
+| `telemetry-console.py` | `enable_console_tracing` | Export Voice Live traces to the console |
+| `telemetry-azure-monitor.py` | `enable_azure_monitor_tracing` | Export traces to Azure Monitor / Application Insights |
+| `telemetry-custom-attributes.py` | `custom_span_processor`, `add_custom_processor` | Add custom span attributes for correlation |
+| `telemetry-content-recording.py` | `enable_content_recording` | Enable full message payload recording in traces |
+
+### Adding telemetry to other samples
+
+Copy the code between the region tags into your own sample. For example, to add console tracing to any Voice Live app, copy the code inside `# <enable_console_tracing>` / `# </enable_console_tracing>` from `telemetry-console.py` and place it before your `connect()` call.
+
+## Prerequisites
+
+- Python 3.9 or later
+- An Azure AI Services or Speech resource
+- Complete one of the Voice Live quickstarts first:
+  - [Voice Live with Foundry models](https://learn.microsoft.com/azure/ai-services/speech-service/voice-live-quickstart)
+  - [Voice Live with Foundry agents](https://learn.microsoft.com/azure/ai-services/speech-service/voice-live-agents-quickstart)
+
+## Setup
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Set environment variables:
+
+   ```bash
+   export AZURE_VOICELIVE_ENDPOINT="https://<your-resource>.services.ai.azure.com"
+   export AZURE_VOICELIVE_API_KEY="<your-api-key>"
+   ```
+
+   For the Azure Monitor sample, also set:
+
+   ```bash
+   export APPLICATIONINSIGHTS_CONNECTION_STRING="<your-connection-string>"
+   ```
+
+3. Run any sample:
+
+   ```bash
+   python telemetry-console.py
+   ```

--- a/python/voice-live-quickstarts/TelemetryQuickstart/requirements.txt
+++ b/python/voice-live-quickstarts/TelemetryQuickstart/requirements.txt
@@ -1,0 +1,4 @@
+azure-ai-voicelive
+opentelemetry-sdk
+azure-core-tracing-opentelemetry
+azure-monitor-opentelemetry

--- a/python/voice-live-quickstarts/TelemetryQuickstart/telemetry-azure-monitor.py
+++ b/python/voice-live-quickstarts/TelemetryQuickstart/telemetry-azure-monitor.py
@@ -1,0 +1,136 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# -------------------------------------------------------------------------
+
+"""
+FILE: telemetry-azure-monitor.py
+
+DESCRIPTION:
+    This sample demonstrates how to export Voice Live OpenTelemetry traces
+    to Azure Monitor / Application Insights. View results in the "Tracing"
+    tab in your Azure AI Foundry project page or in Application Insights.
+
+    The telemetry setup code (marked with region tags) can be copied into
+    any existing Voice Live application to add Azure Monitor tracing.
+
+USAGE:
+    python telemetry-azure-monitor.py
+
+    Set the environment variables with your own values before running:
+    1) AZURE_VOICELIVE_ENDPOINT - The Azure VoiceLive endpoint
+    2) AZURE_VOICELIVE_API_KEY  - The Azure VoiceLive API key
+    3) APPLICATIONINSIGHTS_CONNECTION_STRING - Application Insights
+       connection string
+
+REQUIREMENTS:
+    - azure-ai-voicelive
+    - azure-monitor-opentelemetry
+"""
+
+import asyncio
+import os
+
+# <enable_azure_monitor_tracing>
+from azure.core.settings import settings
+
+# Step 1: Tell azure-core to use OpenTelemetry for tracing.
+settings.tracing_implementation = "opentelemetry"
+
+# Step 2: Configure Azure Monitor as the trace exporter.
+from opentelemetry import trace
+from azure.monitor.opentelemetry import configure_azure_monitor
+
+application_insights_connection_string = os.environ[
+    "APPLICATIONINSIGHTS_CONNECTION_STRING"
+]
+configure_azure_monitor(
+    connection_string=application_insights_connection_string
+)
+
+# Step 3: Enable the VoiceLive instrumentor.
+from azure.ai.voicelive.telemetry import VoiceLiveInstrumentor
+
+os.environ.setdefault(
+    "AZURE_EXPERIMENTAL_ENABLE_GENAI_TRACING", "true"
+)
+VoiceLiveInstrumentor().instrument()
+# </enable_azure_monitor_tracing>
+
+from azure.core.credentials import AzureKeyCredential
+from azure.ai.voicelive.aio import connect
+from azure.ai.voicelive.models import (
+    InputTextContentPart,
+    Modality,
+    OutputAudioFormat,
+    RequestSession,
+    ServerEventType,
+    ServerVad,
+    UserMessageItem,
+)
+
+tracer = trace.get_tracer(__name__)
+
+
+async def main() -> None:
+    endpoint = os.environ["AZURE_VOICELIVE_ENDPOINT"]
+    api_key = os.environ["AZURE_VOICELIVE_API_KEY"]
+    model = os.environ.get(
+        "AZURE_VOICELIVE_MODEL", "gpt-realtime"
+    )
+
+    credential = AzureKeyCredential(api_key)
+
+    with tracer.start_as_current_span(
+        "telemetry-azure-monitor"
+    ):
+        async with connect(
+            endpoint=endpoint,
+            credential=credential,
+            model=model,
+        ) as connection:
+            print(f"Connected to VoiceLive at {endpoint}")
+
+            session_config = RequestSession(
+                modalities=[Modality.TEXT],
+                instructions=(
+                    "You are a helpful assistant. "
+                    "Say hello briefly."
+                ),
+                turn_detection=ServerVad(
+                    threshold=0.5,
+                    prefix_padding_ms=300,
+                    silence_duration_ms=500,
+                ),
+                output_audio_format=OutputAudioFormat.PCM16,
+            )
+            await connection.session.update(
+                session=session_config
+            )
+            print("Session configured.")
+
+            await connection.conversation.item.create(
+                item=UserMessageItem(
+                    content=[
+                        InputTextContentPart(
+                            text="Hello, tell me a joke"
+                        )
+                    ]
+                )
+            )
+            await connection.response.create()
+            print("User message sent.")
+
+            async for event in connection:
+                event_type = getattr(event, "type", None)
+                print(f"Received event: {event_type}")
+
+                if event_type == ServerEventType.RESPONSE_DONE:
+                    print("Response complete.")
+                    break
+
+        print("Connection closed.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/voice-live-quickstarts/TelemetryQuickstart/telemetry-azure-monitor.py
+++ b/python/voice-live-quickstarts/TelemetryQuickstart/telemetry-azure-monitor.py
@@ -26,6 +26,7 @@ USAGE:
 REQUIREMENTS:
     - azure-ai-voicelive
     - azure-monitor-opentelemetry
+    - azure-core-tracing-opentelemetry
 """
 
 import asyncio
@@ -133,4 +134,11 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    finally:
+        tracer_provider = trace.get_tracer_provider()
+        if hasattr(tracer_provider, "force_flush"):
+            tracer_provider.force_flush()
+        if hasattr(tracer_provider, "shutdown"):
+            tracer_provider.shutdown()

--- a/python/voice-live-quickstarts/TelemetryQuickstart/telemetry-console.py
+++ b/python/voice-live-quickstarts/TelemetryQuickstart/telemetry-console.py
@@ -1,0 +1,140 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# -------------------------------------------------------------------------
+
+"""
+FILE: telemetry-console.py
+
+DESCRIPTION:
+    This sample demonstrates how to enable OpenTelemetry tracing for the
+    Azure AI Voice Live SDK with console output. All connection, send, and
+    receive operations produce OpenTelemetry spans printed to stdout.
+
+    The telemetry setup code (marked with region tags) can be copied into
+    any existing Voice Live application, such as the model quickstart or
+    agent quickstart, to add tracing without changing application logic.
+
+USAGE:
+    python telemetry-console.py
+
+    Set the environment variables with your own values before running:
+    1) AZURE_VOICELIVE_ENDPOINT - The Azure VoiceLive endpoint
+    2) AZURE_VOICELIVE_API_KEY  - The Azure VoiceLive API key
+
+REQUIREMENTS:
+    - azure-ai-voicelive
+    - opentelemetry-sdk
+    - azure-core-tracing-opentelemetry
+"""
+
+import asyncio
+import os
+
+# <enable_console_tracing>
+from azure.core.settings import settings
+
+# Step 1: Tell azure-core to use OpenTelemetry for tracing.
+settings.tracing_implementation = "opentelemetry"
+
+# Step 2: Configure a TracerProvider with a console exporter.
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    ConsoleSpanExporter,
+)
+
+tracer_provider = TracerProvider()
+tracer_provider.add_span_processor(
+    SimpleSpanProcessor(ConsoleSpanExporter())
+)
+trace.set_tracer_provider(tracer_provider)
+
+# Step 3: Enable the VoiceLive instrumentor.
+from azure.ai.voicelive.telemetry import VoiceLiveInstrumentor
+
+os.environ.setdefault(
+    "AZURE_EXPERIMENTAL_ENABLE_GENAI_TRACING", "true"
+)
+VoiceLiveInstrumentor().instrument()
+# </enable_console_tracing>
+
+from azure.core.credentials import AzureKeyCredential
+from azure.ai.voicelive.aio import connect
+from azure.ai.voicelive.models import (
+    InputTextContentPart,
+    Modality,
+    OutputAudioFormat,
+    RequestSession,
+    ServerEventType,
+    ServerVad,
+    UserMessageItem,
+)
+
+tracer = trace.get_tracer(__name__)
+
+
+async def main() -> None:
+    endpoint = os.environ["AZURE_VOICELIVE_ENDPOINT"]
+    api_key = os.environ["AZURE_VOICELIVE_API_KEY"]
+    model = os.environ.get(
+        "AZURE_VOICELIVE_MODEL", "gpt-realtime"
+    )
+
+    credential = AzureKeyCredential(api_key)
+
+    with tracer.start_as_current_span("telemetry-console"):
+        async with connect(
+            endpoint=endpoint,
+            credential=credential,
+            model=model,
+        ) as connection:
+            print(f"Connected to VoiceLive at {endpoint}")
+
+            session_config = RequestSession(
+                modalities=[Modality.TEXT],
+                instructions=(
+                    "You are a helpful assistant. "
+                    "Say hello briefly."
+                ),
+                turn_detection=ServerVad(
+                    threshold=0.5,
+                    prefix_padding_ms=300,
+                    silence_duration_ms=500,
+                ),
+                output_audio_format=OutputAudioFormat.PCM16,
+            )
+            await connection.session.update(
+                session=session_config
+            )
+            print("Session configured.")
+
+            await connection.conversation.item.create(
+                item=UserMessageItem(
+                    content=[
+                        InputTextContentPart(
+                            text="Hello, tell me a joke"
+                        )
+                    ]
+                )
+            )
+            await connection.response.create()
+            print("User message sent.")
+
+            async for event in connection:
+                event_type = getattr(event, "type", None)
+                print(f"Received event: {event_type}")
+
+                if event_type == ServerEventType.RESPONSE_DONE:
+                    print("Response complete.")
+                    break
+
+        print("Connection closed.")
+
+    tracer_provider.force_flush()
+    tracer_provider.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/voice-live-quickstarts/TelemetryQuickstart/telemetry-content-recording.py
+++ b/python/voice-live-quickstarts/TelemetryQuickstart/telemetry-content-recording.py
@@ -1,0 +1,154 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# -------------------------------------------------------------------------
+
+"""
+FILE: telemetry-content-recording.py
+
+DESCRIPTION:
+    This sample demonstrates how to enable content recording for Voice Live
+    OpenTelemetry traces. When enabled, full message payloads (send and
+    receive) are captured in span events as gen_ai.event.content attributes.
+
+    WARNING: Content recording may capture personal data. Only enable in
+    development or controlled environments.
+
+    The content recording setup code (marked with region tags) can be
+    copied into any existing Voice Live application.
+
+USAGE:
+    python telemetry-content-recording.py
+
+    Set the environment variables with your own values before running:
+    1) AZURE_VOICELIVE_ENDPOINT - The Azure VoiceLive endpoint
+    2) AZURE_VOICELIVE_API_KEY  - The Azure VoiceLive API key
+
+REQUIREMENTS:
+    - azure-ai-voicelive
+    - opentelemetry-sdk
+    - azure-core-tracing-opentelemetry
+"""
+
+import asyncio
+import os
+
+from azure.core.settings import settings
+
+settings.tracing_implementation = "opentelemetry"
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    ConsoleSpanExporter,
+)
+
+tracer_provider = TracerProvider()
+tracer_provider.add_span_processor(
+    SimpleSpanProcessor(ConsoleSpanExporter())
+)
+trace.set_tracer_provider(tracer_provider)
+
+from azure.ai.voicelive.telemetry import VoiceLiveInstrumentor
+
+os.environ.setdefault(
+    "AZURE_EXPERIMENTAL_ENABLE_GENAI_TRACING", "true"
+)
+
+# <enable_content_recording>
+# Option 1: Enable via environment variable.
+# os.environ[
+#     "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
+# ] = "true"
+
+# Option 2: Enable programmatically.
+VoiceLiveInstrumentor().instrument(
+    enable_content_recording=True
+)
+# </enable_content_recording>
+
+from azure.core.credentials import AzureKeyCredential
+from azure.ai.voicelive.aio import connect
+from azure.ai.voicelive.models import (
+    InputTextContentPart,
+    Modality,
+    OutputAudioFormat,
+    RequestSession,
+    ServerEventType,
+    ServerVad,
+    UserMessageItem,
+)
+
+tracer = trace.get_tracer(__name__)
+
+
+async def main() -> None:
+    endpoint = os.environ["AZURE_VOICELIVE_ENDPOINT"]
+    api_key = os.environ["AZURE_VOICELIVE_API_KEY"]
+    model = os.environ.get(
+        "AZURE_VOICELIVE_MODEL", "gpt-realtime"
+    )
+
+    credential = AzureKeyCredential(api_key)
+
+    with tracer.start_as_current_span(
+        "telemetry-content-recording"
+    ):
+        async with connect(
+            endpoint=endpoint,
+            credential=credential,
+            model=model,
+        ) as connection:
+            print(f"Connected to VoiceLive at {endpoint}")
+
+            # The full session config payload appears in the
+            # span event as gen_ai.event.content.
+            session_config = RequestSession(
+                modalities=[Modality.TEXT],
+                instructions=(
+                    "You are a helpful assistant. "
+                    "Say hello briefly."
+                ),
+                turn_detection=ServerVad(
+                    threshold=0.5,
+                    prefix_padding_ms=300,
+                    silence_duration_ms=500,
+                ),
+                output_audio_format=OutputAudioFormat.PCM16,
+            )
+            await connection.session.update(
+                session=session_config
+            )
+            print("Session configured.")
+
+            # The full message content is captured.
+            await connection.conversation.item.create(
+                item=UserMessageItem(
+                    content=[
+                        InputTextContentPart(
+                            text="Hello, tell me a joke"
+                        )
+                    ]
+                )
+            )
+            await connection.response.create()
+            print("User message sent.")
+
+            # The full event payloads are captured.
+            async for event in connection:
+                event_type = getattr(event, "type", None)
+                print(f"Received event: {event_type}")
+
+                if event_type == ServerEventType.RESPONSE_DONE:
+                    print("Response complete.")
+                    break
+
+        print("Connection closed.")
+
+    tracer_provider.force_flush()
+    tracer_provider.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/voice-live-quickstarts/TelemetryQuickstart/telemetry-custom-attributes.py
+++ b/python/voice-live-quickstarts/TelemetryQuickstart/telemetry-custom-attributes.py
@@ -1,0 +1,177 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# -------------------------------------------------------------------------
+
+"""
+FILE: telemetry-custom-attributes.py
+
+DESCRIPTION:
+    This sample demonstrates how to add custom attributes to Voice Live
+    OpenTelemetry spans using a custom SpanProcessor. This is useful for
+    correlating Voice Live traces with application-specific context such
+    as session IDs, user IDs, or request identifiers.
+
+    The custom SpanProcessor code (marked with region tags) can be copied
+    into any existing Voice Live application.
+
+USAGE:
+    python telemetry-custom-attributes.py
+
+    Set the environment variables with your own values before running:
+    1) AZURE_VOICELIVE_ENDPOINT - The Azure VoiceLive endpoint
+    2) AZURE_VOICELIVE_API_KEY  - The Azure VoiceLive API key
+
+REQUIREMENTS:
+    - azure-ai-voicelive
+    - opentelemetry-sdk
+    - azure-core-tracing-opentelemetry
+"""
+
+import asyncio
+import os
+from typing import cast
+
+from azure.core.settings import settings
+
+settings.tracing_implementation = "opentelemetry"
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import (
+    TracerProvider,
+    SpanProcessor,
+    ReadableSpan,
+    Span,
+)
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    ConsoleSpanExporter,
+)
+
+from azure.ai.voicelive.telemetry import VoiceLiveInstrumentor
+
+# <custom_span_processor>
+class CustomAttributeSpanProcessor(SpanProcessor):
+    """Add application-specific attributes to every span."""
+
+    def on_start(self, span: Span, parent_context=None):
+        # Add a session identifier to all spans.
+        span.set_attribute(
+            "app.session_id", "my-session-123"
+        )
+
+        # Tag send spans with extra context.
+        if span.name and span.name.startswith("send"):
+            span.set_attribute(
+                "app.send.context", "user-interaction"
+            )
+
+        # Tag receive spans with a priority level.
+        if span.name and span.name.startswith("recv"):
+            span.set_attribute(
+                "app.recv.priority", "normal"
+            )
+
+    def on_end(self, span: ReadableSpan):
+        pass
+# </custom_span_processor>
+
+
+# Set up tracing with the custom processor.
+tracer_provider = TracerProvider()
+tracer_provider.add_span_processor(
+    SimpleSpanProcessor(ConsoleSpanExporter())
+)
+trace.set_tracer_provider(tracer_provider)
+
+os.environ.setdefault(
+    "AZURE_EXPERIMENTAL_ENABLE_GENAI_TRACING", "true"
+)
+VoiceLiveInstrumentor().instrument()
+
+# <add_custom_processor>
+# Register the custom processor with the global provider.
+provider = cast(TracerProvider, trace.get_tracer_provider())
+provider.add_span_processor(CustomAttributeSpanProcessor())
+# </add_custom_processor>
+
+from azure.core.credentials import AzureKeyCredential
+from azure.ai.voicelive.aio import connect
+from azure.ai.voicelive.models import (
+    InputTextContentPart,
+    Modality,
+    OutputAudioFormat,
+    RequestSession,
+    ServerEventType,
+    ServerVad,
+    UserMessageItem,
+)
+
+tracer = trace.get_tracer(__name__)
+
+
+async def main() -> None:
+    endpoint = os.environ["AZURE_VOICELIVE_ENDPOINT"]
+    api_key = os.environ["AZURE_VOICELIVE_API_KEY"]
+    model = os.environ.get(
+        "AZURE_VOICELIVE_MODEL", "gpt-realtime"
+    )
+
+    credential = AzureKeyCredential(api_key)
+
+    with tracer.start_as_current_span(
+        "telemetry-custom-attributes"
+    ):
+        async with connect(
+            endpoint=endpoint,
+            credential=credential,
+            model=model,
+        ) as connection:
+            print(f"Connected to VoiceLive at {endpoint}")
+
+            session_config = RequestSession(
+                modalities=[Modality.TEXT],
+                instructions=(
+                    "You are a helpful assistant. "
+                    "Say hello briefly."
+                ),
+                turn_detection=ServerVad(
+                    threshold=0.5,
+                    prefix_padding_ms=300,
+                    silence_duration_ms=500,
+                ),
+                output_audio_format=OutputAudioFormat.PCM16,
+            )
+            await connection.session.update(
+                session=session_config
+            )
+            print("Session configured.")
+
+            await connection.conversation.item.create(
+                item=UserMessageItem(
+                    content=[
+                        InputTextContentPart(
+                            text="Hello, tell me a joke"
+                        )
+                    ]
+                )
+            )
+            await connection.response.create()
+            print("User message sent.")
+
+            async for event in connection:
+                event_type = getattr(event, "type", None)
+                print(f"Received event: {event_type}")
+
+                if event_type == ServerEventType.RESPONSE_DONE:
+                    print("Response complete.")
+                    break
+
+        print("Connection closed.")
+
+    tracer_provider.force_flush()
+    tracer_provider.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Adds Python telemetry samples for the Voice Live SDK with placeholder folders for C#, Java, and JavaScript.

## Samples added

- **telemetry-console.py** — Export Voice Live traces to the console
- **telemetry-azure-monitor.py** — Export traces to Azure Monitor / Application Insights
- **telemetry-custom-attributes.py** — Add custom span attributes for correlation
- **telemetry-content-recording.py** — Enable full message payload recording

All samples use region tags for \:::code\ extraction in the corresponding docs how-to guide.

## Related docs PR

azure-ai-docs-pr branch: \oice-live-ga-may-26\ (new how-to: \how-to-voice-live-telemetry.md\)