### PR TITLE
Add Live Reference AEC browser sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ JavaScript/TypeScript samples showcasing:
 - **Model Quickstart**: Direct Voice Live model integration with proactive greetings
 - **Basic Web Voice Assistant**: Browser-based voice assistant with real-time streaming and barge-in support
 - **Voice Live Education Demo**: Browser-based English pronunciation coach that pairs Voice Live with the Azure Speech SDK for real-time pronunciation assessment (Conversation / Concise / Read Along scenarios)
+- **Live Reference AEC**: Browser sample that streams the mic plus the app's own speaker playback as a stereo reference so the service can cancel echo against the exact signal played
 - **Voice Live Avatar**: Avatar-enabled voice conversations with Docker deployment
 - **Voice Live Car Demo**: Voice-Enabled Car Assistant powered by multiple architectures
 - **Voice Live Interpreter**: Real-time speech translation, speech in and speech out

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -55,6 +55,17 @@ A browser-based voice assistant demonstrating Azure Voice Live SDK integration i
 - Audio level visualization
 - Support for OpenAI and Azure Neural voices
 
+### [Live Reference AEC](./live-reference-aec/)
+
+A browser sample showing how to stream stereo audio (microphone + a tap of your app's speaker playback) to Azure Voice Live so the service cancels echo using the exact signal the speaker plays. This feature is called Live Reference AEC. Available at api-version `2026-07-15` and later.
+
+**Key Features:**
+- Stereo PCM16 streaming with mic on channel 0 and speaker reference on channel 1
+- `AudioWorklet` interleaver and a Web Audio playback bus (speakers + reference)
+- Session config via `inputAudioEchoCancellation` (`referenceSource: "client"`, `channels: 2`)
+- Mic capture with browser echo cancellation, noise suppression, and AGC disabled
+- Barge-in support and streaming transcription
+
 ### [Voice Live Avatar](./voice-live-avatar/)
 
 A Dockerized sample demonstrating Azure Voice Live API with avatar integration, enabling visual avatar representation during voice conversations.
@@ -137,6 +148,7 @@ All samples require:
 | MCP Quickstart | [Node.js 18+](https://nodejs.org/) with npm |
 | Model Quickstart | [Node.js 18+](https://nodejs.org/) with npm |
 | Basic Web Voice Assistant | [Node.js 18+](https://nodejs.org/) with npm |
+| Live Reference AEC | [Node.js 22+](https://nodejs.org/) with npm |
 | Voice Live Avatar | [Docker](https://www.docker.com/get-started) |
 | Voice Live Car Demo | [Node.js 18+](https://nodejs.org/) with npm |
 | Voice Live Education Demo | [Node.js 18+](https://nodejs.org/) with npm |

--- a/javascript/live-reference-aec/.gitignore
+++ b/javascript/live-reference-aec/.gitignore
@@ -1,0 +1,15 @@
+# dependencies
+/node_modules
+
+# build output
+/dist
+
+# misc
+.DS_Store
+*.tsbuildinfo
+
+# logs
+npm-debug.log*
+
+# env files
+.env*

--- a/javascript/live-reference-aec/README.md
+++ b/javascript/live-reference-aec/README.md
@@ -1,0 +1,199 @@
+# Live Reference AEC
+
+A browser sample showing how to send **both the microphone audio and your app's speaker playback** to Azure Voice Live as a single stereo stream, so the service can cancel echo using the same signal your app plays out to the speaker. This feature is called Live Reference AEC.
+
+Available at REST api-version `2026-07-15` and later.
+
+## Why use a client-side reference
+
+By default, Voice Live uses its own generated TTS output as the echo reference (server loopback). That works when the only sound on the device is Voice Live's TTS, but the server's copy is not always what the speaker actually plays. The client may change volume, apply equalization, mix in other sounds, or buffer audio differently, and network jitter shifts the reference out of sync with the mic. When the reference no longer matches the real speaker output, echo cancellation degrades.
+
+Client-side reference fixes this by having the client capture and send the real speaker output alongside the mic:
+
+- **True source of truth**: the reference is the signal your app sends to the speaker, after all client-side mixing, effects, and buffering. It is captured in the browser before OS volume and device processing, so it reflects your app's output rather than the final acoustic signal.
+- **Packet-synchronized**: mic and reference travel in the same packet, so network conditions cannot misalign them.
+- **Minimal protocol change**: activate by adding two fields to your session config (`reference_source: "client"`, `channels: 2`). The client work is capturing and interleaving the reference audio.
+- **No billing change**: billing is based on mic audio content. The reference channel is stripped on arrival and used only for alignment.
+
+## How it works
+
+The client sends interleaved stereo PCM16 where channel 0 is the mic and channel 1 is a tap of the speaker playback:
+
+```
+[ mic0, ref0, mic1, ref1, mic2, ref2, ... ]
+```
+
+In the browser this is done entirely with the Web Audio API, so the playback never has to leave the page or be recorded from a second microphone. All assistant audio is routed through a shared playback bus that feeds both the speakers and the reference channel of an `AudioWorklet` interleaver:
+
+```
+ mic         --> interleaver input 0 (mic)
+ playbackBus --> speakers (AudioContext.destination)
+ playbackBus --> interleaver input 1 (reference)
+ interleaver --> stereo PCM16 --> session.sendAudio()
+```
+
+| File | Purpose |
+| ---- | ------- |
+| `public/stereo-interleaver.js` | `AudioWorklet` that interleaves mic + reference into stereo PCM16. |
+| `src/echoCancellationAudio.ts` | Builds the audio graph: mic capture (browser EC off), playback bus, interleaver, and TTS scheduling through the bus. |
+| `src/voiceAssistant.ts` | Voice Live SDK session wired with `inputAudioEchoCancellation` and stereo streaming. |
+| `src/main.ts` | Minimal UI wiring. |
+
+## Quick Start
+
+### Prerequisites
+
+- **Node.js 22 or later** with npm
+- **Azure AI Foundry** resource with Voice Live enabled, using api-version `2026-07-15` or later
+- `@azure/ai-voicelive` `1.1.0` or later (adds the Live Reference AEC fields; installed by `npm install`)
+- Modern browser (Chrome 80+, Edge 80+, Firefox 76+, Safari 14.1+)
+
+
+### 1. Install dependencies
+
+```bash
+cd javascript/live-reference-aec
+npm install
+```
+
+### 2. Start the dev server
+
+```bash
+npm run dev
+```
+
+Opens at **http://localhost:3000**.
+
+### 3. Configure and run
+
+1. Enter your **Voice Live endpoint** and **API key** (Azure AI Foundry portal > your resource > **Keys and Endpoint**).
+2. Optionally adjust **model**, **voice**, and **instructions**.
+3. Click **Start** and allow microphone access.
+4. Speak. Play the assistant's replies through your speakers (not headphones) to hear echo cancellation in action.
+
+> **Tip:** To see the benefit, use speakers rather than headphones so the assistant's voice re-enters the microphone. With the client reference active, that echo is cancelled and the assistant does not talk over itself.
+
+> **Security:** This sample takes an API key in the browser to stay self-contained. A key in client code is visible to anyone who loads the page. In production, do not ship the key to the browser: authenticate with Microsoft Entra ID, or have a backend mint short-lived tokens that the client uses instead.
+
+## Session configuration
+
+The only feature-specific configuration is the echo cancellation block, sent with the session update before any audio is streamed. The sample then waits for the server's `session.updated` acknowledgement before it starts streaming, so audio is never sent under a stale configuration; a rejected configuration surfaces as an error instead. On the wire:
+
+```json
+{
+  "type": "session.update",
+  "session": {
+    "modalities": ["text", "audio"],
+    "input_audio_format": "pcm16",
+    "input_audio_sampling_rate": 24000,
+    "input_audio_echo_cancellation": {
+      "type": "server_echo_cancellation",
+      "reference_source": "client",
+      "channels": 2
+    },
+    "turn_detection": { "type": "server_vad" }
+  }
+}
+```
+
+In this sample the same configuration is expressed in the SDK's camelCase form (`inputAudioEchoCancellation`, `referenceSource`, `inputAudioSamplingRate`), typed by `@azure/ai-voicelive` `1.1.0+` and serialized to the wire shape shown above.
+
+### Field reference
+
+| Field | Value | Notes |
+| ----- | ----- | ----- |
+| `type` | `"server_echo_cancellation"` | Required. Currently the only supported EC type. |
+| `reference_source` | `"client"` | EC uses the client-supplied reference on channel 1. Set to `"server"` (default) for internal TTS loopback. |
+| `channels` | `2` | Stereo input: ch0 = mic, ch1 = reference. Default is `1` (mono). |
+| `input_audio_format` | `"pcm16"` | Required when using a client reference. Only PCM16 is supported for this feature. |
+| `input_audio_sampling_rate` | `24000` | Sample rate of your stream in Hz. PCM16 supports `8000`, `16000`, or `24000`. Must match your actual capture rate. Defaults to 24000 if omitted. |
+
+### Validation rules
+
+| Condition | Error code | Meaning |
+| --------- | ---------- | ------- |
+| `reference_source: "client"` without stereo (`channels: 1`) | `invalid_ec_reference_channels` | Client reference requires stereo input. |
+| Stereo (`channels: 2`) without client reference | `invalid_ec_channels_requires_client` | Stereo input is only valid with a client reference. |
+| Stereo with a non-PCM16 format | `invalid_ec_channels_format` | Only PCM16 is supported with a client reference. |
+| Changing `channels` mid-session | `change_in_ec_channels_not_allowed` | Channel config is immutable after the session starts. |
+
+## Common pitfalls
+
+The server does not validate the quality of the reference channel. It trusts that the client sends the correct speaker output.
+
+| Issue | Result | How to avoid |
+| ----- | ------ | ------------ |
+| Reference is all silence / zeros | Nothing to cancel against; worse than server loopback | Ensure all TTS routes through the playback bus (`playbackBus`), not directly to `destination` or an `<audio>` element. |
+| Channels swapped (ref in ch0, mic in ch1) | EC cancels the mic against itself; severe degradation | Keep the interleave order ch0 = mic, ch1 = reference. |
+| Browser EC/NS/AGC left on for the mic | The browser alters the mic before the server sees it | Set `echoCancellation`, `noiseSuppression`, and `autoGainControl` to `false` in `getUserMedia` (the server does EC). |
+| Mono audio sent with `channels: 2` | Server deinterleaves mono as stereo and garbles both channels | Match the actual audio layout to the `channels` setting. |
+| Sampling rate mismatch | Reference and mic drift; EC degrades | Read `AudioContext.sampleRate` after construction and send it as `input_audio_sampling_rate`. |
+
+## Bandwidth and billing
+
+Stereo doubles the input audio bandwidth. For most voice applications this is not a concern.
+
+| Mode | Rate (per second) | Per hour |
+| ---- | ----------------- | -------- |
+| Mono (default) | ~47 KB/s | ~165 MB |
+| Stereo (client reference) | ~94 KB/s | ~330 MB |
+
+After base64 encoding for WebSocket transport, effective stereo bandwidth is about 125 KB/s per session. **Billing does not change**: it is based on mic audio content, not raw WebSocket bytes. The reference channel is stripped on arrival and used only for EC alignment.
+
+## Beyond the browser
+
+The reference audio in this sample is your app's own Web Audio playback. It does not capture other browser tabs or OS-level sounds. On native platforms, capture the system or app playback and interleave it with the mic in the same `[mic, ref, mic, ref, ...]` PCM16 order:
+
+| Platform | Suggested capture method |
+| -------- | ------------------------ |
+| **Windows** | WASAPI loopback (`IAudioClient` in loopback mode) captures the speaker mix. |
+| **macOS** | `AudioUnit` with a tap on the output device. |
+| **iOS** | `AVAudioEngine` tap on the main mixer output node. |
+| **Android** | Route TTS through your own `AudioTrack` and tap before output. `AudioPlaybackCapture` (Android 10+) cannot capture `USAGE_VOICE_COMMUNICATION` audio. |
+
+Capture the reference as close to the speaker output as possible, before analog processing. The server accepts PCM16 at 8, 16, or 24 kHz and resamples internally to 16 kHz for EC processing.
+
+## Notes and limitations
+
+- **PCM16 only** for the input stream when using a client reference.
+- **16 kHz internal processing**: regardless of input rate, the EC model runs at 16 kHz internally. This covers the full speech range and does not affect voice quality.
+- EC removes echo (speaker output re-entering the mic). It is not a noise canceller. For ambient noise, configure `input_audio_noise_reduction` (`type: "azure_deep_noise_suppression"`) alongside EC.
+- **Only your app's own playback is cancelled.** Web Audio can only tap audio produced inside its own `AudioContext` (the `playbackBus`), so the reference contains just the assistant's TTS. Sound from other tabs, OS notifications, or other apps still reaches the mic and is not cancelled. If a user runs system audio on speakers, that audio can be sent back to the service and degrade recognition. For dedicated audio experiences this is the intended trade-off; if you need system-wide echo cancellation, keep the browser's native `echoCancellation: true` instead of client reference.
+- **Reconnection is out of scope.** On an unexpected socket drop the sample tears the session down (`onDisconnected`). Production apps on mobile or unstable networks should add reconnection with exponential backoff and session/history replay.
+- Performance varies by environment and degrades in high-reverb rooms, where the echo becomes too diffuse to match against the reference.
+
+## Troubleshooting
+
+### "Microphone not accessible"
+- Serve over `http://localhost` or **HTTPS** (required for microphone access).
+- Check the browser's site permissions for microphone access.
+- Refresh the page and re-allow permissions.
+
+### "Connection failed"
+- Verify your **endpoint** and **API key** are correct.
+- Confirm the resource uses api-version `2026-07-15` or later with Voice Live enabled.
+- Check the browser console for detailed error messages.
+
+### "No audio playback"
+- Check browser audio permissions and system volume.
+- Verify your speakers are working (use speakers, not headphones, to hear the echo cancellation).
+
+### "Echo cancellation has no effect"
+- Ensure all assistant audio routes through the playback bus, not an `<audio>` element or `destination` directly, so the reference channel is not silent.
+- Confirm the mic is captured with `echoCancellation`, `noiseSuppression`, and `autoGainControl` set to `false`.
+- Confirm `input_audio_sampling_rate` matches the actual `AudioContext.sampleRate`.
+
+## Development
+
+```bash
+npm run dev        # Development server
+npm run build      # Production build
+npm run preview    # Preview production build
+npm run type-check # TypeScript type checking
+```
+
+Microphone access requires `http://localhost` or an HTTPS origin.
+
+## License
+
+This sample is licensed under the MIT License. See the repository LICENSE for details.

--- a/javascript/live-reference-aec/index.html
+++ b/javascript/live-reference-aec/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Voice Live - Live Reference AEC</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Live Reference AEC</h1>
+        <p>
+          Streams stereo audio to Azure Voice Live — microphone on channel 0 and your
+          app's speaker playback on channel 1 — so the service can cancel echo using the
+          exact signal the speaker plays.
+        </p>
+      </header>
+
+      <section class="config">
+        <label>
+          Endpoint
+          <input id="endpoint" type="text" placeholder="https://your-resource.cognitiveservices.azure.com" />
+        </label>
+        <label>
+          API Key
+          <input id="apiKey" type="password" placeholder="Your Voice Live API key" />
+        </label>
+        <div class="row">
+          <label>
+            Model
+            <input id="model" type="text" value="gpt-realtime" />
+          </label>
+          <label>
+            Voice
+            <input id="voice" type="text" value="en-US-AvaNeural" />
+          </label>
+        </div>
+        <label>
+          Instructions
+          <textarea id="instructions" rows="2">You are a helpful assistant.</textarea>
+        </label>
+      </section>
+
+      <section class="controls">
+        <button id="start">Start</button>
+        <button id="stop" disabled>Stop</button>
+        <div class="status">
+          <span>Connection: <span id="connectionStatus" class="badge disconnected">disconnected</span></span>
+          <span>Assistant: <span id="assistantStatus">idle</span></span>
+        </div>
+      </section>
+
+      <section id="transcript" class="transcript" aria-live="polite"></section>
+    </main>
+
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/javascript/live-reference-aec/package.json
+++ b/javascript/live-reference-aec/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "live-reference-aec",
+  "version": "1.0.0",
+  "description": "Browser sample for Azure Voice Live Reference AEC (client-supplied echo cancellation reference)",
+  "type": "module",
+  "main": "src/main.ts",
+  "scripts": {
+    "build": "tsc && vite build",
+    "dev": "vite",
+    "dev-sdk": "vite --force",
+    "preview": "vite preview",
+    "serve": "python -m http.server 8080",
+    "type-check": "tsc --noEmit",
+    "reload": "curl -X POST http://localhost:3000/__vite_ping 2>/dev/null || echo 'Vite server not responding'"
+  },
+  "dependencies": {
+    "@azure/ai-voicelive": "^1.1.0",
+    "@azure/core-auth": "^1.9.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.2",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  },
+  "browserslist": [
+    "> 1%",
+    "last 2 versions",
+    "not dead"
+  ],
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/javascript/live-reference-aec/public/stereo-interleaver.js
+++ b/javascript/live-reference-aec/public/stereo-interleaver.js
@@ -1,0 +1,39 @@
+// stereo-interleaver.js
+// AudioWorklet processor that interleaves mic (input 0) and playback reference
+// (input 1) into a single stereo PCM16 stream: [mic0, ref0, mic1, ref1, ...].
+// The stereo buffer is transferred to the main thread via postMessage, where it
+// is sent to Voice Live as the Live Reference AEC signal.
+class StereoInterleaver extends AudioWorkletProcessor {
+  process(inputs) {
+    const mic = inputs[0]?.[0]; // input 0, channel 0 = mic
+    if (!mic) return true; // no mic data yet; nothing to send
+
+    // Use the playback tap if connected, otherwise treat as silence so mic audio
+    // is always sent even when TTS is not playing. Downmix stereo playback to mono.
+    const refChannels = inputs[1];
+    let ref = null;
+    if (refChannels?.length === 1) {
+      ref = refChannels[0];
+    } else if (refChannels?.length > 1) {
+      ref = new Float32Array(mic.length);
+      for (let i = 0; i < mic.length; i++) {
+        let sum = 0;
+        for (const ch of refChannels) sum += ch[i];
+        ref[i] = sum / refChannels.length;
+      }
+    }
+
+    // Interleave into stereo PCM16: ch0 = mic, ch1 = reference.
+    const stereo = new Int16Array(mic.length * 2);
+    for (let i = 0; i < mic.length; i++) {
+      const m = Math.max(-1, Math.min(1, mic[i]));
+      const r = ref ? Math.max(-1, Math.min(1, ref[i])) : 0;
+      stereo[i * 2] = Math.round(m < 0 ? m * 0x8000 : m * 0x7fff);
+      stereo[i * 2 + 1] = Math.round(r < 0 ? r * 0x8000 : r * 0x7fff);
+    }
+    this.port.postMessage(stereo.buffer, [stereo.buffer]);
+    return true;
+  }
+}
+
+registerProcessor('stereo-interleaver', StereoInterleaver);

--- a/javascript/live-reference-aec/src/echoCancellationAudio.ts
+++ b/javascript/live-reference-aec/src/echoCancellationAudio.ts
@@ -1,0 +1,148 @@
+// Web Audio graph for Live Reference AEC (client-supplied echo cancellation reference).
+//
+// Mic and the app's TTS playback are captured into a single AudioContext so the
+// reference channel reflects exactly what the speaker plays. The graph:
+//
+//   mic         -> interleaver input 0 (mic channel)
+//   playbackBus -> speakers (destination)
+//   playbackBus -> interleaver input 1 (reference channel)
+//
+// The interleaver worklet emits stereo PCM16 [mic, ref, mic, ref, ...] which is
+// forwarded to Voice Live. All assistant audio MUST route through playbackBus,
+// otherwise the reference channel will not capture it and echo will not cancel.
+
+export type AudioChunkHandler = (bytes: Uint8Array) => void;
+
+// Voice Live streams TTS as 24 kHz mono PCM16 regardless of the capture context's
+// rate, so decode at this fixed rate and let Web Audio resample to the device.
+const OUTPUT_SAMPLE_RATE = 24000;
+
+export class EchoCancellationAudio {
+  private audioContext?: AudioContext;
+  private micStream?: MediaStream;
+  private micSource?: MediaStreamAudioSourceNode;
+  private interleaver?: AudioWorkletNode;
+  private playbackBus?: GainNode;
+  private nextStartTime = 0;
+  private scheduledSources = new Set<AudioBufferSourceNode>();
+
+  /** Actual capture sample rate; send this to the server as input_audio_sampling_rate. */
+  get sampleRate(): number {
+    return this.audioContext?.sampleRate ?? 24000;
+  }
+
+  /** Create the AudioContext, load the worklet, and build the graph (mic not yet streaming). */
+  async init(): Promise<void> {
+    try {
+      this.audioContext = new AudioContext({ sampleRate: 24000 });
+    } catch {
+      this.audioContext = new AudioContext(); // fallback if 24 kHz is rejected
+    }
+    await this.audioContext.resume();
+
+    // Voice Live accepts PCM16 at 8, 16, or 24 kHz. If the browser could not honor the
+    // 24 kHz request and fell back to an unsupported native rate (often 44.1/48 kHz),
+    // fail clearly instead of streaming audio the server will reject.
+    const supportedRates = [8000, 16000, 24000];
+    if (!supportedRates.includes(this.audioContext.sampleRate)) {
+      throw new Error(
+        `This browser's AudioContext runs at ${this.audioContext.sampleRate} Hz, which ` +
+          `Voice Live does not support for PCM16 (expected 8000, 16000, or 24000 Hz).`,
+      );
+    }
+
+    await this.audioContext.audioWorklet.addModule('/stereo-interleaver.js');
+
+    // Capture the mic with browser processing OFF; the server performs EC.
+    this.micStream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+        channelCount: 1,
+      },
+    });
+    this.micSource = this.audioContext.createMediaStreamSource(this.micStream);
+
+    // Interleaver worklet: 2 inputs (mic + reference). numberOfOutputs is 1 for
+    // compatibility with older Chrome that skipped process() on 0-output nodes.
+    this.interleaver = new AudioWorkletNode(this.audioContext, 'stereo-interleaver', {
+      numberOfInputs: 2,
+      numberOfOutputs: 1,
+      outputChannelCount: [1],
+    });
+    this.interleaver.connect(this.audioContext.destination);
+
+    // Shared playback bus: speakers + reference channel.
+    this.playbackBus = this.audioContext.createGain();
+    this.playbackBus.connect(this.audioContext.destination);
+    this.playbackBus.connect(this.interleaver, 0, 1);
+    // Mic is connected in start(), after session.update, to avoid streaming audio
+    // under the default (mono) server settings.
+  }
+
+  /** Wire the worklet output, then connect the mic so audio begins streaming. */
+  start(onChunk: AudioChunkHandler): void {
+    if (!this.audioContext || !this.interleaver || !this.micSource) {
+      throw new Error('EchoCancellationAudio.init() must be called before start()');
+    }
+    this.interleaver.port.onmessage = (event) => onChunk(new Uint8Array(event.data as ArrayBuffer));
+    this.nextStartTime = this.audioContext.currentTime;
+    this.micSource.connect(this.interleaver, 0, 0);
+  }
+
+  /** Schedule a mono PCM16 TTS chunk through the playback bus (speakers + reference). */
+  playTts(pcm16: Uint8Array): void {
+    if (!this.audioContext || !this.playbackBus || pcm16.byteLength === 0) return;
+
+    const samples = pcm16.byteLength / 2;
+    const view = new DataView(pcm16.buffer, pcm16.byteOffset, pcm16.byteLength);
+    const buffer = this.audioContext.createBuffer(1, samples, OUTPUT_SAMPLE_RATE);
+    const channel = buffer.getChannelData(0);
+    for (let i = 0; i < samples; i++) {
+      channel[i] = view.getInt16(i * 2, true) / 0x8000;
+    }
+
+    const source = this.audioContext.createBufferSource();
+    source.buffer = buffer;
+    source.connect(this.playbackBus);
+    this.scheduledSources.add(source);
+    source.onended = () => {
+      source.disconnect();
+      this.scheduledSources.delete(source);
+    };
+
+    const now = this.audioContext.currentTime;
+    if (this.nextStartTime < now) this.nextStartTime = now;
+    source.start(this.nextStartTime);
+    this.nextStartTime += buffer.duration;
+  }
+
+  /** Stop and discard all scheduled/playing TTS (e.g. on barge-in) without tearing down the graph. */
+  stopPlayback(): void {
+    for (const source of this.scheduledSources) {
+      source.onended = null;
+      try {
+        source.stop();
+      } catch {
+        // already stopped
+      }
+      source.disconnect();
+    }
+    this.scheduledSources.clear();
+    if (this.audioContext) this.nextStartTime = this.audioContext.currentTime;
+  }
+
+  /** Release the mic, worklet, and AudioContext. */
+  async cleanup(): Promise<void> {
+    this.stopPlayback();
+    this.micStream?.getTracks().forEach((t) => t.stop());
+    this.micSource?.disconnect();
+    this.interleaver?.disconnect();
+    this.playbackBus?.disconnect();
+    if (this.audioContext && this.audioContext.state !== 'closed') {
+      await this.audioContext.close();
+    }
+    this.audioContext = undefined;
+  }
+}

--- a/javascript/live-reference-aec/src/main.ts
+++ b/javascript/live-reference-aec/src/main.ts
@@ -1,0 +1,79 @@
+import { VoiceAssistant, type VoiceAssistantConfig } from './voiceAssistant.js';
+
+const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
+
+const endpointInput = $('endpoint') as HTMLInputElement;
+const apiKeyInput = $('apiKey') as HTMLInputElement;
+const modelInput = $('model') as HTMLInputElement;
+const voiceInput = $('voice') as HTMLInputElement;
+const instructionsInput = $('instructions') as HTMLTextAreaElement;
+const startBtn = $('start') as HTMLButtonElement;
+const stopBtn = $('stop') as HTMLButtonElement;
+const connStatus = $('connectionStatus');
+const asstStatus = $('assistantStatus');
+const transcript = $('transcript');
+
+const assistant = new VoiceAssistant();
+let streamingEl: HTMLDivElement | null = null;
+
+function addMessage(role: string, text: string): HTMLDivElement {
+  const el = document.createElement('div');
+  el.className = `message ${role}`;
+  el.textContent = text;
+  transcript.appendChild(el);
+  transcript.scrollTop = transcript.scrollHeight;
+  return el;
+}
+
+assistant.setCallbacks({
+  onConnectionStatusChange: (s) => {
+    connStatus.textContent = s;
+    connStatus.className = `badge ${s}`;
+    const connected = s === 'connected';
+    startBtn.disabled = connected || s === 'connecting';
+    stopBtn.disabled = !connected;
+    // Finalize any in-progress bubble so a new session cannot overwrite the last
+    // assistant message from a session that ended mid-response.
+    if (s === 'connecting' || s === 'disconnected') streamingEl = null;
+  },
+  onAssistantStatusChange: (s) => {
+    asstStatus.textContent = s;
+  },
+  onUserMessage: (text) => {
+    streamingEl = null;
+    addMessage('user', text);
+  },
+  onAssistantMessage: (text, isStreaming) => {
+    if (isStreaming) {
+      if (!streamingEl) streamingEl = addMessage('assistant', '');
+      streamingEl.textContent = text;
+      transcript.scrollTop = transcript.scrollHeight;
+    } else {
+      if (streamingEl) streamingEl.textContent = text;
+      streamingEl = null;
+    }
+  },
+  onError: (msg) => addMessage('error', msg),
+});
+
+startBtn.addEventListener('click', async () => {
+  const config: VoiceAssistantConfig = {
+    endpoint: endpointInput.value.trim(),
+    apiKey: apiKeyInput.value.trim(),
+    model: modelInput.value.trim() || 'gpt-realtime',
+    voice: voiceInput.value.trim() || 'en-US-AvaNeural',
+    instructions: instructionsInput.value.trim() || 'You are a helpful assistant.',
+  };
+  if (!config.endpoint || !config.apiKey) {
+    addMessage('error', 'Endpoint and API key are required.');
+    return;
+  }
+  try {
+    await assistant.start(config);
+  } catch (e) {
+    addMessage('error', `Failed to start: ${e}`);
+  }
+});
+
+stopBtn.addEventListener('click', () => assistant.stop());
+window.addEventListener('beforeunload', () => assistant.stop());

--- a/javascript/live-reference-aec/src/voiceAssistant.ts
+++ b/javascript/live-reference-aec/src/voiceAssistant.ts
@@ -1,0 +1,277 @@
+// Voice Live session wired for Live Reference AEC.
+//
+// The only feature-specific configuration is the inputAudioEchoCancellation block
+// in updateSession (referenceSource: "client", channels: 2) together with a
+// stereo PCM16 stream produced by EchoCancellationAudio. Everything else is a
+// standard Voice Live realtime session.
+import {
+  VoiceLiveClient,
+  VoiceLiveSession,
+  KnownOAIVoice,
+  type RequestSession,
+  type VoiceLiveSessionHandlers,
+  type VoiceLiveSubscription,
+} from '@azure/ai-voicelive';
+import { AzureKeyCredential } from '@azure/core-auth';
+import { EchoCancellationAudio } from './echoCancellationAudio.js';
+
+// GA api-version that introduces Live Reference AEC.
+const API_VERSION = '2026-07-15';
+
+export interface VoiceAssistantConfig {
+  endpoint: string;
+  apiKey: string;
+  model: string;
+  voice: string;
+  instructions: string;
+}
+
+export interface VoiceAssistantCallbacks {
+  onConnectionStatusChange: (status: string) => void;
+  onAssistantStatusChange: (status: string) => void;
+  onUserMessage: (text: string) => void;
+  onAssistantMessage: (text: string, isStreaming: boolean) => void;
+  onError: (message: string) => void;
+}
+
+export class VoiceAssistant {
+  private client?: VoiceLiveClient;
+  private session?: VoiceLiveSession;
+  private subscription?: VoiceLiveSubscription;
+  private audio = new EchoCancellationAudio();
+  private callbacks?: VoiceAssistantCallbacks;
+  private assistantText = '';
+  // Suppresses audio deltas that arrive after a barge-in until the next response,
+  // so an interrupted response cannot re-feed the reference or resume playing.
+  private suppressPlayback = false;
+  // Lifecycle flags. `active` is set synchronously so concurrent start() calls
+  // cannot race past the guard; `stopPromise` holds the in-flight teardown so
+  // concurrent stop() callers all await the same cleanup (and so reentry via
+  // onDisconnected does not start a second teardown).
+  private active = false;
+  private stopPromise?: Promise<void>;
+  // Resolves/rejects the start() wait for the server's session.updated ack.
+  private pendingConfig?: { resolve: () => void; reject: (e: Error) => void };
+
+  setCallbacks(callbacks: VoiceAssistantCallbacks): void {
+    this.callbacks = callbacks;
+  }
+
+  async start(config: VoiceAssistantConfig): Promise<void> {
+    if (this.active) {
+      throw new Error('start() called while a session is active; call stop() first');
+    }
+    this.active = true; // set synchronously so concurrent starts cannot race
+    this.suppressPlayback = false;
+    this.callbacks?.onConnectionStatusChange('connecting');
+    try {
+      // Build the audio graph first so we know the actual capture sample rate.
+      await this.audio.init();
+
+      this.client = new VoiceLiveClient(config.endpoint, new AzureKeyCredential(config.apiKey), {
+        apiVersion: API_VERSION,
+      });
+      this.session = await this.client.startSession(config.model);
+      this.subscription = this.session.subscribe(this.createHandlers());
+
+      // Configure the session for Live Reference AEC BEFORE streaming audio.
+      // WebSocket preserves order, so the server applies this before the first packet.
+      // referenceSource: "client" + channels: 2 activate the client-supplied echo
+      // reference; the stereo PCM16 stream carries the mic on channel 0 and the
+      // speaker playback on channel 1. inputAudioSamplingRate must match the actual
+      // capture rate. autoTruncate + interruptResponse keep the server's conversation
+      // history in sync with what the user actually heard when they barge in.
+      const sessionConfig: RequestSession = {
+        modalities: ['audio', 'text'],
+        instructions: config.instructions,
+        voice: this.toVoice(config.voice),
+        inputAudioFormat: 'pcm16',
+        outputAudioFormat: 'pcm16',
+        inputAudioTranscription: { model: 'whisper-1' },
+        turnDetection: {
+          type: 'server_vad',
+          threshold: 0.5,
+          prefixPaddingInMs: 300,
+          silenceDurationInMs: 500,
+          autoTruncate: true,
+          interruptResponse: true,
+        },
+        inputAudioEchoCancellation: {
+          type: 'server_echo_cancellation',
+          referenceSource: 'client',
+          channels: 2,
+        },
+        inputAudioSamplingRate: this.audio.sampleRate,
+      };
+
+      // Arm the acknowledgement listener BEFORE sending the update so a fast
+      // session.updated can never resolve before we are listening for it.
+      const sessionAck = this.waitForSessionAck(10000);
+      // If updateSession throws before we await sessionAck below, stop() rejects this
+      // promise; attach a no-op handler so that rejection is never unhandled. The await
+      // further down still observes the real outcome.
+      sessionAck.catch(() => {});
+      await this.session.updateSession(sessionConfig);
+
+      // Wait for the server to acknowledge the configuration (session.updated) before
+      // streaming. If the stereo/EC config is rejected, the server keeps the socket
+      // open and replies with an error instead, so streaming stereo now would send it
+      // under the previous mono configuration. onSessionUpdated resolves this; a
+      // rejecting onServerError or a timeout throws and triggers rollback.
+      await sessionAck;
+
+      // Session is confirmed stereo-ready; begin streaming interleaved mic + reference.
+      this.audio.start((bytes) => {
+        this.session?.sendAudio(bytes).catch((e) => console.error('sendAudio failed:', e));
+      });
+
+      this.callbacks?.onConnectionStatusChange('connected');
+      this.callbacks?.onAssistantStatusChange('listening');
+    } catch (err) {
+      // Roll back any partial state (mic, session, subscription) so the UI recovers.
+      await this.stop();
+      throw err;
+    }
+  }
+
+  async stop(): Promise<void> {
+    // All callers share one in-flight teardown; also makes reentry (onDisconnected
+    // firing while we disconnect) a no-op that awaits the same promise.
+    if (this.stopPromise) return this.stopPromise;
+    this.stopPromise = this.doStop();
+    try {
+      await this.stopPromise;
+    } finally {
+      this.stopPromise = undefined;
+    }
+  }
+
+  // Awaits the server's session.updated ack (resolved in onSessionUpdated), or
+  // rejects if the config is refused (onServerError) or no ack arrives in time.
+  private waitForSessionAck(timeoutMs: number): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingConfig = undefined;
+        reject(new Error('Timed out waiting for session configuration acknowledgement'));
+      }, timeoutMs);
+      this.pendingConfig = {
+        resolve: () => {
+          clearTimeout(timer);
+          this.pendingConfig = undefined;
+          resolve();
+        },
+        reject: (e) => {
+          clearTimeout(timer);
+          this.pendingConfig = undefined;
+          reject(e);
+        },
+      };
+    });
+  }
+
+  private async doStop(): Promise<void> {
+    // Unblock a start() still awaiting the session ack so it rolls back promptly.
+    this.pendingConfig?.reject(new Error('stopped'));
+    // Clean up each resource independently so one failure cannot skip the others.
+    const results = await Promise.allSettled([
+      this.audio.cleanup(),
+      Promise.resolve(this.subscription?.close()),
+      Promise.resolve(this.session?.disconnect()),
+    ]);
+    for (const r of results) {
+      if (r.status === 'rejected') console.error('stop cleanup error:', r.reason);
+    }
+    this.subscription = undefined;
+    this.session = undefined;
+    this.client = undefined;
+    this.active = false;
+    this.callbacks?.onConnectionStatusChange('disconnected');
+    this.callbacks?.onAssistantStatusChange('idle');
+  }
+
+  // OpenAI-hosted voices take a { type: "openai" } config; everything else is
+  // treated as an Azure standard voice name.
+  private toVoice(name: string): any {
+    const lower = name.toLowerCase();
+    const openAIVoices = Object.values(KnownOAIVoice) as string[];
+    return openAIVoices.includes(lower)
+      ? { type: 'openai', name: lower }
+      : { type: 'azure-standard', name };
+  }
+
+  private createHandlers(): VoiceLiveSessionHandlers {
+    return {
+      onError: async (args) => this.callbacks?.onError(args.error?.message ?? 'Service error'),
+
+      // Server-side protocol errors arrive here, separate from connection errors.
+      // Surface the message but do not tear down: most server errors are recoverable,
+      // and the service closes the socket itself on fatal errors (handled by onDisconnected).
+      // If a config ack is still pending, the update was refused, so fail the start.
+      onServerError: async (event) => {
+        const message = event.error?.message ?? 'Server error';
+        this.callbacks?.onError(message);
+        this.pendingConfig?.reject(new Error(message));
+      },
+
+      // Server acknowledged the session configuration; safe to stream stereo now.
+      onSessionUpdated: async () => {
+        this.pendingConfig?.resolve();
+      },
+
+      // Unexpected connection loss: tear down mic/audio and reset the UI so it does
+      // not appear connected while sendAudio keeps failing. No-op during our own stop().
+      onDisconnected: async () => {
+        if (this.active && !this.stopPromise) {
+          this.callbacks?.onError('Connection lost.');
+          await this.stop();
+        }
+      },
+
+      onResponseCreated: async () => {
+        this.assistantText = '';
+        this.suppressPlayback = false;
+        this.callbacks?.onAssistantStatusChange('responding');
+      },
+
+      onResponseDone: async (event) => {
+        if (this.assistantText.trim()) this.callbacks?.onAssistantMessage(this.assistantText.trim(), false);
+        this.assistantText = '';
+        // Surface failures so a customer sees why a turn produced no audio.
+        // "cancelled" is the expected result of a barge-in, not an error.
+        const status = event.response?.status;
+        const details = event.response?.statusDetails;
+        if (status === 'failed') {
+          const reason = (details && 'error' in details && details.error?.message) || status;
+          this.callbacks?.onError(`Response failed: ${reason}`);
+        } else if (status === 'incomplete') {
+          const reason = (details && 'reason' in details && details.reason) || status;
+          this.callbacks?.onError(`Response incomplete: ${reason}`);
+        }
+        this.callbacks?.onAssistantStatusChange('listening');
+      },
+
+      // Barge-in: user speech while assistant is talking. Drop queued playback and
+      // ignore any late audio deltas from the interrupted response.
+      onInputAudioBufferSpeechStarted: async () => {
+        this.suppressPlayback = true;
+        this.audio.stopPlayback();
+        this.callbacks?.onAssistantStatusChange('listening');
+      },
+
+      onResponseAudioTranscriptDelta: async (event) => {
+        this.assistantText += event.delta ?? '';
+        this.callbacks?.onAssistantMessage(this.assistantText, true);
+      },
+
+      onConversationItemInputAudioTranscriptionCompleted: async (event) => {
+        if (event.transcript) this.callbacks?.onUserMessage(event.transcript);
+      },
+
+      // Route assistant audio through the playback bus (speakers + EC reference).
+      onResponseAudioDelta: async (event) => {
+        if (this.suppressPlayback) return;
+        if (event.delta && event.delta.byteLength > 0) this.audio.playTts(new Uint8Array(event.delta));
+      },
+    };
+  }
+}

--- a/javascript/live-reference-aec/style.css
+++ b/javascript/live-reference-aec/style.css
@@ -1,0 +1,162 @@
+:root {
+  --bg: #0f1115;
+  --panel: #1a1d24;
+  --border: #2a2f3a;
+  --text: #e6e8ec;
+  --muted: #9aa2b1;
+  --accent: #3b82f6;
+  --user: #1e3a5f;
+  --assistant: #23324a;
+  --error: #4a1e1e;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+main {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 24px 16px 48px;
+}
+
+header h1 {
+  margin: 0 0 8px;
+  font-size: 1.4rem;
+}
+
+header p {
+  margin: 0 0 20px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.config,
+.controls,
+.transcript {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+label {
+  display: block;
+  margin-bottom: 12px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.row {
+  display: flex;
+  gap: 12px;
+}
+
+.row label {
+  flex: 1;
+}
+
+input,
+textarea {
+  width: 100%;
+  margin-top: 4px;
+  padding: 8px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 6px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.status {
+  margin-left: auto;
+  display: flex;
+  gap: 16px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.badge {
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+}
+
+.badge.connected {
+  background: #14532d;
+  color: #86efac;
+}
+
+.badge.connecting {
+  background: #713f12;
+  color: #fde68a;
+}
+
+.badge.disconnected {
+  background: #3f1d1d;
+  color: #fca5a5;
+}
+
+.transcript {
+  min-height: 200px;
+  max-height: 420px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.message {
+  padding: 8px 12px;
+  border-radius: 8px;
+  line-height: 1.4;
+  font-size: 0.9rem;
+  max-width: 85%;
+}
+
+.message.user {
+  background: var(--user);
+  align-self: flex-end;
+}
+
+.message.assistant {
+  background: var(--assistant);
+  align-self: flex-start;
+}
+
+.message.error {
+  background: var(--error);
+  color: #fca5a5;
+  align-self: stretch;
+  max-width: 100%;
+}

--- a/javascript/live-reference-aec/tsconfig.json
+++ b/javascript/live-reference-aec/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/javascript/live-reference-aec/vite.config.ts
+++ b/javascript/live-reference-aec/vite.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: '.',
+  build: {
+    target: 'es2020',
+    outDir: 'dist',
+    sourcemap: true,
+    rollupOptions: {
+      input: {
+        main: 'index.html'
+      }
+    }
+  },
+  server: {
+    port: 3000,
+    host: true,
+    // Enable file watching for SDK source changes
+    watch: {
+      usePolling: true,
+      interval: 300
+    }
+  },
+  // Configure to watch node_modules changes
+  optimizeDeps: {
+    force: true // Force dependency re-optimization on restart
+  }
+});


### PR DESCRIPTION
## Live Reference AEC (browser sample)

Adds a browser (TypeScript + Vite) sample under `javascript/live-reference-aec/` demonstrating VL's **Live Reference AEC** (client-supplied echo cancellation reference) feature, available at REST api-version `2026-07-15`.

### What it does
The browser captures the microphone and a tap of the app's own TTS playback, interleaves them into stereo PCM16 (channel 0 = mic, channel 1 = reference) via an `AudioWorklet`, and streams that to the service so it cancels echo against the exact signal the speaker plays. It waits for the `session.updated` acknowledgement before streaming, supports barge-in, and surfaces server and response errors.

### Included
- Sample: `README.md`, `index.html`, `src/` (`voiceAssistant.ts`, `echoCancellationAudio.ts`, `main.ts`), `public/stereo-interleaver.js`, `style.css`, `package.json`, `vite.config.ts`, `tsconfig.json`, `.gitignore`
- Registered in the root `README.md` and `javascript/README.md` indexes

### Validation
- `npm run type-check` and `npm run build` pass on GA `@azure/ai-voicelive@1.1.0`