### PR TITLE
Add Voice Live + Twilio call center samples

### DIFF
--- a/python/voice-live-twilio-callcenter/README.md
+++ b/python/voice-live-twilio-callcenter/README.md
@@ -1,0 +1,87 @@
+# Voice Live + Twilio Call Center Samples
+
+These samples show how to connect the **Azure AI Speech Voice Live** API to the
+**public telephone network (PSTN)** using [Twilio Programmable Voice](https://www.twilio.com/docs/voice)
+and [Media Streams](https://www.twilio.com/docs/voice/media-streams). A real
+caller dials (or is dialed by) a Twilio phone number, and Voice Live handles the
+conversation end‑to‑end with natural, low‑latency speech‑to‑speech.
+
+Unlike the microphone‑based quickstarts in this repo, these samples run as a
+**server‑side WebSocket bridge**: Twilio streams call audio to your service, your
+service relays it to Voice Live, and Voice Live's audio is streamed back to the
+caller. The Voice Live SDK runs entirely on the server — the phone is the client.
+
+## Samples
+
+| Sample | Direction | Scenario |
+| --- | --- | --- |
+| [`inbound-receptionist`](./inbound-receptionist) | Inbound | Answers incoming calls as an AI receptionist — greets the caller, answers FAQs, takes a message, and transfers to a human. |
+| [`outbound-appointment-reminder`](./outbound-appointment-reminder) | Outbound | Places an outbound call to a customer, confirms an appointment, and records whether they confirmed, rescheduled, or cancelled. |
+
+Each subfolder is self‑contained with its own `app.py`, `requirements.txt`,
+`.env_sample`, and `README.md`.
+
+## How it works
+
+Twilio Media Streams and Voice Live both speak **G.711 μ‑law at 8 kHz**, so audio
+flows through the bridge as base64 with **no transcoding**:
+
+```
+                 PSTN                      WebSocket (μ-law 8kHz base64)
+Caller  ◄──────────────────►  Twilio  ◄──────────────────────────────►  Your bridge (FastAPI)
+                                                                              │
+                                                                              │  Voice Live SDK
+                                                                              ▼
+                                                                        Azure Voice Live
+```
+
+- **Inbound audio**: Twilio `media` frames (`media.payload`) are passed straight
+  into `connection.input_audio_buffer.append(audio=payload)`.
+- **Outbound audio**: Voice Live `response.audio.delta` bytes are base64‑encoded
+  and sent back to Twilio as `media` frames.
+- **Barge‑in**: when the caller starts speaking, the bridge sends Twilio a
+  `clear` message and cancels the in‑progress Voice Live response.
+
+## Prerequisites
+
+- [Python 3.9+](https://www.python.org/downloads/)
+- An [AI Foundry resource](https://learn.microsoft.com/azure/ai-services/multi-service-resource)
+  with Voice Live enabled (endpoint + API key, or Azure credentials)
+- A [Twilio account](https://www.twilio.com/try-twilio) with:
+  - A **Voice‑capable phone number**
+  - Your **Account SID** and **Auth Token** (from the Twilio Console)
+- A way to expose your local server to the public internet so Twilio can reach it,
+  e.g. [ngrok](https://ngrok.com/) (`ngrok http 8000`) or an Azure deployment.
+
+## Quick start
+
+1. Pick a sample folder and follow its README.
+2. Copy `.env_sample` to `.env` and fill in your Voice Live and Twilio values.
+3. Install dependencies:
+
+   ```bash
+   python -m venv .venv
+   # Windows: .venv\Scripts\activate  |  Linux/macOS: source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+4. Start the bridge, expose it with a tunnel, and point Twilio at the public URL.
+
+## Notes on production use
+
+These samples prioritize clarity over completeness. Before going to production,
+consider: authenticating Twilio webhooks with
+[request signature validation](https://www.twilio.com/docs/usage/webhooks/webhooks-security),
+per‑call error handling and reconnection, call recording consent where legally
+required, and horizontal scaling of the WebSocket bridge.
+
+## Resources
+
+- [Azure AI Speech — Voice Live documentation](https://learn.microsoft.com/azure/ai-services/speech-service/voice-live)
+- [Voice Live Python SDK](https://learn.microsoft.com/python/api/overview/azure/ai-voicelive-readme)
+- [Twilio Media Streams](https://www.twilio.com/docs/voice/media-streams)
+- [Twilio TwiML `<Connect><Stream>`](https://www.twilio.com/docs/voice/twiml/stream)
+
+## License
+
+Licensed under the MIT License. See the repository [LICENSE](../../LICENSE).

--- a/python/voice-live-twilio-callcenter/inbound-receptionist/.env_sample
+++ b/python/voice-live-twilio-callcenter/inbound-receptionist/.env_sample
@@ -1,0 +1,20 @@
+# --- Azure Voice Live ---
+AZURE_VOICELIVE_ENDPOINT=https://your-resource-name.services.ai.azure.com/
+AZURE_VOICELIVE_API_KEY=<your_api_key>          # omit if using Azure credentials
+AZURE_VOICELIVE_MODEL=gpt-realtime
+AZURE_VOICELIVE_VOICE=en-US-Ava:DragonHDLatestNeural
+# Set to true to authenticate with DefaultAzureCredential (az login) instead of an API key.
+USE_TOKEN_CREDENTIAL=false
+
+# --- Server ---
+PORT=8000
+
+# --- Business profile (used in the receptionist's instructions) ---
+BUSINESS_NAME=Contoso Dental
+MESSAGES_DIR=./messages
+
+# --- Transfer to human (optional) ---
+# All three are required for the transfer_to_human function to work.
+TRANSFER_PHONE_NUMBER=+15551234567
+TWILIO_ACCOUNT_SID=<your_twilio_account_sid>
+TWILIO_AUTH_TOKEN=<your_twilio_auth_token>

--- a/python/voice-live-twilio-callcenter/inbound-receptionist/README.md
+++ b/python/voice-live-twilio-callcenter/inbound-receptionist/README.md
@@ -1,0 +1,108 @@
+# Inbound AI Receptionist (Voice Live + Twilio)
+
+An AI receptionist that answers **inbound phone calls**. When someone dials your
+Twilio number, Azure Voice Live greets them, answers questions about your
+business, can take a message, and can transfer the call to a human — all as a
+natural, low‑latency voice conversation.
+
+## Key Features
+
+- Inbound PSTN call handling via Twilio Media Streams
+- Server‑side Voice Live SDK bridge (the phone is the only client)
+- G.711 μ‑law 8 kHz audio passed through with **no transcoding**
+- Proactive greeting and natural barge‑in (caller can interrupt)
+- `take_message` function — persists caller messages to JSON
+- `transfer_to_human` function — redirects the live call via the Twilio REST API
+- API key **or** Azure credential (`DefaultAzureCredential`) authentication
+
+## How it works
+
+```
+Caller → Twilio number → (Voice webhook) /incoming-call → TwiML <Connect><Stream>
+      → WebSocket /media-stream ⇄ CallBridge ⇄ Azure Voice Live
+```
+
+1. Twilio requests `/incoming-call` and receives TwiML telling it to open a Media
+   Stream to `wss://<host>/media-stream`.
+2. `/media-stream` connects to Voice Live, configures a G.711 μ‑law session, and
+   bridges audio in both directions.
+3. Voice Live drives the conversation and calls functions when appropriate.
+
+## Setup
+
+1. **Install dependencies**
+
+   ```bash
+   python -m venv .venv
+   # Windows: .venv\Scripts\activate  |  Linux/macOS: source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. **Configure** — copy `.env_sample` to `.env` and fill in your values:
+
+   ```bash
+   cp .env_sample .env
+   ```
+
+   At minimum set `AZURE_VOICELIVE_ENDPOINT` and `AZURE_VOICELIVE_API_KEY`
+   (or set `USE_TOKEN_CREDENTIAL=true` and run `az login`).
+
+3. **Run the server**
+
+   ```bash
+   python app.py
+   ```
+
+4. **Expose it publicly** so Twilio can reach it:
+
+   ```bash
+   ngrok http 8000
+   ```
+
+5. **Point your Twilio number at it.** In the Twilio Console, open your phone
+   number's *Voice Configuration* and set **A call comes in** → *Webhook* to:
+
+   ```
+   https://<your-ngrok-subdomain>.ngrok.app/incoming-call     (HTTP POST)
+   ```
+
+6. **Call your Twilio number** and talk to the receptionist. Try: *"What are your
+   hours?"*, *"Can I leave a message?"*, or *"Can I speak to someone?"*
+
+## Configuration reference
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `AZURE_VOICELIVE_ENDPOINT` | Yes | Your AI Foundry / Voice Live endpoint. |
+| `AZURE_VOICELIVE_API_KEY` | Yes* | API key. *Not needed if `USE_TOKEN_CREDENTIAL=true`. |
+| `USE_TOKEN_CREDENTIAL` | No | `true` to use `DefaultAzureCredential` (az login). |
+| `AZURE_VOICELIVE_MODEL` | No | Defaults to `gpt-realtime`. |
+| `AZURE_VOICELIVE_VOICE` | No | Defaults to `en-US-Ava:DragonHDLatestNeural`. |
+| `BUSINESS_NAME` | No | Injected into the receptionist's instructions. |
+| `RECEPTIONIST_INSTRUCTIONS` | No | Override the full system prompt. |
+| `MESSAGES_DIR` | No | Where `take_message` writes JSON (default `./messages`). |
+| `TRANSFER_PHONE_NUMBER` | No | Number to transfer callers to. |
+| `TWILIO_ACCOUNT_SID` / `TWILIO_AUTH_TOKEN` | No | Required only for transfers. |
+
+## Customizing the receptionist
+
+Edit the business facts and behavior by setting `BUSINESS_NAME` and
+`RECEPTIONIST_INSTRUCTIONS` in `.env`, or edit the `INSTRUCTIONS` default in
+[`app.py`](./app.py). Add new capabilities by adding a `FunctionTool` in
+`build_tools()` and handling it in `CallBridge._execute_function_call`.
+
+## Troubleshooting
+
+- **Caller hears silence**: confirm your public URL is reachable and the Twilio
+  webhook points at `/incoming-call`. Check that the WebSocket upgraded (look for
+  "Twilio connected to /media-stream" in the logs).
+- **`wss` connection fails**: the TwiML `<Stream url>` is built from the `Host`
+  header — make sure Twilio reaches you over HTTPS (ngrok/Azure), not raw HTTP.
+- **401 Unauthorized**: verify `AZURE_VOICELIVE_API_KEY`, or run `az login` when
+  using `USE_TOKEN_CREDENTIAL=true`.
+- **Transfer does nothing**: set `TRANSFER_PHONE_NUMBER`, `TWILIO_ACCOUNT_SID`,
+  and `TWILIO_AUTH_TOKEN`.
+
+## License
+
+Licensed under the MIT License. See the repository [LICENSE](../../../LICENSE).

--- a/python/voice-live-twilio-callcenter/inbound-receptionist/app.py
+++ b/python/voice-live-twilio-callcenter/inbound-receptionist/app.py
@@ -1,0 +1,376 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# -------------------------------------------------------------------------
+"""
+Inbound AI Receptionist — Azure Voice Live + Twilio Media Streams.
+
+A caller dials your Twilio number. Twilio opens a Media Stream WebSocket to this
+server, which bridges the call audio to the Azure Voice Live API. Voice Live acts
+as a receptionist: it greets the caller, answers questions, can take a message,
+and can transfer the call to a human.
+
+Run:
+    python app.py
+    # then expose it, e.g.:  ngrok http 8000
+    # point your Twilio number's Voice webhook at  https://<public-host>/incoming-call
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+from typing import Any, Dict, Optional, Union
+
+import uvicorn
+from dotenv import load_dotenv
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import PlainTextResponse
+
+from azure.core.credentials import AzureKeyCredential
+from azure.identity.aio import DefaultAzureCredential
+from azure.ai.voicelive.aio import connect, VoiceLiveConnection
+from azure.ai.voicelive.models import (
+    AudioInputTranscriptionOptions,
+    AzureStandardVoice,
+    FunctionCallOutputItem,
+    FunctionTool,
+    InputAudioFormat,
+    ItemType,
+    Modality,
+    OutputAudioFormat,
+    RequestSession,
+    ServerEventType,
+    ServerVad,
+    Tool,
+    ToolChoiceLiteral,
+)
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+load_dotenv("./.env", override=True)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s:%(name)s:%(levelname)s:%(message)s",
+)
+logger = logging.getLogger("inbound-receptionist")
+
+# ---------------------------------------------------------------------------
+# Configuration (from environment / .env)
+# ---------------------------------------------------------------------------
+ENDPOINT = os.environ.get("AZURE_VOICELIVE_ENDPOINT", "")
+API_KEY = os.environ.get("AZURE_VOICELIVE_API_KEY", "")
+MODEL = os.environ.get("AZURE_VOICELIVE_MODEL", "gpt-realtime")
+VOICE = os.environ.get("AZURE_VOICELIVE_VOICE", "en-US-Ava:DragonHDLatestNeural")
+USE_TOKEN_CREDENTIAL = os.environ.get("USE_TOKEN_CREDENTIAL", "false").lower() == "true"
+PORT = int(os.environ.get("PORT", "8000"))
+
+# Business details used to tailor the receptionist's behavior.
+BUSINESS_NAME = os.environ.get("BUSINESS_NAME", "Contoso Dental")
+TRANSFER_PHONE_NUMBER = os.environ.get("TRANSFER_PHONE_NUMBER", "")
+
+# Twilio credentials are only needed for the "transfer to human" feature.
+TWILIO_ACCOUNT_SID = os.environ.get("TWILIO_ACCOUNT_SID", "")
+TWILIO_AUTH_TOKEN = os.environ.get("TWILIO_AUTH_TOKEN", "")
+
+INSTRUCTIONS = os.environ.get(
+    "RECEPTIONIST_INSTRUCTIONS",
+    f"You are a friendly, professional AI receptionist for {BUSINESS_NAME}. "
+    "Greet the caller warmly and ask how you can help. Answer questions about the "
+    "business using the facts below. Keep responses short and natural — this is a "
+    "phone call, so speak conversationally and avoid long monologues.\n\n"
+    "Business facts:\n"
+    "- Hours: Monday to Friday, 8am to 5pm. Closed weekends.\n"
+    "- Location: 123 Main Street, Redmond, WA.\n"
+    "- Services: general checkups, cleanings, fillings, and emergency dental care.\n"
+    "- New patients are welcome.\n\n"
+    "If the caller wants to leave a message, call the `take_message` function with "
+    "their name, phone number, and message. If the caller asks to speak to a person "
+    "or has an urgent issue you cannot resolve, call the `transfer_to_human` "
+    "function. Always confirm details back to the caller before taking an action.",
+)
+
+MESSAGES_DIR = os.environ.get("MESSAGES_DIR", "./messages")
+
+
+# ---------------------------------------------------------------------------
+# Function tools the receptionist can call
+# ---------------------------------------------------------------------------
+def build_tools() -> list[Tool]:
+    return [
+        FunctionTool(
+            name="take_message",
+            description="Record a message from the caller for staff to follow up on.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "caller_name": {"type": "string", "description": "The caller's full name."},
+                    "phone_number": {"type": "string", "description": "A callback phone number."},
+                    "message": {"type": "string", "description": "The message to pass on to staff."},
+                },
+                "required": ["caller_name", "message"],
+            },
+        ),
+        FunctionTool(
+            name="transfer_to_human",
+            description="Transfer the current call to a human staff member.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "reason": {"type": "string", "description": "Why the caller needs a human."},
+                },
+                "required": [],
+            },
+        ),
+    ]
+
+
+def take_message(args: Dict[str, Any]) -> Dict[str, Any]:
+    """Persist a caller message as a JSON file."""
+    os.makedirs(MESSAGES_DIR, exist_ok=True)
+    from datetime import datetime, timezone
+
+    record = {
+        "received_at": datetime.now(timezone.utc).isoformat(),
+        "caller_name": args.get("caller_name", "Unknown"),
+        "phone_number": args.get("phone_number", ""),
+        "message": args.get("message", ""),
+    }
+    filename = os.path.join(
+        MESSAGES_DIR, f"message_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+    )
+    with open(filename, "w", encoding="utf-8") as f:
+        json.dump(record, f, indent=2)
+    logger.info("Saved message to %s", filename)
+    return {"status": "saved", "confirmation": "Your message has been recorded."}
+
+
+# ---------------------------------------------------------------------------
+# Twilio <-> Voice Live bridge for a single call
+# ---------------------------------------------------------------------------
+class CallBridge:
+    """Bridges one Twilio Media Stream to one Voice Live session."""
+
+    def __init__(self, websocket: WebSocket, connection: VoiceLiveConnection):
+        self.websocket = websocket
+        self.connection = connection
+        self.stream_sid: Optional[str] = None
+        self.call_sid: Optional[str] = None
+        self.active_response = False
+        self._pending_call: Optional[Dict[str, Any]] = None
+
+    async def configure_session(self) -> None:
+        """Configure Voice Live for a G.711 μ-law telephone call."""
+        voice_config: Union[AzureStandardVoice, str]
+        voice_config = AzureStandardVoice(name=VOICE) if "-" in VOICE else VOICE
+
+        session = RequestSession(
+            modalities=[Modality.TEXT, Modality.AUDIO],
+            instructions=INSTRUCTIONS,
+            voice=voice_config,
+            # Telephony audio: G.711 μ-law, 8kHz — matches Twilio Media Streams.
+            input_audio_format=InputAudioFormat.G711_ULAW,
+            output_audio_format=OutputAudioFormat.G711_ULAW,
+            turn_detection=ServerVad(
+                threshold=0.5, prefix_padding_ms=300, silence_duration_ms=500
+            ),
+            tools=build_tools(),
+            tool_choice=ToolChoiceLiteral.AUTO,
+            input_audio_transcription=AudioInputTranscriptionOptions(model="whisper-1"),
+        )
+        await self.connection.session.update(session=session)
+        logger.info("Voice Live session configured for telephony")
+
+    # --- Twilio -> Voice Live -------------------------------------------------
+    async def pump_twilio_to_voicelive(self) -> None:
+        """Read Twilio media frames and forward audio to Voice Live."""
+        try:
+            while True:
+                message = await self.websocket.receive_text()
+                data = json.loads(message)
+                event = data.get("event")
+
+                if event == "start":
+                    start = data["start"]
+                    self.stream_sid = start["streamSid"]
+                    self.call_sid = start.get("callSid")
+                    logger.info("Call started (streamSid=%s callSid=%s)", self.stream_sid, self.call_sid)
+                    # Greet the caller proactively.
+                    await self.connection.response.create()
+
+                elif event == "media":
+                    # Twilio payload is base64 μ-law — forward as-is (no transcoding).
+                    await self.connection.input_audio_buffer.append(
+                        audio=data["media"]["payload"]
+                    )
+
+                elif event == "stop":
+                    logger.info("Call stopped by Twilio")
+                    break
+        except WebSocketDisconnect:
+            logger.info("Twilio WebSocket disconnected")
+
+    # --- Voice Live -> Twilio -------------------------------------------------
+    async def pump_voicelive_to_twilio(self) -> None:
+        """Read Voice Live events and stream audio back to the caller."""
+        async for event in self.connection:
+            if event.type == ServerEventType.RESPONSE_CREATED:
+                self.active_response = True
+
+            elif event.type == ServerEventType.RESPONSE_AUDIO_DELTA:
+                if self.stream_sid is None:
+                    continue
+                # event.delta is raw μ-law bytes — base64-encode for Twilio.
+                payload = base64.b64encode(event.delta).decode("utf-8")
+                await self.websocket.send_json(
+                    {
+                        "event": "media",
+                        "streamSid": self.stream_sid,
+                        "media": {"payload": payload},
+                    }
+                )
+
+            elif event.type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STARTED:
+                # Barge-in: caller interrupted — flush Twilio's buffered audio
+                # and cancel the in-progress Voice Live response.
+                if self.stream_sid is not None:
+                    await self.websocket.send_json(
+                        {"event": "clear", "streamSid": self.stream_sid}
+                    )
+                if self.active_response:
+                    try:
+                        await self.connection.response.cancel()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug("Cancel ignored: %s", exc)
+
+            elif event.type == ServerEventType.RESPONSE_DONE:
+                self.active_response = False
+                if self._pending_call and "arguments" in self._pending_call:
+                    await self._execute_function_call(self._pending_call)
+                    self._pending_call = None
+
+            elif event.type == ServerEventType.CONVERSATION_ITEM_CREATED:
+                if event.item.type == ItemType.FUNCTION_CALL:
+                    self._pending_call = {
+                        "name": event.item.name,
+                        "call_id": event.item.call_id,
+                        "previous_item_id": event.item.id,
+                    }
+
+            elif event.type == ServerEventType.RESPONSE_FUNCTION_CALL_ARGUMENTS_DONE:
+                if self._pending_call and event.call_id == self._pending_call["call_id"]:
+                    self._pending_call["arguments"] = event.arguments
+
+            elif event.type == ServerEventType.ERROR:
+                logger.error("Voice Live error: %s", event.error.message)
+
+    async def _execute_function_call(self, call: Dict[str, Any]) -> None:
+        name = call["name"]
+        try:
+            args = json.loads(call["arguments"]) if call.get("arguments") else {}
+        except json.JSONDecodeError:
+            args = {}
+
+        if name == "take_message":
+            result = take_message(args)
+        elif name == "transfer_to_human":
+            result = self._transfer_to_human(args)
+        else:
+            result = {"error": f"Unknown function {name}"}
+
+        output = FunctionCallOutputItem(call_id=call["call_id"], output=json.dumps(result))
+        await self.connection.conversation.item.create(
+            previous_item_id=call["previous_item_id"], item=output
+        )
+        await self.connection.response.create()
+
+    def _transfer_to_human(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Redirect the live Twilio call to a human via the Twilio REST API."""
+        if not (TRANSFER_PHONE_NUMBER and TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN):
+            return {
+                "status": "unavailable",
+                "message": "Transfer is not configured. Offer to take a message instead.",
+            }
+        if not self.call_sid:
+            return {"status": "error", "message": "No active call to transfer."}
+        try:
+            from twilio.rest import Client
+            from twilio.twiml.voice_response import VoiceResponse, Dial
+
+            response = VoiceResponse()
+            response.say("Please hold while I connect you.")
+            dial = Dial()
+            dial.number(TRANSFER_PHONE_NUMBER)
+            response.append(dial)
+
+            client = Client(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)
+            client.calls(self.call_sid).update(twiml=str(response))
+            logger.info("Transferred call %s to %s", self.call_sid, TRANSFER_PHONE_NUMBER)
+            return {"status": "transferring", "message": "Connecting the caller now."}
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Transfer failed")
+            return {"status": "error", "message": str(exc)}
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+app = FastAPI(title="Voice Live Inbound Receptionist")
+
+
+def _credential():
+    if USE_TOKEN_CREDENTIAL or not API_KEY:
+        return DefaultAzureCredential()
+    return AzureKeyCredential(API_KEY)
+
+
+@app.get("/health")
+async def health() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.api_route("/incoming-call", methods=["GET", "POST"])
+async def incoming_call(request: Request) -> PlainTextResponse:
+    """Return TwiML that connects the inbound call to our media stream."""
+    host = request.headers.get("host")
+    twiml = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        "<Response>"
+        f'<Connect><Stream url="wss://{host}/media-stream" /></Connect>'
+        "</Response>"
+    )
+    return PlainTextResponse(content=twiml, media_type="text/xml")
+
+
+@app.websocket("/media-stream")
+async def media_stream(websocket: WebSocket) -> None:
+    """Twilio Media Stream endpoint — bridges the call to Voice Live."""
+    import asyncio
+
+    await websocket.accept()
+    logger.info("Twilio connected to /media-stream")
+
+    credential = _credential()
+    try:
+        async with connect(endpoint=ENDPOINT, credential=credential, model=MODEL) as connection:
+            bridge = CallBridge(websocket, connection)
+            await bridge.configure_session()
+            await asyncio.gather(
+                bridge.pump_twilio_to_voicelive(),
+                bridge.pump_voicelive_to_twilio(),
+            )
+    except WebSocketDisconnect:
+        logger.info("Call ended")
+    except Exception:  # noqa: BLE001
+        logger.exception("Bridge error")
+    finally:
+        if hasattr(credential, "close"):
+            await credential.close()
+
+
+if __name__ == "__main__":
+    if not ENDPOINT:
+        raise SystemExit("AZURE_VOICELIVE_ENDPOINT is required. Copy .env_sample to .env and fill it in.")
+    logger.info("Starting inbound receptionist on port %d", PORT)
+    uvicorn.run(app, host="0.0.0.0", port=PORT)

--- a/python/voice-live-twilio-callcenter/inbound-receptionist/requirements.txt
+++ b/python/voice-live-twilio-callcenter/inbound-receptionist/requirements.txt
@@ -1,0 +1,6 @@
+azure-ai-voicelive[aiohttp]
+azure-identity
+python-dotenv
+fastapi
+uvicorn[standard]
+twilio

--- a/python/voice-live-twilio-callcenter/outbound-appointment-reminder/.env_sample
+++ b/python/voice-live-twilio-callcenter/outbound-appointment-reminder/.env_sample
@@ -1,0 +1,21 @@
+# --- Azure Voice Live ---
+AZURE_VOICELIVE_ENDPOINT=https://your-resource-name.services.ai.azure.com/
+AZURE_VOICELIVE_API_KEY=<your_api_key>          # omit if using Azure credentials
+AZURE_VOICELIVE_MODEL=gpt-realtime
+AZURE_VOICELIVE_VOICE=en-US-Ava:DragonHDLatestNeural
+# Set to true to authenticate with DefaultAzureCredential (az login) instead of an API key.
+USE_TOKEN_CREDENTIAL=false
+
+# --- Server ---
+PORT=8000
+
+# --- Business profile ---
+BUSINESS_NAME=Contoso Dental
+OUTCOMES_DIR=./outcomes
+
+# --- Twilio (required to place outbound calls with make_call.py) ---
+TWILIO_ACCOUNT_SID=<your_twilio_account_sid>
+TWILIO_AUTH_TOKEN=<your_twilio_auth_token>
+TWILIO_FROM_NUMBER=+15550001111
+# Public HTTPS base URL of your running app (e.g. your ngrok address).
+PUBLIC_BASE_URL=https://your-subdomain.ngrok.app

--- a/python/voice-live-twilio-callcenter/outbound-appointment-reminder/README.md
+++ b/python/voice-live-twilio-callcenter/outbound-appointment-reminder/README.md
@@ -1,0 +1,116 @@
+# Outbound Appointment Reminder (Voice Live + Twilio)
+
+Places an **outbound phone call** to a customer and uses Azure Voice Live to
+remind them of an appointment, then records whether they **confirmed**, want to
+**reschedule**, or **cancel** — as a natural voice conversation.
+
+## Key Features
+
+- Outbound PSTN calling via the Twilio REST API + Media Streams
+- Per‑call personalization (customer name + appointment time) passed as Twilio
+  `<Parameter>` stream values
+- Server‑side Voice Live SDK bridge with G.711 μ‑law (no transcoding)
+- Proactive greeting and natural barge‑in
+- `record_outcome` function — persists the result (confirmed / reschedule /
+  cancel + notes) to JSON
+- API key **or** Azure credential (`DefaultAzureCredential`) authentication
+
+## How it works
+
+```
+make_call.py → Twilio REST (create call) → customer's phone rings
+    → Twilio fetches /outbound-twiml?customer_name=…&appointment_time=…
+    → TwiML <Connect><Stream> with <Parameter> details
+    → WebSocket /media-stream ⇄ CallBridge ⇄ Azure Voice Live
+    → record_outcome() writes the result to ./outcomes
+```
+
+The appointment details flow end‑to‑end: `make_call.py` puts them in the TwiML
+URL, `/outbound-twiml` embeds them as `<Parameter>` values, and they arrive in
+Twilio's `start` event as `customParameters`, which the bridge uses to build the
+assistant's instructions.
+
+## Setup
+
+1. **Install dependencies**
+
+   ```bash
+   python -m venv .venv
+   # Windows: .venv\Scripts\activate  |  Linux/macOS: source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. **Configure** — copy `.env_sample` to `.env` and fill in your values
+   (Voice Live endpoint/key, Twilio credentials, `TWILIO_FROM_NUMBER`, and
+   `PUBLIC_BASE_URL`).
+
+3. **Run the server**
+
+   ```bash
+   python app.py
+   ```
+
+4. **Expose it publicly** so Twilio can fetch the TwiML and open the stream:
+
+   ```bash
+   ngrok http 8000
+   ```
+
+   Put the resulting HTTPS URL in `PUBLIC_BASE_URL` in `.env` (or pass
+   `--base-url`).
+
+5. **Place a call**
+
+   ```bash
+   python make_call.py \
+       --to +15551234567 \
+       --name "Jamie Rivera" \
+       --time "Tuesday, July 28 at 3:00 PM"
+   ```
+
+   The customer's phone rings; when they answer, Voice Live delivers the reminder
+   and records the outcome under `./outcomes`.
+
+## `make_call.py` options
+
+| Flag | Required | Description |
+| --- | --- | --- |
+| `--to` | Yes | Customer phone number (E.164), e.g. `+15551234567`. |
+| `--name` | Yes | Customer name used in the reminder. |
+| `--time` | Yes | Appointment time text, e.g. `"Tuesday at 3 PM"`. |
+| `--from` | No | Your Twilio number; defaults to `TWILIO_FROM_NUMBER`. |
+| `--base-url` | No | Public app URL; defaults to `PUBLIC_BASE_URL`. |
+
+## Configuration reference
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `AZURE_VOICELIVE_ENDPOINT` | Yes | Your AI Foundry / Voice Live endpoint. |
+| `AZURE_VOICELIVE_API_KEY` | Yes* | API key. *Not needed if `USE_TOKEN_CREDENTIAL=true`. |
+| `USE_TOKEN_CREDENTIAL` | No | `true` to use `DefaultAzureCredential` (az login). |
+| `AZURE_VOICELIVE_MODEL` | No | Defaults to `gpt-realtime`. |
+| `AZURE_VOICELIVE_VOICE` | No | Defaults to `en-US-Ava:DragonHDLatestNeural`. |
+| `BUSINESS_NAME` | No | Injected into the assistant's instructions. |
+| `OUTCOMES_DIR` | No | Where `record_outcome` writes JSON (default `./outcomes`). |
+| `TWILIO_ACCOUNT_SID` / `TWILIO_AUTH_TOKEN` | Yes | Twilio credentials. |
+| `TWILIO_FROM_NUMBER` | Yes | Your Twilio caller ID (E.164). |
+| `PUBLIC_BASE_URL` | Yes | Public HTTPS URL of this server. |
+
+## Compliance note
+
+Outbound automated calls are regulated in many regions (e.g. TCPA in the US).
+Only call customers who have consented, honor do‑not‑call requests, and disclose
+that the caller is an automated assistant.
+
+## Troubleshooting
+
+- **Call connects but is silent**: verify `PUBLIC_BASE_URL` is correct and the
+  server logs show "Twilio connected to /media-stream".
+- **`make_call.py` errors on missing config**: ensure Twilio credentials,
+  `--from`/`TWILIO_FROM_NUMBER`, and `--base-url`/`PUBLIC_BASE_URL` are set.
+- **401 Unauthorized (Voice Live)**: check `AZURE_VOICELIVE_API_KEY` or run
+  `az login` when `USE_TOKEN_CREDENTIAL=true`.
+
+## License
+
+Licensed under the MIT License. See the repository [LICENSE](../../../LICENSE).

--- a/python/voice-live-twilio-callcenter/outbound-appointment-reminder/app.py
+++ b/python/voice-live-twilio-callcenter/outbound-appointment-reminder/app.py
@@ -1,0 +1,369 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# -------------------------------------------------------------------------
+"""
+Outbound Appointment Reminder — Azure Voice Live + Twilio Media Streams.
+
+This server places (via make_call.py) an *outbound* call to a customer and uses
+Azure Voice Live to remind them of an appointment, then records whether they
+confirmed, want to reschedule, or cancelled.
+
+Flow:
+    make_call.py  --to +1555...  --name "Jamie" --time "Tuesday at 3 PM"
+        -> Twilio dials the customer, fetching TwiML from /outbound-twiml
+        -> TwiML opens a Media Stream to /media-stream with the appointment
+           details passed as <Parameter> values
+        -> this server bridges audio to Voice Live and records the outcome
+
+Run:
+    python app.py
+    # expose it, e.g.:  ngrok http 8000
+    # then place a call:  python make_call.py --to +15551234567 --name Jamie --time "Tue 3 PM"
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+from typing import Any, Dict, Optional, Union
+
+import uvicorn
+from dotenv import load_dotenv
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import PlainTextResponse
+
+from azure.core.credentials import AzureKeyCredential
+from azure.identity.aio import DefaultAzureCredential
+from azure.ai.voicelive.aio import connect, VoiceLiveConnection
+from azure.ai.voicelive.models import (
+    AudioInputTranscriptionOptions,
+    AzureStandardVoice,
+    FunctionCallOutputItem,
+    FunctionTool,
+    InputAudioFormat,
+    ItemType,
+    Modality,
+    OutputAudioFormat,
+    RequestSession,
+    ServerEventType,
+    ServerVad,
+    Tool,
+    ToolChoiceLiteral,
+)
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+load_dotenv("./.env", override=True)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s:%(name)s:%(levelname)s:%(message)s",
+)
+logger = logging.getLogger("outbound-appointment-reminder")
+
+# ---------------------------------------------------------------------------
+# Configuration (from environment / .env)
+# ---------------------------------------------------------------------------
+ENDPOINT = os.environ.get("AZURE_VOICELIVE_ENDPOINT", "")
+API_KEY = os.environ.get("AZURE_VOICELIVE_API_KEY", "")
+MODEL = os.environ.get("AZURE_VOICELIVE_MODEL", "gpt-realtime")
+VOICE = os.environ.get("AZURE_VOICELIVE_VOICE", "en-US-Ava:DragonHDLatestNeural")
+USE_TOKEN_CREDENTIAL = os.environ.get("USE_TOKEN_CREDENTIAL", "false").lower() == "true"
+PORT = int(os.environ.get("PORT", "8000"))
+
+BUSINESS_NAME = os.environ.get("BUSINESS_NAME", "Contoso Dental")
+OUTCOMES_DIR = os.environ.get("OUTCOMES_DIR", "./outcomes")
+
+
+def build_instructions(customer_name: str, appointment_time: str) -> str:
+    """Tailor the assistant's script to a specific appointment."""
+    return (
+        f"You are a polite assistant calling on behalf of {BUSINESS_NAME}. "
+        f"You are calling {customer_name} to remind them about their upcoming "
+        f"appointment on {appointment_time}. This is a phone call, so keep every "
+        "turn short and conversational.\n\n"
+        "Goals, in order:\n"
+        "1. Politely identify yourself and confirm you are speaking with "
+        f"{customer_name}.\n"
+        "2. Remind them of the appointment time and ask if they can still make it.\n"
+        "3. Based on their answer, call the `record_outcome` function with status "
+        "'confirmed', 'reschedule', or 'cancel'. If they want to reschedule, ask "
+        "for their preferred day/time and include it in the notes.\n"
+        "4. Thank them and end the call warmly.\n\n"
+        "Do not be pushy. If they are busy, offer to call back later and record the "
+        "outcome as 'reschedule' with a note."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Function tool: record the call outcome
+# ---------------------------------------------------------------------------
+def build_tools() -> list[Tool]:
+    return [
+        FunctionTool(
+            name="record_outcome",
+            description="Record the result of the appointment reminder call.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": ["confirmed", "reschedule", "cancel"],
+                        "description": "The customer's decision about the appointment.",
+                    },
+                    "notes": {
+                        "type": "string",
+                        "description": "Any details, e.g. a preferred reschedule time.",
+                    },
+                },
+                "required": ["status"],
+            },
+        ),
+    ]
+
+
+def record_outcome(args: Dict[str, Any], context: Dict[str, str]) -> Dict[str, Any]:
+    """Persist the call outcome as a JSON file."""
+    os.makedirs(OUTCOMES_DIR, exist_ok=True)
+    from datetime import datetime, timezone
+
+    record = {
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+        "customer_name": context.get("customer_name", ""),
+        "appointment_time": context.get("appointment_time", ""),
+        "status": args.get("status", ""),
+        "notes": args.get("notes", ""),
+    }
+    filename = os.path.join(
+        OUTCOMES_DIR, f"outcome_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+    )
+    with open(filename, "w", encoding="utf-8") as f:
+        json.dump(record, f, indent=2)
+    logger.info("Recorded outcome '%s' to %s", record["status"], filename)
+    return {"status": "recorded"}
+
+
+# ---------------------------------------------------------------------------
+# Twilio <-> Voice Live bridge for a single outbound call
+# ---------------------------------------------------------------------------
+class CallBridge:
+    """Bridges one outbound Twilio Media Stream to one Voice Live session."""
+
+    def __init__(self, websocket: WebSocket, connection: VoiceLiveConnection):
+        self.websocket = websocket
+        self.connection = connection
+        self.stream_sid: Optional[str] = None
+        self.active_response = False
+        self._pending_call: Optional[Dict[str, Any]] = None
+        # Appointment context, populated from Twilio <Parameter> values.
+        self.context: Dict[str, str] = {"customer_name": "there", "appointment_time": "your appointment"}
+
+    async def configure_session(self) -> None:
+        voice_config: Union[AzureStandardVoice, str]
+        voice_config = AzureStandardVoice(name=VOICE) if "-" in VOICE else VOICE
+
+        session = RequestSession(
+            modalities=[Modality.TEXT, Modality.AUDIO],
+            instructions=build_instructions(
+                self.context["customer_name"], self.context["appointment_time"]
+            ),
+            voice=voice_config,
+            input_audio_format=InputAudioFormat.G711_ULAW,
+            output_audio_format=OutputAudioFormat.G711_ULAW,
+            turn_detection=ServerVad(
+                threshold=0.5, prefix_padding_ms=300, silence_duration_ms=500
+            ),
+            tools=build_tools(),
+            tool_choice=ToolChoiceLiteral.AUTO,
+            input_audio_transcription=AudioInputTranscriptionOptions(model="whisper-1"),
+        )
+        await self.connection.session.update(session=session)
+        logger.info(
+            "Session configured for %s (%s)",
+            self.context["customer_name"],
+            self.context["appointment_time"],
+        )
+
+    # --- Twilio -> Voice Live -------------------------------------------------
+    async def pump_twilio_to_voicelive(self) -> None:
+        try:
+            while True:
+                message = await self.websocket.receive_text()
+                data = json.loads(message)
+                event = data.get("event")
+
+                if event == "start":
+                    start = data["start"]
+                    self.stream_sid = start["streamSid"]
+                    # Appointment details arrive as custom stream parameters.
+                    params = start.get("customParameters", {}) or {}
+                    if params.get("customer_name"):
+                        self.context["customer_name"] = params["customer_name"]
+                    if params.get("appointment_time"):
+                        self.context["appointment_time"] = params["appointment_time"]
+                    logger.info("Outbound call started (streamSid=%s)", self.stream_sid)
+                    # Reconfigure with the now-known appointment details, then greet.
+                    await self.configure_session()
+                    await self.connection.response.create()
+
+                elif event == "media":
+                    await self.connection.input_audio_buffer.append(
+                        audio=data["media"]["payload"]
+                    )
+
+                elif event == "stop":
+                    logger.info("Call stopped by Twilio")
+                    break
+        except WebSocketDisconnect:
+            logger.info("Twilio WebSocket disconnected")
+
+    # --- Voice Live -> Twilio -------------------------------------------------
+    async def pump_voicelive_to_twilio(self) -> None:
+        async for event in self.connection:
+            if event.type == ServerEventType.RESPONSE_CREATED:
+                self.active_response = True
+
+            elif event.type == ServerEventType.RESPONSE_AUDIO_DELTA:
+                if self.stream_sid is None:
+                    continue
+                payload = base64.b64encode(event.delta).decode("utf-8")
+                await self.websocket.send_json(
+                    {
+                        "event": "media",
+                        "streamSid": self.stream_sid,
+                        "media": {"payload": payload},
+                    }
+                )
+
+            elif event.type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STARTED:
+                if self.stream_sid is not None:
+                    await self.websocket.send_json(
+                        {"event": "clear", "streamSid": self.stream_sid}
+                    )
+                if self.active_response:
+                    try:
+                        await self.connection.response.cancel()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug("Cancel ignored: %s", exc)
+
+            elif event.type == ServerEventType.RESPONSE_DONE:
+                self.active_response = False
+                if self._pending_call and "arguments" in self._pending_call:
+                    await self._execute_function_call(self._pending_call)
+                    self._pending_call = None
+
+            elif event.type == ServerEventType.CONVERSATION_ITEM_CREATED:
+                if event.item.type == ItemType.FUNCTION_CALL:
+                    self._pending_call = {
+                        "name": event.item.name,
+                        "call_id": event.item.call_id,
+                        "previous_item_id": event.item.id,
+                    }
+
+            elif event.type == ServerEventType.RESPONSE_FUNCTION_CALL_ARGUMENTS_DONE:
+                if self._pending_call and event.call_id == self._pending_call["call_id"]:
+                    self._pending_call["arguments"] = event.arguments
+
+            elif event.type == ServerEventType.ERROR:
+                logger.error("Voice Live error: %s", event.error.message)
+
+    async def _execute_function_call(self, call: Dict[str, Any]) -> None:
+        name = call["name"]
+        try:
+            args = json.loads(call["arguments"]) if call.get("arguments") else {}
+        except json.JSONDecodeError:
+            args = {}
+
+        if name == "record_outcome":
+            result = record_outcome(args, self.context)
+        else:
+            result = {"error": f"Unknown function {name}"}
+
+        output = FunctionCallOutputItem(call_id=call["call_id"], output=json.dumps(result))
+        await self.connection.conversation.item.create(
+            previous_item_id=call["previous_item_id"], item=output
+        )
+        await self.connection.response.create()
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+app = FastAPI(title="Voice Live Outbound Appointment Reminder")
+
+
+def _credential():
+    if USE_TOKEN_CREDENTIAL or not API_KEY:
+        return DefaultAzureCredential()
+    return AzureKeyCredential(API_KEY)
+
+
+def _xml_escape(value: str) -> str:
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+@app.get("/health")
+async def health() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.api_route("/outbound-twiml", methods=["GET", "POST"])
+async def outbound_twiml(request: Request) -> PlainTextResponse:
+    """TwiML fetched by Twilio when the outbound call connects.
+
+    Appointment details are supplied as query params by make_call.py and passed
+    to the media stream as <Parameter> values.
+    """
+    params = dict(request.query_params)
+    customer_name = _xml_escape(params.get("customer_name", "there"))
+    appointment_time = _xml_escape(params.get("appointment_time", "your appointment"))
+    host = request.headers.get("host")
+    twiml = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        "<Response>"
+        f'<Connect><Stream url="wss://{host}/media-stream">'
+        f'<Parameter name="customer_name" value="{customer_name}" />'
+        f'<Parameter name="appointment_time" value="{appointment_time}" />'
+        "</Stream></Connect>"
+        "</Response>"
+    )
+    return PlainTextResponse(content=twiml, media_type="text/xml")
+
+
+@app.websocket("/media-stream")
+async def media_stream(websocket: WebSocket) -> None:
+    import asyncio
+
+    await websocket.accept()
+    logger.info("Twilio connected to /media-stream")
+
+    credential = _credential()
+    try:
+        async with connect(endpoint=ENDPOINT, credential=credential, model=MODEL) as connection:
+            bridge = CallBridge(websocket, connection)
+            # Session is configured after the 'start' event delivers appointment
+            # details, inside pump_twilio_to_voicelive.
+            await asyncio.gather(
+                bridge.pump_twilio_to_voicelive(),
+                bridge.pump_voicelive_to_twilio(),
+            )
+    except WebSocketDisconnect:
+        logger.info("Call ended")
+    except Exception:  # noqa: BLE001
+        logger.exception("Bridge error")
+    finally:
+        if hasattr(credential, "close"):
+            await credential.close()
+
+
+if __name__ == "__main__":
+    if not ENDPOINT:
+        raise SystemExit("AZURE_VOICELIVE_ENDPOINT is required. Copy .env_sample to .env and fill it in.")
+    logger.info("Starting outbound appointment reminder on port %d", PORT)
+    uvicorn.run(app, host="0.0.0.0", port=PORT)

--- a/python/voice-live-twilio-callcenter/outbound-appointment-reminder/make_call.py
+++ b/python/voice-live-twilio-callcenter/outbound-appointment-reminder/make_call.py
@@ -1,0 +1,76 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# -------------------------------------------------------------------------
+"""
+Place an outbound appointment-reminder call via the Twilio REST API.
+
+The call fetches TwiML from your running app.py (`/outbound-twiml`), which opens
+a Media Stream to Voice Live carrying the appointment details.
+
+Example:
+    python make_call.py \
+        --to +15551234567 \
+        --name "Jamie Rivera" \
+        --time "Tuesday, July 28 at 3:00 PM"
+
+Requires a publicly reachable server URL (PUBLIC_BASE_URL), e.g. your ngrok
+HTTPS address. Set it in .env or pass --base-url.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from urllib.parse import urlencode
+
+from dotenv import load_dotenv
+
+load_dotenv("./.env", override=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Place an outbound appointment reminder call.")
+    parser.add_argument("--to", required=True, help="Customer phone number in E.164 format, e.g. +15551234567")
+    parser.add_argument("--name", required=True, help="Customer name.")
+    parser.add_argument("--time", required=True, help="Appointment time, e.g. 'Tuesday at 3 PM'.")
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("PUBLIC_BASE_URL", ""),
+        help="Public HTTPS base URL of your running app (e.g. https://abc123.ngrok.app).",
+    )
+    parser.add_argument(
+        "--from",
+        dest="from_number",
+        default=os.environ.get("TWILIO_FROM_NUMBER", ""),
+        help="Your Twilio phone number (E.164). Defaults to TWILIO_FROM_NUMBER.",
+    )
+    args = parser.parse_args()
+
+    account_sid = os.environ.get("TWILIO_ACCOUNT_SID", "")
+    auth_token = os.environ.get("TWILIO_AUTH_TOKEN", "")
+
+    missing = [
+        name
+        for name, value in {
+            "TWILIO_ACCOUNT_SID": account_sid,
+            "TWILIO_AUTH_TOKEN": auth_token,
+            "--from / TWILIO_FROM_NUMBER": args.from_number,
+            "--base-url / PUBLIC_BASE_URL": args.base_url,
+        }.items()
+        if not value
+    ]
+    if missing:
+        raise SystemExit("Missing required configuration: " + ", ".join(missing))
+
+    from twilio.rest import Client
+
+    query = urlencode({"customer_name": args.name, "appointment_time": args.time})
+    twiml_url = f"{args.base_url.rstrip('/')}/outbound-twiml?{query}"
+
+    client = Client(account_sid, auth_token)
+    call = client.calls.create(to=args.to, from_=args.from_number, url=twiml_url)
+    print(f"Placed call {call.sid} to {args.to}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/voice-live-twilio-callcenter/outbound-appointment-reminder/requirements.txt
+++ b/python/voice-live-twilio-callcenter/outbound-appointment-reminder/requirements.txt
@@ -1,0 +1,6 @@
+azure-ai-voicelive[aiohttp]
+azure-identity
+python-dotenv
+fastapi
+uvicorn[standard]
+twilio


### PR DESCRIPTION
## Summary
- add an inbound AI receptionist sample using Twilio Media Streams and Azure Voice Live
- add an outbound appointment reminder sample with per-call personalization and outcome recording
- document setup, configuration, architecture, troubleshooting, and production considerations

## Validation
- python -m py_compile for all three Python entry points