### PR TITLE
Fix redundant speech-start response cancellation in samples

### DIFF
--- a/csharp/CustomerServiceBot/CustomerServiceBot.cs
+++ b/csharp/CustomerServiceBot/CustomerServiceBot.cs
@@ -37,8 +37,6 @@ public class CustomerServiceBot : IDisposable
     private bool _responseActive;
     // Tracks whether we've already sent the initial proactive greeting to start the conversation
     private bool _conversationStarted;
-    // Tracks whether the assistant can still cancel the current response (between ResponseCreated and ResponseDone)
-    private bool _canCancelResponse;
 
     /// <summary>
     /// Initializes a new instance of the CustomerServiceBot class.
@@ -433,33 +431,13 @@ public class CustomerServiceBot : IDisposable
                     await _audioProcessor.StopPlaybackAsync().ConfigureAwait(false);
                 }
 
-                // Only attempt cancellation / clearing if a response is actually active
-                if (_responseActive && _canCancelResponse)
+                // Clear streaming audio only while a response is active.
+                if (_responseActive)
                 {
-                    // Cancel any ongoing response (only if server may still be generating)
-                    try
-                    {
-                        await _session!.CancelResponseAsync(cancellationToken).ConfigureAwait(false);
-                        _logger.LogInformation("🛑 Active response cancelled due to customer barge-in");
-                    }
-                    catch (Exception ex)
-                    {
-                        // Treat known benign message as debug-level (server already finished response)
-                        if (ex.Message.Contains("no active response", StringComparison.OrdinalIgnoreCase))
-                        {
-                            _logger.LogDebug("Cancellation benign: response already completed");
-                        }
-                        else
-                        {
-                            _logger.LogWarning(ex, "Response cancellation failed during barge-in");
-                        }
-                    }
-
-                    // Clear any streaming audio still in transit only if response still marked active
                     try
                     {
                         await _session!.ClearStreamingAudioAsync(cancellationToken).ConfigureAwait(false);
-                        _logger.LogInformation("✨ Cleared streaming audio after cancellation");
+                        _logger.LogInformation("✨ Cleared streaming audio during barge-in");
                     }
                     catch (Exception ex)
                     {
@@ -468,7 +446,7 @@ public class CustomerServiceBot : IDisposable
                 }
                 else
                 {
-                    _logger.LogDebug("No active response to cancel during barge-in; skipping cancellation and clear operations");
+                    _logger.LogDebug("No active response during barge-in; skipping streaming audio clear");
                 }
                 break;
 
@@ -486,7 +464,6 @@ public class CustomerServiceBot : IDisposable
             case SessionUpdateResponseCreated responseCreated:
                 _logger.LogInformation("🤖 Assistant response created");
                 _responseActive = true;
-                _canCancelResponse = true; // Response can be cancelled until completion
                 break;
 
             case SessionUpdateResponseOutputItemAdded outputItemAdded:
@@ -520,7 +497,6 @@ public class CustomerServiceBot : IDisposable
             case SessionUpdateResponseDone responseDone:
                 _logger.LogInformation("✅ Response complete");
                 _responseActive = false; // Response fully complete
-                _canCancelResponse = false; // No longer cancellable
                 break;
             case SessionUpdateResponseFunctionCallArgumentsDone functionCallArgumentsDone:
                 _logger.LogInformation("🔧 Function call arguments done for call ID: {CallId}", functionCallArgumentsDone.CallId);
@@ -545,7 +521,6 @@ public class CustomerServiceBot : IDisposable
                 _logger.LogError("❌ VoiceLive error: {ErrorMessage}", errorEvent.Error?.Message);
                 Console.WriteLine($"Error: {errorEvent.Error?.Message}");
                 _responseActive = false;
-                _canCancelResponse = false;
                 break;
 
             default:

--- a/csharp/voice-live-quickstarts/AgentQuickstart/Program.cs
+++ b/csharp/voice-live-quickstarts/AgentQuickstart/Program.cs
@@ -321,7 +321,6 @@ namespace Azure.AI.VoiceLive.Samples
     /// <remarks>
     /// This sample now demonstrates some of the new convenience methods added to the VoiceLive SDK:
     /// - ClearStreamingAudioAsync() - Clears all input audio currently being streamed
-    /// - CancelResponseAsync() - Cancels the current response generation (existing method)
     /// - ConfigureSessionAsync() - Configures session options (existing method)
     ///
     /// Additional convenience methods available but not shown in this sample:
@@ -349,8 +348,6 @@ namespace Azure.AI.VoiceLive.Samples
         private bool _responseActive;
         // Tracks whether we've already sent the initial proactive greeting to start the conversation
         private bool _conversationStarted;
-        // Tracks whether the assistant can still cancel the current response (between ResponseCreated and ResponseDone)
-        private bool _canCancelResponse;
 
         /// <summary>
         /// Initializes a new instance of the BasicVoiceAssistant class.
@@ -543,33 +540,13 @@ namespace Azure.AI.VoiceLive.Samples
                         await _audioProcessor.StopPlaybackAsync().ConfigureAwait(false);
                     }
 
-                    // Only attempt cancellation / clearing if a response is actually active
-                    if (_responseActive && _canCancelResponse)
+                    // Clear streaming audio only while a response is active.
+                    if (_responseActive)
                     {
-                        // Cancel any ongoing response (only if server may still be generating)
-                        try
-                        {
-                            await _session!.CancelResponseAsync(cancellationToken).ConfigureAwait(false);
-                            _logger.LogInformation("🛑 Active response cancelled due to user barge-in");
-                        }
-                        catch (Exception ex)
-                        {
-                            // Treat known benign message as debug-level (server already finished response)
-                            if (ex.Message.Contains("no active response", StringComparison.OrdinalIgnoreCase))
-                            {
-                                _logger.LogDebug("Cancellation benign: response already completed");
-                            }
-                            else
-                            {
-                                _logger.LogWarning(ex, "Response cancellation failed during barge-in");
-                            }
-                        }
-
-                        // Clear any streaming audio still in transit only if response still marked active
                         try
                         {
                             await _session!.ClearStreamingAudioAsync(cancellationToken).ConfigureAwait(false);
-                            _logger.LogInformation("✨ Cleared streaming audio after cancellation");
+                            _logger.LogInformation("✨ Cleared streaming audio during barge-in");
                         }
                         catch (Exception ex)
                         {
@@ -578,7 +555,7 @@ namespace Azure.AI.VoiceLive.Samples
                     }
                     else
                     {
-                        _logger.LogDebug("No active response to cancel during barge-in; skipping cancellation and clear operations");
+                        _logger.LogDebug("No active response during barge-in; skipping streaming audio clear");
                     }
                     break;
 
@@ -596,7 +573,6 @@ namespace Azure.AI.VoiceLive.Samples
                 case SessionUpdateResponseCreated responseCreated:
                     _logger.LogInformation("🤖 Assistant response created");
                     _responseActive = true;
-                    _canCancelResponse = true; // Response can be cancelled until completion
                     break;
 
                 case SessionUpdateResponseAudioDelta audioDelta:
@@ -619,14 +595,12 @@ namespace Azure.AI.VoiceLive.Samples
                 case SessionUpdateResponseDone responseDone:
                     _logger.LogInformation("✅ Response complete");
                     _responseActive = false; // Response fully complete
-                    _canCancelResponse = false; // No longer cancellable
                     break;
 
                 case SessionUpdateError errorEvent:
                     _logger.LogError("❌ VoiceLive error: {ErrorMessage}", errorEvent.Error?.Message);
                     Console.WriteLine($"Error: {errorEvent.Error?.Message}");
                     _responseActive = false;
-                    _canCancelResponse = false;
                     break;
 
                 default:

--- a/csharp/voice-live-quickstarts/AgentsNewQuickstart/VoiceLiveWithAgentV2.cs
+++ b/csharp/voice-live-quickstarts/AgentsNewQuickstart/VoiceLiveWithAgentV2.cs
@@ -181,8 +181,6 @@ class BasicVoiceAssistant : IDisposable
     private VoiceLiveSession? _session;
     private AudioProcessor? _audioProcessor;
     private bool _greetingSent;
-    private bool _activeResponse;
-    private bool _responseApiDone;
 
     // Conversation log
     private static readonly string LogFilename = $"conversation_{DateTime.Now:yyyyMMdd_HHmmss}.log";
@@ -335,28 +333,10 @@ class BasicVoiceAssistant : IDisposable
             case SessionUpdateInputAudioBufferSpeechStarted:
                 Console.WriteLine("🎤 Listening...");
                 _audioProcessor?.SkipPendingAudio();
-
-                // Cancel in-progress response for barge-in
-                if (_activeResponse && !_responseApiDone)
-                {
-                    try
-                    {
-                        await _session!.CancelResponseAsync(cancellationToken).ConfigureAwait(false);
-                    }
-                    catch (Exception ex) when (ex.Message?.Contains("no active response") == true)
-                    {
-                        // Benign - response already completed
-                    }
-                }
                 break;
 
             case SessionUpdateInputAudioBufferSpeechStopped:
                 Console.WriteLine("🤔 Processing...");
-                break;
-
-            case SessionUpdateResponseCreated:
-                _activeResponse = true;
-                _responseApiDone = false;
                 break;
 
             case SessionUpdateResponseAudioDelta audioDelta:
@@ -370,21 +350,9 @@ class BasicVoiceAssistant : IDisposable
                 Console.WriteLine("🎤 Ready for next input...");
                 break;
 
-            case SessionUpdateResponseDone:
-                _activeResponse = false;
-                _responseApiDone = true;
-                break;
-
             case SessionUpdateError errorEvent:
                 var errorMsg = errorEvent.Error?.Message;
-                if (errorMsg?.Contains("Cancellation failed: no active response") == true)
-                {
-                    // Benign cancellation error
-                }
-                else
-                {
-                    Console.Error.WriteLine($"VoiceLive error: {errorMsg}");
-                }
+                Console.Error.WriteLine($"VoiceLive error: {errorMsg}");
                 break;
         }
     }

--- a/csharp/voice-live-quickstarts/BringYourOwnModelQuickstart/Program.cs
+++ b/csharp/voice-live-quickstarts/BringYourOwnModelQuickstart/Program.cs
@@ -300,7 +300,6 @@ namespace Azure.AI.VoiceLive.Samples
     /// <remarks>
     /// This sample now demonstrates some of the new convenience methods added to the VoiceLive SDK:
     /// - ClearStreamingAudioAsync() - Clears all input audio currently being streamed
-    /// - CancelResponseAsync() - Cancels the current response generation (existing method)
     /// - ConfigureSessionAsync() - Configures session options (existing method)
     ///
     /// Additional convenience methods available but not shown in this sample:
@@ -329,8 +328,6 @@ namespace Azure.AI.VoiceLive.Samples
         private bool _responseActive;
         // Tracks whether we've already sent the initial proactive greeting to start the conversation
         private bool _conversationStarted;
-        // Tracks whether the assistant can still cancel the current response (between ResponseCreated and ResponseDone)
-        private bool _canCancelResponse;    
 
         /// <summary>
         /// Initializes a new instance of the BasicVoiceAssistant class.
@@ -521,33 +518,13 @@ namespace Azure.AI.VoiceLive.Samples
                         await _audioProcessor.StopPlaybackAsync().ConfigureAwait(false);
                     }
 
-                    // Only attempt cancellation / clearing if a response is actually active
-                    if (_responseActive && _canCancelResponse)
+                    // Clear streaming audio only while a response is active.
+                    if (_responseActive)
                     {
-                        // Cancel any ongoing response (only if server may still be generating)
-                        try
-                        {
-                            await _session!.CancelResponseAsync(cancellationToken).ConfigureAwait(false);
-                            _logger.LogInformation("🛑 Active response cancelled due to user barge-in");
-                        }
-                        catch (Exception ex)
-                        {
-                            // Treat known benign message as debug-level (server already finished response)
-                            if (ex.Message.Contains("no active response", StringComparison.OrdinalIgnoreCase))
-                            {
-                                _logger.LogDebug("Cancellation benign: response already completed");
-                            }
-                            else
-                            {
-                                _logger.LogWarning(ex, "Response cancellation failed during barge-in");
-                            }
-                        }
-
-                        // Clear any streaming audio still in transit only if response still marked active
                         try
                         {
                             await _session!.ClearStreamingAudioAsync(cancellationToken).ConfigureAwait(false);
-                            _logger.LogInformation("✨ Cleared streaming audio after cancellation");
+                            _logger.LogInformation("✨ Cleared streaming audio during barge-in");
                         }
                         catch (Exception ex)
                         {
@@ -556,7 +533,7 @@ namespace Azure.AI.VoiceLive.Samples
                     }
                     else
                     {
-                        _logger.LogDebug("No active response to cancel during barge-in; skipping cancellation and clear operations");
+                        _logger.LogDebug("No active response during barge-in; skipping streaming audio clear");
                     }
                     break;
 
@@ -574,7 +551,6 @@ namespace Azure.AI.VoiceLive.Samples
                 case SessionUpdateResponseCreated responseCreated:
                     _logger.LogInformation("🤖 Assistant response created");
                     _responseActive = true;
-                    _canCancelResponse = true; // Response can be cancelled until completion
                     break;
 
                 case SessionUpdateResponseAudioDelta audioDelta:
@@ -597,14 +573,12 @@ namespace Azure.AI.VoiceLive.Samples
                 case SessionUpdateResponseDone responseDone:
                     _logger.LogInformation("✅ Response complete");
                     _responseActive = false; // Response fully complete
-                    _canCancelResponse = false; // No longer cancellable
                     break;
 
                 case SessionUpdateError errorEvent:
                     _logger.LogError("❌ VoiceLive error: {ErrorMessage}", errorEvent.Error?.Message);
                     Console.WriteLine($"Error: {errorEvent.Error?.Message}");
                     _responseActive = false;
-                    _canCancelResponse = false;
                     break;
 
                 default:

--- a/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
+++ b/csharp/voice-live-quickstarts/MCPQuickstart/MCPQuickstart.cs
@@ -141,7 +141,6 @@ namespace Azure.AI.VoiceLive.Samples
         private AudioProcessor? _audioProcessor;
         private bool _disposed;
         private bool _responseActive;
-        private bool _canCancelResponse;
 
         // Voice-based MCP approval state
         private record ApprovalInfo(string ApprovalId, string ServerLabel, string FunctionName);
@@ -320,10 +319,8 @@ namespace Azure.AI.VoiceLive.Samples
                     Console.WriteLine("🎤 Listening...");
                     if (_audioProcessor != null)
                         await _audioProcessor.StopPlaybackAsync().ConfigureAwait(false);
-                    if (_responseActive && _canCancelResponse)
+                    if (_responseActive)
                     {
-                        try { await _session!.CancelResponseAsync(cancellationToken).ConfigureAwait(false); }
-                        catch { }
                         try { await _session!.ClearStreamingAudioAsync(cancellationToken).ConfigureAwait(false); }
                         catch { }
                     }
@@ -375,7 +372,6 @@ namespace Azure.AI.VoiceLive.Samples
 
                 case SessionUpdateResponseCreated:
                     _responseActive = true;
-                    _canCancelResponse = true;
                     break;
 
                 case SessionUpdateResponseAudioDelta audioDelta:
@@ -389,7 +385,6 @@ namespace Azure.AI.VoiceLive.Samples
 
                 case SessionUpdateResponseDone:
                     _responseActive = false;
-                    _canCancelResponse = false;
                     WriteLog("--- Response complete ---");
                     // If an approval prompt needs to be injected, do it now
                     if (_approvalPromptNeeded && _pendingApproval != null)
@@ -414,25 +409,21 @@ namespace Azure.AI.VoiceLive.Samples
 
                 case SessionUpdateError errorEvent:
                     var msg = errorEvent.Error?.Message ?? "";
-                    if (!msg.Contains("no active response", StringComparison.OrdinalIgnoreCase))
+                    // Suppress non-fatal interim/collision errors
+                    if (msg.Contains("interim response", StringComparison.OrdinalIgnoreCase))
                     {
-                        // Suppress non-fatal interim/collision errors
-                        if (msg.Contains("interim response", StringComparison.OrdinalIgnoreCase))
-                        {
-                            _logger.LogWarning("Interim response not supported with this model pipeline (non-fatal)");
-                        }
-                        else if (msg.Contains("active response", StringComparison.OrdinalIgnoreCase))
-                        {
-                            _logger.LogDebug("Response collision (expected during MCP flow): {Message}", msg);
-                        }
-                        else
-                        {
-                            Console.WriteLine($"❌ Error: {msg}");
-                            WriteLog($"ERROR: {msg}");
-                        }
+                        _logger.LogWarning("Interim response not supported with this model pipeline (non-fatal)");
+                    }
+                    else if (msg.Contains("active response", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogDebug("Response collision (expected during MCP flow): {Message}", msg);
+                    }
+                    else
+                    {
+                        Console.WriteLine($"❌ Error: {msg}");
+                        WriteLog($"ERROR: {msg}");
                     }
                     _responseActive = false;
-                    _canCancelResponse = false;
                     break;
 
                 // Transcription event — used for voice-based approval resolution

--- a/csharp/voice-live-quickstarts/ModelQuickstart/Program.cs
+++ b/csharp/voice-live-quickstarts/ModelQuickstart/Program.cs
@@ -275,7 +275,6 @@ namespace Azure.AI.VoiceLive.Samples
     /// <remarks>
     /// This sample now demonstrates some of the new convenience methods added to the VoiceLive SDK:
     /// - ClearStreamingAudioAsync() - Clears all input audio currently being streamed
-    /// - CancelResponseAsync() - Cancels the current response generation (existing method)
     /// - ConfigureSessionAsync() - Configures session options (existing method)
     ///
     /// Additional convenience methods available but not shown in this sample:
@@ -300,8 +299,6 @@ namespace Azure.AI.VoiceLive.Samples
         private bool _disposed;
     // Tracks whether an assistant response is currently active (created and not yet completed)
     private bool _responseActive;
-    // Tracks whether the assistant can still cancel the current response (between ResponseCreated and ResponseDone)
-    private bool _canCancelResponse;
 
         /// <summary>
         /// Initializes a new instance of the BasicVoiceAssistant class.
@@ -476,32 +473,13 @@ namespace Azure.AI.VoiceLive.Samples
                         await _audioProcessor.StopPlaybackAsync().ConfigureAwait(false);
                     }
 
-                    // Only attempt cancellation / clearing if a response is active and cancellable
-                    if (_responseActive && _canCancelResponse)
+                    // Clear streaming audio only while a response is active.
+                    if (_responseActive)
                     {
-                        // Cancel any ongoing response
-                        try
-                        {
-                            await _session!.CancelResponseAsync(cancellationToken).ConfigureAwait(false);
-                            _logger.LogInformation("🛑 Active response cancelled due to user barge-in");
-                        }
-                        catch (Exception ex)
-                        {
-                            if (ex.Message.Contains("no active response", StringComparison.OrdinalIgnoreCase))
-                            {
-                                _logger.LogDebug("Cancellation benign: response already completed");
-                            }
-                            else
-                            {
-                                _logger.LogWarning(ex, "Response cancellation failed during barge-in");
-                            }
-                        }
-
-                        // Clear any streaming audio still in transit
                         try
                         {
                             await _session!.ClearStreamingAudioAsync(cancellationToken).ConfigureAwait(false);
-                            _logger.LogInformation("✨ Cleared streaming audio after cancellation");
+                            _logger.LogInformation("✨ Cleared streaming audio during barge-in");
                         }
                         catch (Exception ex)
                         {
@@ -510,7 +488,7 @@ namespace Azure.AI.VoiceLive.Samples
                     }
                     else
                     {
-                        _logger.LogDebug("No active/cancellable response during barge-in; skipping cancellation");
+                        _logger.LogDebug("No active response during barge-in; skipping streaming audio clear");
                     }
                     break;
 
@@ -528,7 +506,6 @@ namespace Azure.AI.VoiceLive.Samples
                 case SessionUpdateResponseCreated responseCreated:
                     _logger.LogInformation("🤖 Assistant response created");
                     _responseActive = true;
-                    _canCancelResponse = true;
                     break;
 
                 case SessionUpdateResponseAudioDelta audioDelta:
@@ -550,14 +527,12 @@ namespace Azure.AI.VoiceLive.Samples
                 case SessionUpdateResponseDone responseDone:
                     _logger.LogInformation("✅ Response complete");
                     _responseActive = false;
-                    _canCancelResponse = false;
                     break;
 
                 case SessionUpdateError errorEvent:
                     _logger.LogError("❌ VoiceLive error: {ErrorMessage}", errorEvent.Error?.Message);
                     Console.WriteLine($"Error: {errorEvent.Error?.Message}");
                     _responseActive = false;
-                    _canCancelResponse = false;
                     break;
 
                 default:

--- a/java/voice-live-quickstarts/AgentsNewQuickstart/VoiceLiveWithAgentV2.java
+++ b/java/voice-live-quickstarts/AgentsNewQuickstart/VoiceLiveWithAgentV2.java
@@ -6,7 +6,6 @@ import com.azure.ai.voicelive.VoiceLiveClientBuilder;
 import com.azure.ai.voicelive.VoiceLiveSessionAsyncClient;
 import com.azure.ai.voicelive.models.AgentSessionConfig;
 import com.azure.ai.voicelive.models.ClientEventConversationItemCreate;
-import com.azure.ai.voicelive.models.ClientEventResponseCancel;
 import com.azure.ai.voicelive.models.ClientEventResponseCreate;
 import com.azure.ai.voicelive.models.ClientEventSessionUpdate;
 import com.azure.ai.voicelive.models.ConversationRequestItem;
@@ -237,8 +236,6 @@ public class VoiceLiveWithAgentV2 {
         private AudioProcessor audioProcessor;
         private boolean sessionReady = false;
         private boolean greetingSent = false;
-        private boolean activeResponse = false;
-        private boolean responseApiDone = false;
 
         // <agent_config>
         BasicVoiceAssistant(String endpoint, String agentName, String projectName,
@@ -393,28 +390,12 @@ public class VoiceLiveWithAgentV2 {
                 System.out.println("🎤 Listening...");
                 audioProcessor.skipPendingAudio();
 
-                // Cancel in-progress response for barge-in
-                if (activeResponse && !responseApiDone) {
-                    try {
-                        session.sendEvent(new ClientEventResponseCancel()).block();
-                        logger.fine("Cancelled in-progress response due to barge-in");
-                    } catch (Exception e) {
-                        if (e.getMessage() != null && e.getMessage().toLowerCase().contains("no active response")) {
-                            logger.fine("Cancel ignored - response already completed");
-                        } else {
-                            logger.warning("Cancel failed: " + e.getMessage());
-                        }
-                    }
-                }
-
             } else if (type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED) {
                 logger.info("User stopped speaking");
                 System.out.println("🤔 Processing...");
 
             } else if (type == ServerEventType.RESPONSE_CREATED) {
                 logger.info("Assistant response created");
-                activeResponse = true;
-                responseApiDone = false;
 
             } else if (type == ServerEventType.RESPONSE_AUDIO_DELTA) {
                 logger.fine("Received audio delta");
@@ -430,18 +411,12 @@ public class VoiceLiveWithAgentV2 {
 
             } else if (type == ServerEventType.RESPONSE_DONE) {
                 logger.info("Response complete");
-                activeResponse = false;
-                responseApiDone = true;
 
             } else if (type == ServerEventType.ERROR) {
                 SessionUpdateError errorEvent = (SessionUpdateError) event;
                 String msg = errorEvent.getError().getMessage();
-                if (msg != null && msg.contains("Cancellation failed: no active response")) {
-                    logger.fine("Benign cancellation error: " + msg);
-                } else {
-                    logger.severe("VoiceLive error: " + msg);
-                    System.out.println("Error: " + msg);
-                }
+                logger.severe("VoiceLive error: " + msg);
+                System.out.println("Error: " + msg);
 
             } else {
                 logger.fine("Unhandled event type: " + type);

--- a/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
+++ b/java/voice-live-quickstarts/MCPQuickstart/src/main/java/MCPQuickstart.java
@@ -417,14 +417,6 @@ public final class MCPQuickstart {
                 System.out.println("🎤 Listening...");
                 audioProcessor.skipPendingAudio();
 
-                // Cancel any active response — prevents duplicate result playback
-                // when the user interrupts during MCP result speech (matches C#/Python/JS)
-                if (state.responseActive) {
-                    session.send(BinaryData.fromString("{\"type\":\"response.cancel\"}"))
-                        .subscribeOn(Schedulers.boundedElastic())
-                        .subscribe(v -> {}, err -> {});
-                }
-
                 // Clear deferred response flags if no MCP calls are in progress.
                 // Without this, a stale needsResponseCreate from a collision during
                 // the approval flow causes the model to re-speak results after the
@@ -518,9 +510,7 @@ public final class MCPQuickstart {
                 state.responseActive = false;
                 if (event instanceof SessionUpdateError) {
                     String msg = ((SessionUpdateError) event).getError().getMessage();
-                    if (msg.contains("no active response")) {
-                        // suppress
-                    } else if (msg.toLowerCase().contains("interim response")) {
+                    if (msg.toLowerCase().contains("interim response")) {
                         // non-fatal
                     } else if (msg.toLowerCase().contains("active response")) {
                         // expected during MCP flow

--- a/javascript/voice-live-quickstarts/AgentsNewQuickstart/voice-live-with-agent-v2.js
+++ b/javascript/voice-live-quickstarts/AgentsNewQuickstart/voice-live-with-agent-v2.js
@@ -281,8 +281,6 @@ class BasicVoiceAssistant {
     this._session = null;
     this._audio = new AudioProcessor(!opts.noAudio, opts.audioInputDevice);
     this._greetingSent = false;
-    this._activeResponse = false;
-    this._responseApiDone = false;
   }
   // </agent_config>
 
@@ -343,27 +341,10 @@ class BasicVoiceAssistant {
       onInputAudioBufferSpeechStarted: async () => {
         console.log("🎤 Listening...");
         this._audio.skipPendingAudio();
-
-        // Cancel in-progress response (barge-in)
-        if (this._activeResponse && !this._responseApiDone) {
-          try {
-            await session.sendEvent({ type: "response.cancel" });
-          } catch (err) {
-            const msg = err?.message ?? "";
-            if (!msg.toLowerCase().includes("no active response")) {
-              console.warn("[barge-in] Cancel failed:", msg);
-            }
-          }
-        }
       },
 
       onInputAudioBufferSpeechStopped: async () => {
         console.log("🤔 Processing...");
-      },
-
-      onResponseCreated: async () => {
-        this._activeResponse = true;
-        this._responseApiDone = false;
       },
 
       onResponseAudioDelta: async (event) => {
@@ -378,16 +359,10 @@ class BasicVoiceAssistant {
 
       onResponseDone: async () => {
         console.log("✅ Response complete");
-        this._activeResponse = false;
-        this._responseApiDone = true;
       },
 
       onServerError: async (event) => {
         const msg = event.error?.message ?? "";
-        if (msg.includes("Cancellation failed: no active response")) {
-          // Benign – ignore
-          return;
-        }
         console.error(`❌ VoiceLive error: ${msg}`);
       },
 

--- a/javascript/voice-live-quickstarts/MCPQuickstart/README.md
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/README.md
@@ -76,10 +76,10 @@ For approval-required servers, once the user approves the first call, subsequent
 
 Users will naturally try to interrupt or ask *"Are you still there?"* during long tool calls. Rather than ignoring this, the quickstart injects a system message so the model can acknowledge the user and respond to what they said. If the original MCP call completes later, its result is introduced as a **late result** (e.g. *"By the way, those results from earlier just came in..."*). Note: since MCP calls cannot be cancelled, the call continues running in the background regardless of what the user says.
 
-Barge-in in the MCP quickstart is more complex than in the Model or Agents quickstarts. Those simpler samples have a trivial `onResponseDone` handler (just reset flags), so cancelling a response is straightforward — the cancelled response's `onResponseDone` is a harmless no-op. In the MCP quickstart, `onResponseDone` processes **deferred actions** — pending approval prompts, queued MCP results, and deferred `response.create` calls. Without protection, the cancelled response's `onResponseDone` would immediately trigger a new response that overlaps the user's speech.
+Barge-in in the MCP quickstart is more complex than in the Model or Agents quickstarts. The service automatically interrupts the active response when speech starts, while the client discards buffered playback audio. The simpler samples have a trivial `onResponseDone` handler that logs completion. In the MCP quickstart, `onResponseDone` processes **deferred actions** — pending approval prompts, queued MCP results, and deferred `response.create` calls. Without protection, the interrupted response's `onResponseDone` would immediately trigger a new response that overlaps the user's speech.
 
 To prevent this, the quickstart uses a `_bargeInActive` flag:
-1. **Set `true`** in `onInputAudioBufferSpeechStarted` just before calling `response.cancel`
+1. **Set `true`** in `onInputAudioBufferSpeechStarted` when a response is active, so its service-driven completion skips deferred actions
 2. **Checked** at the top of `onResponseDone` — if set, all deferred processing is skipped and the flag is cleared
 3. All deferred flags (`_needsResponseCreate`, `_mcpResultsPending`) are also cleared unconditionally on barge-in
 

--- a/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
+++ b/javascript/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.js
@@ -474,14 +474,6 @@ class MCPVoiceAssistant {
           // Mark barge-in so onResponseDone skips deferred actions
           this._bargeInActive = true;
           try {
-            await session.sendEvent({ type: "response.cancel" });
-          } catch (err) {
-            const msg = err?.message ?? "";
-            if (!msg.toLowerCase().includes("no active response")) {
-              console.warn("[barge-in] Cancel failed:", msg);
-            }
-          }
-          try {
             await session.sendEvent({ type: "input_audio_buffer.clear" });
           } catch { /* best-effort */ }
         }
@@ -544,7 +536,6 @@ class MCPVoiceAssistant {
         // Reset response state — errors can terminate a response without onResponseDone
         this._activeResponse = false;
         this._responseApiDone = true;
-        if (msg.includes("Cancellation failed: no active response")) return;
         if (msg.toLowerCase().includes("interim response")) {
           console.log("[session] Interim response not supported (non-fatal)");
           return;

--- a/javascript/voice-live-quickstarts/ModelQuickstart/README.md
+++ b/javascript/voice-live-quickstarts/ModelQuickstart/README.md
@@ -116,7 +116,7 @@ node model-quickstart.js --greeting-text "Welcome! I'm your AI assistant. How ca
   - echo cancellation + noise reduction
   - input audio transcription (`azure-speech`)
 - Real-time microphone streaming and speaker playback
-- Barge-in handling (`response.cancel` when user interrupts)
+- Barge-in handling (service-managed response interruption and immediate local playback cleanup)
 - Proactive greeting support (default: on):
   - LLM-generated (default) — adaptive, context-aware greetings
   - Pre-defined (`--greeting-text`) — deterministic, branded messaging

--- a/javascript/voice-live-quickstarts/ModelQuickstart/model-quickstart.js
+++ b/javascript/voice-live-quickstarts/ModelQuickstart/model-quickstart.js
@@ -376,8 +376,6 @@ class BasicModelVoiceAssistant {
     this._session = null;
     this._subscription = null;
     this._audio = new AudioProcessor(!options.noAudio, options.audioInputDevice);
-    this._activeResponse = false;
-    this._responseApiDone = false;
     this._greetingSent = false;
   }
 
@@ -434,26 +432,10 @@ class BasicModelVoiceAssistant {
       onInputAudioBufferSpeechStarted: async () => {
         console.log("🎤 Listening...");
         this._audio.skipPendingAudio();
-
-        if (this._activeResponse && !this._responseApiDone) {
-          try {
-            await session.sendEvent({ type: "response.cancel" });
-          } catch (err) {
-            const msg = err?.message ?? "";
-            if (!msg.toLowerCase().includes("no active response")) {
-              console.warn("[barge-in] Cancel failed:", msg);
-            }
-          }
-        }
       },
 
       onInputAudioBufferSpeechStopped: async () => {
         console.log("🤔 Processing...");
-      },
-
-      onResponseCreated: async () => {
-        this._activeResponse = true;
-        this._responseApiDone = false;
       },
 
       onResponseAudioDelta: async (event) => {
@@ -468,15 +450,10 @@ class BasicModelVoiceAssistant {
 
       onResponseDone: async () => {
         console.log("✅ Response complete");
-        this._activeResponse = false;
-        this._responseApiDone = true;
       },
 
       onServerError: async (event) => {
         const msg = event.error?.message ?? "";
-        if (msg.includes("Cancellation failed: no active response")) {
-          return;
-        }
         console.error(`❌ VoiceLive error: ${msg}`);
       },
 

--- a/javascript/voice-live-trader-demo/src/lib/voiceLive/VoiceLiveClient.ts
+++ b/javascript/voice-live-trader-demo/src/lib/voiceLive/VoiceLiveClient.ts
@@ -148,13 +148,6 @@ export class VoiceLiveClient {
             // Barge-in UX: stop any currently playing assistant audio immediately.
             if (this.enableBargeIn) {
               this.player.stop();
-
-              // Best-effort: ask server to cancel any in-progress response so it stops streaming TTS.
-              try {
-                await this.session?.sendEvent({ type: "response.cancel" } as any);
-              } catch {
-                // ignore if not supported
-              }
             }
 
             this.callbacks.onServerEvent?.({ type: "input_audio_buffer.speech_started" } as any);

--- a/python/voice-live-quickstarts/AgentsNewQuickstart/voice-live-with-agent-v2.py
+++ b/python/voice-live-quickstarts/AgentsNewQuickstart/voice-live-with-agent-v2.py
@@ -275,8 +275,6 @@ class BasicVoiceAssistant:
         self.audio_processor: Optional[AudioProcessor] = None
         self.session_ready = False
         self.greeting_sent = False
-        self._active_response = False
-        self._response_api_done = False
     # </agent_config>
 
     # <start_session>
@@ -444,25 +442,12 @@ class BasicVoiceAssistant:
 
             ap.skip_pending_audio()
 
-            # Only cancel if response is active and not already done
-            if self._active_response and not self._response_api_done:
-                try:
-                    await conn.response.cancel()
-                    logger.debug("Cancelled in-progress response due to barge-in")
-                except Exception as e:
-                    if "no active response" in str(e).lower():
-                        logger.debug("Cancel ignored - response already completed")
-                    else:
-                        logger.warning("Cancel failed: %s", e)
-
         elif event.type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED:
             logger.info("🎤 User stopped speaking")
             print("🤔 Processing...")
 
         elif event.type == ServerEventType.RESPONSE_CREATED:
             logger.info("🤖 Assistant response created")
-            self._active_response = True
-            self._response_api_done = False
 
         elif event.type == ServerEventType.RESPONSE_AUDIO_DELTA:
             logger.debug("Received audio delta")
@@ -474,16 +459,11 @@ class BasicVoiceAssistant:
 
         elif event.type == ServerEventType.RESPONSE_DONE:
             logger.info("✅ Response complete")
-            self._active_response = False
-            self._response_api_done = True
 
         elif event.type == ServerEventType.ERROR:
             msg = event.error.message
-            if "Cancellation failed: no active response" in msg:
-                logger.debug("Benign cancellation error: %s", msg)
-            else:
-                logger.error("❌ VoiceLive error: %s", msg)
-                print(f"Error: {msg}")
+            logger.error("❌ VoiceLive error: %s", msg)
+            print(f"Error: {msg}")
 
         elif event.type == ServerEventType.CONVERSATION_ITEM_CREATED:
             logger.debug("Conversation item created: %s", event.item.id)

--- a/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
+++ b/python/voice-live-quickstarts/MCPQuickstart/mcp-quickstart.py
@@ -276,7 +276,6 @@ class MCPVoiceAssistant:
         self.audio_processor: Optional[AudioProcessor] = None
         self.session_ready = False
         self._active_response = False
-        self._response_api_done = False
         self._pending_approval: Optional[dict] = None  # Currently active approval request
         self._approval_queue: list[dict] = []  # Queued approvals waiting to be asked
         self._approval_prompt_needed = False  # True when we need to inject the prompt at next RESPONSE_DONE
@@ -461,13 +460,6 @@ class MCPVoiceAssistant:
                 self._needs_response_create = False
                 self._mcp_results_pending = False
 
-            if self._active_response and not self._response_api_done:
-                try:
-                    await conn.response.cancel()
-                except Exception as e:
-                    if "no active response" not in str(e).lower():
-                        logger.warning("Cancel failed: %s", e)
-
             # If an MCP call is running, mark current calls as stale (user is moving on)
             # and let the user know it's still in progress
             if self._mcp_call_in_progress > 0 and self._pending_approval is None:
@@ -494,7 +486,6 @@ class MCPVoiceAssistant:
         elif event.type == ServerEventType.RESPONSE_CREATED:
             logger.info("Assistant response created")
             self._active_response = True
-            self._response_api_done = False
 
         elif event.type == ServerEventType.RESPONSE_AUDIO_DELTA:
             ap.queue_audio(event.delta)
@@ -517,7 +508,6 @@ class MCPVoiceAssistant:
             logger.info("Response complete")
             await write_conversation_log("--- Response complete ---")
             self._active_response = False
-            self._response_api_done = True
 
             # If an approval prompt needs to be injected, do it now that no response is active
             if self._approval_prompt_needed and self._pending_approval is not None:
@@ -556,16 +546,14 @@ class MCPVoiceAssistant:
             msg = event.error.message
             # Reset response state — errors can terminate a response without RESPONSE_DONE
             self._active_response = False
-            self._response_api_done = True
-            if "Cancellation failed: no active response" not in msg:
-                if "interim response" in msg.lower():
-                    logger.warning("Interim response not supported with this model pipeline (non-fatal)")
-                elif "active response" in msg.lower():
-                    logger.debug("Response collision (expected during MCP flow): %s", msg)
-                else:
-                    logger.error("VoiceLive error: %s", msg)
-                    print(f"Error: {msg}")
-                    await write_conversation_log(f"ERROR: {msg}")
+            if "interim response" in msg.lower():
+                logger.warning("Interim response not supported with this model pipeline (non-fatal)")
+            elif "active response" in msg.lower():
+                logger.debug("Response collision (expected during MCP flow): %s", msg)
+            else:
+                logger.error("VoiceLive error: %s", msg)
+                print(f"Error: {msg}")
+                await write_conversation_log(f"ERROR: {msg}")
 
         # MCP-specific events
         elif event.type == ServerEventType.MCP_LIST_TOOLS_IN_PROGRESS:

--- a/python/voice-live-quickstarts/agents-quickstart.py
+++ b/python/voice-live-quickstarts/agents-quickstart.py
@@ -265,8 +265,6 @@ class BasicVoiceAssistant:
         self.audio_processor: Optional[AudioProcessor] = None
         self.session_ready = False
         self.conversation_started = False
-        self._active_response = False
-        self._response_api_done = False
 
     async def start(self):
         """Start the voice assistant session."""
@@ -408,25 +406,12 @@ class BasicVoiceAssistant:
 
             ap.skip_pending_audio()
 
-            # Only cancel if response is active and not already done
-            if self._active_response and not self._response_api_done:
-                try:
-                    await conn.response.cancel()
-                    logger.debug("Cancelled in-progress response due to barge-in")
-                except Exception as e:
-                    if "no active response" in str(e).lower():
-                        logger.debug("Cancel ignored - response already completed")
-                    else:
-                        logger.warning("Cancel failed: %s", e)
-
         elif event.type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED:
             logger.info("🎤 User stopped speaking")
             print("🤔 Processing...")
 
         elif event.type == ServerEventType.RESPONSE_CREATED:
             logger.info("🤖 Assistant response created")
-            self._active_response = True
-            self._response_api_done = False
 
         elif event.type == ServerEventType.RESPONSE_AUDIO_DELTA:
             logger.debug("Received audio delta")
@@ -438,16 +423,11 @@ class BasicVoiceAssistant:
 
         elif event.type == ServerEventType.RESPONSE_DONE:
             logger.info("✅ Response complete")
-            self._active_response = False
-            self._response_api_done = True
 
         elif event.type == ServerEventType.ERROR:
             msg = event.error.message
-            if "Cancellation failed: no active response" in msg:
-                logger.debug("Benign cancellation error: %s", msg)
-            else:
-                logger.error("❌ VoiceLive error: %s", msg)
-                print(f"Error: {msg}")
+            logger.error("❌ VoiceLive error: %s", msg)
+            print(f"Error: {msg}")
 
         elif event.type == ServerEventType.CONVERSATION_ITEM_CREATED:
             logger.debug("Conversation item created: %s", event.item.id)

--- a/python/voice-live-quickstarts/bring-your-own-model-quickstart.py
+++ b/python/voice-live-quickstarts/bring-your-own-model-quickstart.py
@@ -259,8 +259,6 @@ class BasicVoiceAssistant:
         self.connection: Optional["VoiceLiveConnection"] = None
         self.audio_processor: Optional[AudioProcessor] = None
         self.session_ready = False
-        self._active_response = False
-        self._response_api_done = False
         self.conversation_started = False
         self.byom = byom
 
@@ -383,25 +381,12 @@ class BasicVoiceAssistant:
 
             ap.skip_pending_audio()
 
-            # Only cancel if response is active and not already done
-            if self._active_response and not self._response_api_done:
-                try:
-                    await conn.response.cancel()
-                    logger.debug("Cancelled in-progress response due to barge-in")
-                except Exception as e:
-                    if "no active response" in str(e).lower():
-                        logger.debug("Cancel ignored - response already completed")
-                    else:
-                        logger.warning("Cancel failed: %s", e)
-
         elif event.type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED:
             logger.info("🎤 User stopped speaking")
             print("🤔 Processing...")
 
         elif event.type == ServerEventType.RESPONSE_CREATED:
             logger.info("🤖 Assistant response created")
-            self._active_response = True
-            self._response_api_done = False
 
         elif event.type == ServerEventType.RESPONSE_AUDIO_DELTA:
             logger.debug("Received audio delta")
@@ -413,16 +398,11 @@ class BasicVoiceAssistant:
 
         elif event.type == ServerEventType.RESPONSE_DONE:
             logger.info("✅ Response complete")
-            self._active_response = False
-            self._response_api_done = True
 
         elif event.type == ServerEventType.ERROR:
             msg = event.error.message
-            if "Cancellation failed: no active response" in msg:
-                logger.debug("Benign cancellation error: %s", msg)
-            else:
-                logger.error("❌ VoiceLive error: %s", msg)
-                print(f"Error: {msg}")
+            logger.error("❌ VoiceLive error: %s", msg)
+            print(f"Error: {msg}")
 
         elif event.type == ServerEventType.CONVERSATION_ITEM_CREATED:
             logger.debug("Conversation item created: %s", event.item.id)

--- a/python/voice-live-quickstarts/function-calling-quickstart.py
+++ b/python/voice-live-quickstarts/function-calling-quickstart.py
@@ -266,8 +266,6 @@ class AsyncFunctionCallingClient:
         self.audio_processor: Optional[AudioProcessor] = None
         self.session_ready = False
         self.conversation_started = False
-        self._active_response = False
-        self._response_api_done = False
         self._pending_function_call: Optional[Dict[str, Any]] = None
 
         # Define available functions
@@ -434,25 +432,12 @@ class AsyncFunctionCallingClient:
 
             ap.skip_pending_audio()
 
-            # Only cancel if response is active and not already done
-            if self._active_response and not self._response_api_done:
-                try:
-                    await conn.response.cancel()
-                    logger.debug("Cancelled in-progress response due to barge-in")
-                except Exception as e:
-                    if "no active response" in str(e).lower():
-                        logger.debug("Cancel ignored - response already completed")
-                    else:
-                        logger.warning("Cancel failed: %s", e)
-
         elif event.type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED:
             logger.info("🎤 User stopped speaking")
             print("🤔 Processing...")
 
         elif event.type == ServerEventType.RESPONSE_CREATED:
             logger.info("🤖 Assistant response created")
-            self._active_response = True
-            self._response_api_done = False
 
         elif event.type == ServerEventType.RESPONSE_AUDIO_DELTA:
             logger.debug("Received audio delta")
@@ -464,8 +449,6 @@ class AsyncFunctionCallingClient:
 
         elif event.type == ServerEventType.RESPONSE_DONE:
             logger.info("✅ Response complete")
-            self._active_response = False
-            self._response_api_done = True
 
             # Execute pending function call if arguments are ready
             if self._pending_function_call and "arguments" in self._pending_function_call:
@@ -474,11 +457,8 @@ class AsyncFunctionCallingClient:
 
         elif event.type == ServerEventType.ERROR:
             msg = event.error.message
-            if "Cancellation failed: no active response" in msg:
-                logger.debug("Benign cancellation error: %s", msg)
-            else:
-                logger.error("❌ VoiceLive error: %s", msg)
-                print(f"Error: {msg}")
+            logger.error("❌ VoiceLive error: %s", msg)
+            print(f"Error: {msg}")
 
         elif event.type == ServerEventType.CONVERSATION_ITEM_CREATED:
             logger.debug("Conversation item created: %s", event.item.id)

--- a/python/voice-live-quickstarts/model-quickstart.py
+++ b/python/voice-live-quickstarts/model-quickstart.py
@@ -257,8 +257,6 @@ class BasicVoiceAssistant:
         self.connection: Optional["VoiceLiveConnection"] = None
         self.audio_processor: Optional[AudioProcessor] = None
         self.session_ready = False
-        self._active_response = False
-        self._response_api_done = False
 
     async def start(self):
         """Start the voice assistant session."""
@@ -366,25 +364,12 @@ class BasicVoiceAssistant:
 
             ap.skip_pending_audio()
 
-            # Only cancel if response is active and not already done
-            if self._active_response and not self._response_api_done:
-                try:
-                    await conn.response.cancel()
-                    logger.debug("Cancelled in-progress response due to barge-in")
-                except Exception as e:
-                    if "no active response" in str(e).lower():
-                        logger.debug("Cancel ignored - response already completed")
-                    else:
-                        logger.warning("Cancel failed: %s", e)
-
         elif event.type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED:
             logger.info("🎤 User stopped speaking")
             print("🤔 Processing...")
 
         elif event.type == ServerEventType.RESPONSE_CREATED:
             logger.info("🤖 Assistant response created")
-            self._active_response = True
-            self._response_api_done = False
 
         elif event.type == ServerEventType.RESPONSE_AUDIO_DELTA:
             logger.debug("Received audio delta")
@@ -396,16 +381,11 @@ class BasicVoiceAssistant:
 
         elif event.type == ServerEventType.RESPONSE_DONE:
             logger.info("✅ Response complete")
-            self._active_response = False
-            self._response_api_done = True
 
         elif event.type == ServerEventType.ERROR:
             msg = event.error.message
-            if "Cancellation failed: no active response" in msg:
-                logger.debug("Benign cancellation error: %s", msg)
-            else:
-                logger.error("❌ VoiceLive error: %s", msg)
-                print(f"Error: {msg}")
+            logger.error("❌ VoiceLive error: %s", msg)
+            print(f"Error: {msg}")
 
         elif event.type == ServerEventType.CONVERSATION_ITEM_CREATED:
             logger.debug("Conversation item created: %s", event.item.id)

--- a/python/voice-live-voicerag-assistant/app/backend/web_handler.py
+++ b/python/voice-live-voicerag-assistant/app/backend/web_handler.py
@@ -355,7 +355,7 @@ class WebSocketVoiceClient:
             # Speech detection events
             elif event_type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STARTED:
                 logger.info("🎤 User started speaking")
-                await self._handle_user_interruption(connection)
+                await self._handle_user_interruption()
 
             elif event_type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED:
                 logger.info("🎤 User stopped speaking")
@@ -639,26 +639,16 @@ class WebSocketVoiceClient:
         self.connection = None
         logger.info("Voice client cleaned up")
 
-    async def _handle_user_interruption(self, connection):
+    async def _handle_user_interruption(self):
         """Handle user interrupting the assistant by speaking."""
         try:
-            # 1. Stop current audio playback via WebSocket
+            # Stop current audio playback via WebSocket
             await self.bridge.send_message(self.client_id, {
                 "type": "stop_playback",
                 "reason": "user_interruption",
                 "timestamp": asyncio.get_event_loop().time()
             })
-            
-            # 2. Cancel any ongoing response from VoiceLive API
-            try:
-                await connection.response.cancel()
-                logger.info("Cancelled ongoing response due to user interruption")
-            except Exception as e:
-                logger.debug(f"No response to cancel: {e}")
-                
-            # 3. Clear audio buffer if needed
-            # await connection.input_audio_buffer.clear()  # Uncomment if available
-            
+
         except Exception as e:
             logger.error(f"Error handling user interruption: {e}")
 

--- a/python/voice-live-voicerag-assistant/scripts/handler.py
+++ b/python/voice-live-voicerag-assistant/scripts/handler.py
@@ -507,12 +507,6 @@ class AsyncFunctionCallingClient:
             # Stop current assistant audio playback (interruption handling)
             await ap.stop_playback()
 
-            # Cancel any ongoing response
-            try:
-                await connection.response.cancel()
-            except Exception as e:
-                logger.debug(f"No response to cancel: {e}")
-
         elif event.type == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED:
             logger.info("🎤 User stopped speaking")
             print("🤔 Processing...")

--- a/voice-live-universal-assistant/csharp/VoiceLiveHandler.cs
+++ b/voice-live-universal-assistant/csharp/VoiceLiveHandler.cs
@@ -460,7 +460,6 @@ public class VoiceLiveHandler
             case SessionUpdateInputAudioBufferSpeechStarted:
                 await _sendMessage(new Dictionary<string, object> { ["type"] = "status", ["state"] = "listening" });
                 await _sendMessage(new Dictionary<string, object> { ["type"] = "stop_playback" });
-                try { await _session!.CancelResponseAsync(); } catch { }
                 break;
 
             // -- User stops speaking ------------------------------------------

--- a/voice-live-universal-assistant/java/src/main/java/com/azure/voicelive/sample/VoiceLiveHandler.java
+++ b/voice-live-universal-assistant/java/src/main/java/com/azure/voicelive/sample/VoiceLiveHandler.java
@@ -461,12 +461,6 @@ public class VoiceLiveHandler {
     private void handleSpeechStarted() {
         send("status", "state", "listening");
         sendMessage.accept(Map.of("type", "stop_playback"));
-        // Cancel any active response (barge-in)
-        try {
-            session.cancelResponse().block();
-        } catch (Exception e) {
-            // Ignore — no active response
-        }
     }
 
     private void handleAudioDelta(SessionUpdate event) {

--- a/voice-live-universal-assistant/javascript/voiceHandler.js
+++ b/voice-live-universal-assistant/javascript/voiceHandler.js
@@ -248,15 +248,6 @@ export class VoiceHandler {
       onInputAudioBufferSpeechStarted: async (_event, _context) => {
         this.sendMessage({ type: "status", state: "listening" });
         this.sendMessage({ type: "stop_playback" });
-        // Cancel any in-progress response (barge-in)
-        try {
-          await this.session?.sendEvent({
-            type: KnownClientEventType.ResponseCancel,
-            eventId: `evt_bargein_${Date.now()}`,
-          });
-        } catch (_) {
-          // Ignore — may not have an active response
-        }
       },
 
       onInputAudioBufferSpeechStopped: async (_event, _context) => {

--- a/voice-live-universal-assistant/python/voice_handler.py
+++ b/voice-live-universal-assistant/python/voice_handler.py
@@ -278,7 +278,7 @@ class VoiceLiveHandler:
                 logger.error(f"[{self.client_id}] Error forwarding audio: {e}")
 
     async def interrupt(self) -> None:
-        """Cancel the current response (user barge-in)."""
+        """Cancel the current response on an explicit user interrupt request."""
         if self.connection:
             try:
                 await self.connection.response.cancel()
@@ -472,10 +472,6 @@ class VoiceLiveHandler:
         elif t == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STARTED:
             await self.send({"type": "status", "state": "listening"})
             await self.send({"type": "stop_playback"})
-            try:
-                await connection.response.cancel()
-            except Exception:
-                pass
 
         # -- User stops speaking ------------------------------------------
         elif t == ServerEventType.INPUT_AUDIO_BUFFER_SPEECH_STOPPED:


### PR DESCRIPTION
## Summary
- Remove 24 redundant automatic response cancellations across Python (9), C# (7), JavaScript/TypeScript (5), and Java (3). Voice Live already interrupts the response when speech starts.
- Preserve immediate local playback cleanup, streaming-buffer clearing, MCP bookkeeping, and all six explicit/manual cancellation paths.
- Remove dead cancellation-only state/error handling and correct two quickstart READMEs. No SDK, authentication, or session-configuration changes.

## Validation
- Passed Java MCP/universal Maven compilation and direct compilation of the agent-v2 source; trader production build and TypeScript checks; changed JavaScript syntax checks; compilation of all 32 tracked Python sources.
- Isolated speech-start checks confirmed no redundant cancellation and preserved playback, MCP deferred-action handling, and manual cancellation. C# static preservation checks passed.
- Full C# builds were blocked by SDK/dependency availability and NuGet TLS failures; Python live E2E tests were blocked by unavailable dependencies/download failures. No live audio/service validation was performed.

Companion docs update: https://github.com/MicrosoftDocs/azure-ai-docs-pr/pull/14280 aligns the 28 imported snippet directives with these source changes.